### PR TITLE
feat: Add verbose and debug output modes

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -133,6 +133,7 @@ config = load_effective_config(Path("recipes/Google/chrome.yaml"))
 
 ### ✅ Implemented
 - CLI with `check` command
+- Three output modes: normal, verbose, and debug
 - Config loading and merging
 - HTTP static discovery strategy
 - Robust file downloads
@@ -162,15 +163,45 @@ sudo apt-get install msitools
 ### Usage
 
 ```bash
-# Validate a recipe
-python -m notapkgtool.cli check recipes/Google/chrome.yaml
+# Validate a recipe (normal output)
+napt check recipes/Google/chrome.yaml
 
 # Custom output directory
-python -m notapkgtool.cli check recipes/Google/chrome.yaml --output-dir ./cache
+napt check recipes/Google/chrome.yaml --output-dir ./cache
 
-# Verbose errors
-python -m notapkgtool.cli check recipes/Google/chrome.yaml --verbose
+# Verbose output (shows progress details and operations)
+napt check recipes/Google/chrome.yaml --verbose
+
+# Debug output (shows full config dumps and backend details)
+napt check recipes/Google/chrome.yaml --debug
 ```
+
+### Output Verbosity Modes
+
+NAPT supports three output modes to suit different debugging needs:
+
+**1. Normal Mode** (default - no flags)
+- Minimal, clean output with progress steps
+- Download progress percentage
+- Final validation results
+- Suitable for production automation
+
+**2. Verbose Mode** (`-v` or `--verbose`)
+- All normal output plus:
+  - `[CONFIG]` Configuration loading and merging details
+  - `[DISCOVERY]` Discovery strategy selection
+  - `[HTTP]` HTTP request/response status, headers, redirects
+  - `[FILE]` File operations, paths, SHA-256 hashes
+  - `[VERSION]` Version extraction methods and results
+- Useful for understanding workflow and troubleshooting issues
+
+**3. Debug Mode** (`-d` or `--debug`)
+- All verbose output plus:
+  - Complete YAML content from all configuration layers
+  - Final merged configuration structure
+  - Backend selection attempts (e.g., msilib vs PowerShell COM)
+  - Maximum detail for deep troubleshooting
+- Note: Debug mode automatically enables verbose mode
 
 ### Programmatic API
 
@@ -178,9 +209,24 @@ python -m notapkgtool.cli check recipes/Google/chrome.yaml --verbose
 from pathlib import Path
 from notapkgtool.core import check_recipe
 
+# Normal mode
 result = check_recipe(
     recipe_path=Path("recipes/Google/chrome.yaml"),
     output_dir=Path("./downloads"),
+)
+
+# Verbose mode
+result = check_recipe(
+    recipe_path=Path("recipes/Google/chrome.yaml"),
+    output_dir=Path("./downloads"),
+    verbose=True,
+)
+
+# Debug mode
+result = check_recipe(
+    recipe_path=Path("recipes/Google/chrome.yaml"),
+    output_dir=Path("./downloads"),
+    debug=True,
 )
 
 print(f"App: {result['app_name']}")

--- a/README.md
+++ b/README.md
@@ -38,14 +38,38 @@ sudo apt-get install msitools  # Debian/Ubuntu
 
 ```bash
 # Check a recipe (downloads installer and extracts version)
-python -m notapkgtool.cli check recipes/Google/chrome.yaml
+napt check recipes/Google/chrome.yaml
 
 # Specify custom output directory
-python -m notapkgtool.cli check recipes/Google/chrome.yaml --output-dir ./cache
+napt check recipes/Google/chrome.yaml --output-dir ./cache
 
-# Show detailed errors
-python -m notapkgtool.cli check recipes/Google/chrome.yaml --verbose
+# Show verbose output with progress details
+napt check recipes/Google/chrome.yaml --verbose
+
+# Show debug output with full configuration dumps
+napt check recipes/Google/chrome.yaml --debug
 ```
+
+### Output Modes
+
+NAPT supports three output verbosity levels:
+
+**Normal Mode** (default):
+- Clean, minimal output with step indicators
+- Download progress bar
+- Final results summary
+
+**Verbose Mode** (`-v` or `--verbose`):
+- Configuration loading details
+- HTTP request/response information
+- File operations and SHA-256 hashes
+- Version extraction details
+
+**Debug Mode** (`-d` or `--debug`):
+- All verbose output
+- Complete YAML configuration dumps
+- Backend selection details (e.g., MSI extraction methods)
+- Full troubleshooting information
 
 ### Example Output
 
@@ -127,12 +151,20 @@ from notapkgtool.core import check_recipe
 from notapkgtool.config import load_effective_config
 from notapkgtool.versioning import compare_any, is_newer_any
 
-# Validate a recipe
+# Validate a recipe (with verbose output)
 result = check_recipe(
     recipe_path=Path("recipes/Google/chrome.yaml"),
-    output_dir=Path("./downloads")
+    output_dir=Path("./downloads"),
+    verbose=True
 )
 print(f"Version: {result['version']}")
+
+# Validate with debug output
+result = check_recipe(
+    recipe_path=Path("recipes/Google/chrome.yaml"),
+    output_dir=Path("./downloads"),
+    debug=True
+)
 
 # Load configuration
 config = load_effective_config(Path("recipes/Google/chrome.yaml"))
@@ -220,6 +252,7 @@ apps:
 
 ### v0.1.0 (Current)
 - ✅ CLI with `check` command
+- ✅ Verbose and debug output modes
 - ✅ Configuration system with 3-layer merging
 - ✅ HTTP static discovery strategy
 - ✅ MSI ProductVersion extraction

--- a/notapkgtool/core.py
+++ b/notapkgtool/core.py
@@ -57,7 +57,7 @@ from notapkgtool.discovery import get_strategy
 
 
 def check_recipe(
-    recipe_path: Path, output_dir: Path, verbose: bool = False
+    recipe_path: Path, output_dir: Path, verbose: bool = False, debug: bool = False
 ) -> dict[str, Any]:
     """
     Validate a recipe by loading config, discovering version, and downloading.
@@ -142,7 +142,7 @@ def check_recipe(
 
     # 1. Load and merge configuration
     print_step(1, 4, "Loading configuration...")
-    config = load_effective_config(recipe_path, verbose=verbose)
+    config = load_effective_config(recipe_path, verbose=verbose, debug=debug)
 
     # 2. Extract the first app (for now we only process one app per recipe)
     print_step(2, 4, "Discovering version...")
@@ -169,7 +169,7 @@ def check_recipe(
     # 5. Run discovery: download and extract version
     print_step(3, 4, "Downloading installer...")
     discovered_version, file_path, sha256 = strategy.discover_version(
-        app, output_dir, verbose=verbose
+        app, output_dir, verbose=verbose, debug=debug
     )
 
     print_step(4, 4, "Extracting version...")

--- a/notapkgtool/discovery/http_static.py
+++ b/notapkgtool/discovery/http_static.py
@@ -98,7 +98,11 @@ class HttpStaticStrategy:
     """
 
     def discover_version(
-        self, app_config: dict[str, Any], output_dir: Path, verbose: bool = False
+        self,
+        app_config: dict[str, Any],
+        output_dir: Path,
+        verbose: bool = False,
+        debug: bool = False,
     ) -> tuple[DiscoveredVersion, Path, str]:
         """
         Download from static URL and extract version from the file.
@@ -143,7 +147,7 @@ class HttpStaticStrategy:
         # Download the file
         try:
             file_path, sha256, _headers = download_file(
-                url, output_dir, verbose=verbose
+                url, output_dir, verbose=verbose, debug=debug
             )
         except Exception as err:
             raise RuntimeError(f"Failed to download {url}: {err}") from err
@@ -152,7 +156,7 @@ class HttpStaticStrategy:
         if version_type == "msi_product_version_from_file":
             try:
                 discovered = version_from_msi_product_version(
-                    file_path, verbose=verbose
+                    file_path, verbose=verbose, debug=debug
                 )
             except Exception as err:
                 raise RuntimeError(

--- a/notapkgtool/io/download.py
+++ b/notapkgtool/io/download.py
@@ -212,6 +212,7 @@ def download_file(
     etag: str | None = None,
     last_modified: str | None = None,
     verbose: bool = False,
+    debug: bool = False,
 ) -> tuple[Path, str, dict]:
     """
     Download a URL to destination_folder with robustness and reproducibility.


### PR DESCRIPTION
Add -v/--verbose flag for detailed progress and operation logging
Add -d/--debug flag for maximum detail including config dumps
Debug mode automatically enables verbose mode

Implement consistent prefixed logging across all modules:
- [CONFIG] Configuration loading and merging
- [DISCOVERY] Discovery strategy details
- [HTTP] HTTP request/response information
- [FILE] File operations and integrity checks
- [VERSION] Version extraction methods

Add helper functions in cli.py: print_verbose(), print_debug()
Update all modules to support verbose and debug parameters
Update README.md and DOCUMENTATION.md with usage examples
Improve error tracebacks when verbose/debug is enabled