### PR TITLE
feat: add url_regex discovery strategy

### DIFF
--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -229,21 +229,6 @@ NAPT uses **squash and merge** for most Pull Requests to maintain a clean, reada
 - ✅ **Better changelogs**: No noise from "WIP" or "fix typo" commits
 - ✅ **Simple bisecting**: Each commit represents a complete, working change
 
-### GitHub Settings
-
-**Recommended repository settings:**
-
-- ✅ **Allow squash merging** (default method)
-- ✅ **Allow merge commits** (for exceptional cases)
-- ❌ **Disable rebase merging** (can rewrite history, adds complexity)
-
-To configure on GitHub:
-1. Go to Settings → General → Pull Requests
-2. Check "Allow squash merging" (set as default)
-3. Check "Allow merge commits"
-4. Uncheck "Allow rebase merging"
-5. Check "Automatically delete head branches"
-
 ### When to Use Each Strategy
 
 **Squash and Merge (Default - 95% of PRs)**

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -17,7 +17,8 @@ notapkgtool/
 ├── discovery/
 │   ├── __init__.py          # Discovery package exports
 │   ├── base.py              # Strategy protocol and registry
-│   └── http_static.py       # Static URL download strategy
+│   ├── http_static.py       # Static URL download strategy
+│   └── url_regex.py         # URL regex discovery strategy
 ├── io/
 │   ├── __init__.py          # I/O package exports
 │   ├── download.py          # Robust HTTP downloads
@@ -29,7 +30,7 @@ notapkgtool/
     ├── __init__.py          # Versioning package exports
     ├── keys.py              # Version comparison logic
     ├── msi.py               # MSI ProductVersion extraction
-    └── url_regex.py         # URL regex extraction (planned)
+    └── url_regex.py         # URL regex extraction helper
 ```
 
 ## Documentation Standards
@@ -136,13 +137,14 @@ config = load_effective_config(Path("recipes/Google/chrome.yaml"))
 - Three output modes: normal, verbose, and debug
 - Config loading and merging
 - HTTP static discovery strategy
+- URL regex discovery strategy
 - Robust file downloads
 - Version comparison (semver, numeric, lexicographic)
 - MSI ProductVersion extraction
 - Cross-platform support
 
 ### 🚧 Planned
-- Additional discovery strategies (url_regex, github_release, http_json)
+- Additional discovery strategies (github_release, http_json)
 - PSADT package building
 - Intune upload
 - Deployment wave management

--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ notapkgtool/
 │   └── loader.py          # YAML loading and 3-layer merging
 ├── discovery/
 │   ├── base.py            # Strategy protocol and registry
-│   └── http_static.py     # Static URL downloads
+│   ├── http_static.py     # Static URL downloads
+│   └── url_regex.py       # URL regex discovery strategy
 ├── versioning/
 │   ├── keys.py            # Version comparison (semver, numeric)
-│   └── msi.py             # MSI ProductVersion extraction
+│   ├── msi.py             # MSI ProductVersion extraction
+│   └── url_regex.py       # URL regex extraction helper
 ├── io/
 │   ├── download.py        # Robust HTTP downloads with retries
 │   └── upload.py          # Upload adapters (planned)
@@ -138,8 +140,8 @@ Configurations are deep-merged with "last wins" semantics.
 
 Pluggable strategies for obtaining application installers:
 
-- **`http_static`** ✅ - Download from fixed URLs
-- **`url_regex`** 🚧 - Extract version from URL patterns
+- **`http_static`** ✅ - Download from fixed URLs, extract version from file
+- **`url_regex`** ✅ - Extract version from URL patterns before download
 - **`github_release`** 🚧 - Fetch from GitHub releases
 - **`http_json`** 🚧 - Query JSON API endpoints
 
@@ -255,12 +257,13 @@ apps:
 - ✅ Verbose and debug output modes
 - ✅ Configuration system with 3-layer merging
 - ✅ HTTP static discovery strategy
+- ✅ URL regex discovery strategy
 - ✅ MSI ProductVersion extraction
 - ✅ Version comparison utilities
 - ✅ Cross-platform support
 
 ### v0.2.0 (Planned)
-- 🚧 Additional discovery strategies (url_regex, github_release)
+- 🚧 Additional discovery strategies (github_release, http_json)
 - 🚧 PSADT package building
 - 🚧 .intunewin generation
 

--- a/notapkgtool/discovery/__init__.py
+++ b/notapkgtool/discovery/__init__.py
@@ -18,10 +18,12 @@ Available Strategies
 http_static : HttpStaticStrategy
     Download from a fixed URL and extract version from the file itself.
     Supports MSI ProductVersion extraction.
+url_regex : UrlRegexStrategy
+    Extract version from URL patterns using regex, then download.
+    Fast version discovery without downloading first.
 
 Planned Strategies
 ------------------
-url_regex : Parse version from URL patterns using regex
 github_release : Fetch from GitHub releases API
 http_json : Query JSON API endpoints for version and download URL
 
@@ -58,5 +60,9 @@ Register and use a custom strategy:
 """
 
 from .base import DiscoveryStrategy, get_strategy
+
+# Import strategy modules to trigger self-registration
+from . import http_static  # noqa: F401
+from . import url_regex  # noqa: F401
 
 __all__ = ["DiscoveryStrategy", "get_strategy"]

--- a/notapkgtool/discovery/url_regex.py
+++ b/notapkgtool/discovery/url_regex.py
@@ -1,0 +1,257 @@
+"""
+URL regex discovery strategy for NAPT.
+
+This strategy extracts version information directly from the download URL using
+regular expressions, then downloads the installer. It's ideal for vendors who
+encode version numbers in their download URLs, allowing version discovery
+without downloading the entire file first.
+
+Key Advantages
+--------------
+- Fast version discovery (no download required for version check)
+- Bandwidth-efficient (can decide whether to download before fetching)
+- Works with any file type (MSI, EXE, DMG, etc.)
+- No file parsing overhead
+
+Supported Version Extraction
+-----------------------------
+- regex_in_url: Extract version from URL using a regex pattern
+  - Supports named capture groups: (?P<version>...)
+  - Falls back to full match if no named group
+
+Use Cases
+---------
+- Vendors with version-encoded download URLs
+  Example: https://vendor.com/app-v1.2.3-installer.msi
+- API endpoints that return version-specific download links
+  Example: https://api.vendor.com/download/2024.10.28/setup.exe
+- URLs with predictable version patterns in the path
+
+Recipe Configuration
+--------------------
+source:
+  strategy: url_regex
+  url: "https://vendor.com/downloads/app-v1.2.3-setup.msi"
+  version:
+    type: regex_in_url
+    pattern: "app-v(?P<version>[0-9.]+)-setup"
+
+The pattern supports full Python regex syntax. Use a named capture group
+(?P<version>) to extract only the version portion, or let the entire match
+be used as the version.
+
+Workflow
+--------
+1. Extract version from URL using regex pattern
+2. Create DiscoveredVersion with extracted version
+3. Download the installer from source.url using io.download.download_file
+4. Wait for atomic write to complete (.part -> final filename)
+5. Return DiscoveredVersion, file path, and SHA-256 hash
+
+Error Handling
+--------------
+- ValueError: Missing or invalid configuration fields, pattern doesn't match
+- RuntimeError: Download failures (chained with 'from err')
+- re.error: Invalid regex patterns (propagates from regex compilation)
+
+Comparison with http_static
+----------------------------
+- url_regex: Extracts version from URL before download
+  - Pros: Fast, bandwidth-efficient, file-format agnostic
+  - Cons: Requires predictable URL patterns
+  - Best for: Version-encoded URLs
+
+- http_static: Downloads file first, then extracts version from file
+  - Pros: Works with any URL, accurate version from installer
+  - Cons: Must download file to get version
+  - Best for: Fixed URLs with embedded version metadata
+
+Example
+-------
+In a recipe YAML:
+
+    apps:
+      - name: "My App"
+        id: "my-app"
+        source:
+          strategy: url_regex
+          url: "https://example.com/myapp-v2.1.0-setup.msi"
+          version:
+            type: regex_in_url
+            pattern: "myapp-v(?P<version>[0-9.]+)-setup"
+
+From Python:
+
+    from pathlib import Path
+    from notapkgtool.discovery.url_regex import UrlRegexStrategy
+
+    strategy = UrlRegexStrategy()
+    app_config = {
+        "source": {
+            "url": "https://example.com/app-v1.2.3.msi",
+            "version": {
+                "type": "regex_in_url",
+                "pattern": r"app-v(?P<version>[0-9.]+)\.msi",
+            },
+        }
+    }
+
+    discovered, file_path, sha256 = strategy.discover_version(
+        app_config, Path("./downloads")
+    )
+    print(f"Version {discovered.version} downloaded to {file_path}")
+
+Notes
+-----
+- Version extraction happens BEFORE download for efficiency
+- The URL pattern must be stable and predictable
+- Pattern matching is case-sensitive by default (use (?i) for case-insensitive)
+- Consider http_static if URLs don't contain version information
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from notapkgtool.io.download import download_file
+from notapkgtool.versioning.keys import DiscoveredVersion
+from notapkgtool.versioning.url_regex import version_from_regex_in_url
+
+from .base import register_strategy
+
+
+class UrlRegexStrategy:
+    """
+    Discovery strategy for extracting version from URL patterns.
+
+    Configuration example:
+        source:
+          strategy: url_regex
+          url: "https://vendor.com/app-v1.2.3-installer.msi"
+          version:
+            type: regex_in_url
+            pattern: "app-v(?P<version>[0-9.]+)-installer"
+    """
+
+    def discover_version(
+        self,
+        app_config: dict[str, Any],
+        output_dir: Path,
+        verbose: bool = False,
+        debug: bool = False,
+    ) -> tuple[DiscoveredVersion, Path, str]:
+        """
+        Extract version from URL using regex, then download the file.
+
+        This method extracts the version from the URL BEFORE downloading,
+        making it efficient for version checking. The file is then downloaded
+        to the output directory.
+
+        Parameters
+        ----------
+        app_config : dict
+            App configuration containing source.url, source.version.type,
+            and source.version.pattern.
+        output_dir : Path
+            Directory to save the downloaded file.
+        verbose : bool, optional
+            If True, print verbose logging messages. Default is False.
+        debug : bool, optional
+            If True, print debug logging messages. Default is False.
+
+        Returns
+        -------
+        tuple[DiscoveredVersion, Path, str]
+            Version info, file path to downloaded installer, and SHA-256 hash.
+
+        Raises
+        ------
+        ValueError
+            If required config fields are missing, invalid, or if the regex
+            pattern doesn't match the URL.
+        RuntimeError
+            If download fails (chained with 'from err').
+
+        Examples
+        --------
+        Basic usage:
+
+            >>> from pathlib import Path
+            >>> strategy = UrlRegexStrategy()
+            >>> config = {
+            ...     "source": {
+            ...         "url": "https://vendor.com/app-v1.0.0.msi",
+            ...         "version": {
+            ...             "type": "regex_in_url",
+            ...             "pattern": r"app-v(?P<version>[0-9.]+)\.msi"
+            ...         }
+            ...     }
+            ... }
+            >>> discovered, path, sha256 = strategy.discover_version(
+            ...     config, Path("./downloads")
+            ... )
+            >>> discovered.version
+            '1.0.0'
+        """
+        from notapkgtool.cli import print_verbose
+
+        # Validate configuration
+        source = app_config.get("source", {})
+        url = source.get("url")
+        if not url:
+            raise ValueError("url_regex strategy requires 'source.url' in config")
+
+        version_config = source.get("version", {})
+        version_type = version_config.get("type")
+        if not version_type:
+            raise ValueError(
+                "url_regex strategy requires 'source.version.type' in config"
+            )
+
+        if version_type != "regex_in_url":
+            raise ValueError(
+                f"url_regex strategy requires version.type='regex_in_url', "
+                f"got {version_type!r}"
+            )
+
+        pattern = version_config.get("pattern")
+        if not pattern:
+            raise ValueError(
+                "url_regex strategy requires 'source.version.pattern' in config"
+            )
+
+        print_verbose("DISCOVERY", "Strategy: url_regex")
+        print_verbose("DISCOVERY", f"Source URL: {url}")
+        print_verbose("DISCOVERY", f"Version extraction: {version_type}")
+        print_verbose("DISCOVERY", f"Regex pattern: {pattern}")
+
+        # Extract version from URL (BEFORE download for efficiency)
+        try:
+            discovered = version_from_regex_in_url(
+                url, pattern, verbose=verbose, debug=debug
+            )
+        except ValueError as err:
+            raise ValueError(
+                f"Failed to extract version from URL using regex: {err}"
+            ) from err
+
+        print_verbose("DISCOVERY", f"Discovered version: {discovered.version}")
+
+        # Now download the file
+        print_verbose("DISCOVERY", "Downloading installer...")
+        try:
+            file_path, sha256, _headers = download_file(
+                url, output_dir, verbose=verbose, debug=debug
+            )
+        except Exception as err:
+            raise RuntimeError(f"Failed to download {url}: {err}") from err
+
+        print_verbose("DISCOVERY", f"Download complete: {file_path.name}")
+
+        return discovered, file_path, sha256
+
+
+# Register this strategy when the module is imported
+register_strategy("url_regex", UrlRegexStrategy)
+

--- a/notapkgtool/versioning/url_regex.py
+++ b/notapkgtool/versioning/url_regex.py
@@ -1,6 +1,67 @@
 """
-Discovery helper: extract a version from a URL using a regex.
-Keeps concerns separate from comparison and from MSI/EXE parsing.
+URL regex version extraction for NAPT.
+
+This module extracts version information from URLs using regular expressions.
+It's useful when vendors encode version numbers in their download URLs, allowing
+version discovery without downloading the entire file first.
+
+Use Cases
+---------
+- Vendors with version-encoded URLs (e.g., app-v1.2.3-installer.msi)
+- APIs that return version-specific download links
+- URLs with semantic version patterns in the path
+
+Functions
+---------
+version_from_regex_in_url : function
+    Extract version string from a URL using a regex pattern.
+
+Pattern Syntax
+--------------
+Patterns support full Python regex syntax. Two extraction modes:
+
+1. Named capture group (recommended):
+   pattern = r"app-v(?P<version>[0-9.]+)-installer"
+   Extracts only the 'version' group from the match.
+
+2. Full match (fallback):
+   pattern = r"[0-9]+\.[0-9]+\.[0-9]+"
+   Uses the entire regex match as the version.
+
+Examples
+--------
+Extract version from URL with named group:
+
+    >>> from notapkgtool.versioning.url_regex import version_from_regex_in_url
+    >>> url = "https://vendor.com/downloads/myapp-v1.2.3-setup.msi"
+    >>> pattern = r"myapp-v(?P<version>[0-9.]+)-setup"
+    >>> discovered = version_from_regex_in_url(url, pattern)
+    >>> print(f"{discovered.version} from {discovered.source}")
+    1.2.3 from regex_in_url
+
+Extract version with full match:
+
+    >>> url = "https://vendor.com/app/2024.10.28/installer.exe"
+    >>> pattern = r"[0-9]{4}\.[0-9]{2}\.[0-9]{2}"
+    >>> discovered = version_from_regex_in_url(url, pattern)
+    >>> discovered.version
+    '2024.10.28'
+
+Error handling:
+
+    >>> try:
+    ...     url = "https://vendor.com/app.msi"
+    ...     pattern = r"v(?P<version>[0-9.]+)"
+    ...     discovered = version_from_regex_in_url(url, pattern)
+    ... except ValueError as e:
+    ...     print(f"Pattern did not match: {e}")
+
+Notes
+-----
+- This is pure string extraction; no network calls are made
+- The extracted version is not validated for format
+- Empty version strings will raise ValueError
+- Regex compilation errors propagate as-is
 """
 
 from __future__ import annotations
@@ -10,19 +71,84 @@ import re
 from notapkgtool.versioning.keys import DiscoveredVersion
 
 
-def version_from_regex_in_url(url: str, pattern: str) -> DiscoveredVersion:
+def version_from_regex_in_url(
+    url: str, pattern: str, verbose: bool = False, debug: bool = False
+) -> DiscoveredVersion:
     """
-    Extract a version from a URL using a regex.
+    Extract a version from a URL using a regular expression.
 
-    If the regex includes a named group (?P<version>), that group is used;
-    otherwise, the whole match is returned.
+    The function searches for the pattern in the URL and extracts the version
+    based on capture groups. If a named group (?P<version>) exists, that group
+    is used; otherwise, the entire match is used.
 
-    Raises ValueError if the pattern does not match.
+    Parameters
+    ----------
+    url : str
+        The URL to extract the version from. Can be a full URL or just a path.
+    pattern : str
+        Regular expression pattern to match. Use (?P<version>...) for a named
+        capture group to extract only the version portion.
+    verbose : bool, optional
+        If True, print verbose logging messages. Default is False.
+    debug : bool, optional
+        If True, print debug logging messages. Default is False.
+
+    Returns
+    -------
+    DiscoveredVersion
+        Container with the extracted version string and source='regex_in_url'.
+
+    Raises
+    ------
+    ValueError
+        If the pattern does not match the URL, or if the extracted version
+        is empty.
+    re.error
+        If the regex pattern is invalid (propagates from re.search).
+
+    Examples
+    --------
+    Extract with named capture group:
+
+        >>> url = "https://vendor.com/app-v2.1.0-installer.msi"
+        >>> pattern = r"app-v(?P<version>[0-9.]+)-installer"
+        >>> discovered = version_from_regex_in_url(url, pattern)
+        >>> discovered.version
+        '2.1.0'
+
+    Extract with full match:
+
+        >>> url = "https://vendor.com/downloads/1.2.3/setup.exe"
+        >>> pattern = r"[0-9]+\.[0-9]+\.[0-9]+"
+        >>> discovered = version_from_regex_in_url(url, pattern)
+        >>> discovered.version
+        '1.2.3'
     """
-    m = re.search(pattern, url)
+    from notapkgtool.cli import print_debug, print_verbose
+
+    print_verbose("VERSION", "Strategy: regex_in_url")
+    print_verbose("VERSION", f"Pattern: {pattern}")
+    print_debug("VERSION", f"URL: {url}")
+
+    try:
+        m = re.search(pattern, url)
+    except re.error as err:
+        raise ValueError(f"Invalid regex pattern: {pattern!r}") from err
+
     if not m:
         raise ValueError(
-            f"could not extract version from url with pattern: {pattern}; url={url}"
+            f"Pattern did not match URL. Pattern: {pattern!r}, URL: {url!r}"
         )
+
+    # Use named group 'version' if present, otherwise use full match
     ver = m.group("version") if "version" in (m.groupdict() or {}) else m.group(0)
+
+    if not ver:
+        raise ValueError(
+            f"Extracted version is empty. Pattern: {pattern!r}, URL: {url!r}"
+        )
+
+    print_verbose("VERSION", f"Success! Extracted: {ver} (via regex)")
+    print_debug("VERSION", f"Match details: {m.groups()}")
+
     return DiscoveredVersion(version=ver, source="regex_in_url")


### PR DESCRIPTION
## Summary
Implements the `url_regex` discovery strategy for NAPT, enabling version extraction directly from download URLs using regular expressions. This strategy is ideal for vendors who encode version numbers in their download URLs.

## What's Changed

### 1. Improved URL Regex Versioning Function
- Enhanced `notapkgtool/versioning/url_regex.py` with verbose/debug support
- Added comprehensive docstrings following project standards
- Improved error handling and validation
- Added `print_verbose` and `print_debug` logging integration

### 2. New URL Regex Discovery Strategy
- Created `notapkgtool/discovery/url_regex.py` implementing the `DiscoveryStrategy` protocol
- Extracts version from URL **before** downloading (bandwidth-efficient)
- Supports named capture groups `(?P<version>...)` and full regex matches
- Validates configuration fields and provides helpful error messages
- Self-registers with the discovery strategy registry

### 3. Updated Discovery Package
- Modified `notapkgtool/discovery/__init__.py` to import and register new strategy
- Updated documentation to reflect available strategies

### 4. Documentation Updates
- Updated README.md with url_regex status (✅ implemented)
- Updated DOCUMENTATION.md package structure and status
- Updated project roadmap (moved from v0.2.0 Planned to v0.1.0 Current)
- Removed GitHub settings instructions from BRANCHING.md

## How It Works

**Configuration Example:**
```yaml
source:
  strategy: url_regex
  url: "https://vendor.com/app-v1.2.3-installer.msi"
  version:
    type: regex_in_url
    pattern: "app-v(?P<version>[0-9.]+)-installer"
```

**Workflow:**
1. Extract version from URL using regex pattern (no download required)
2. Download installer to output directory
3. Return `DiscoveredVersion`, file path, and SHA-256 hash

## Testing

Manual testing performed:
- ✅ Named capture group extraction
- ✅ Full match extraction  
- ✅ Complex version patterns (prerelease versions)
- ✅ Error handling for non-matching patterns
- ✅ Strategy registration and retrieval

## Benefits

- **Fast**: Version extraction happens before download
- **Bandwidth-efficient**: Can decide whether to download based on version
- **File-agnostic**: Works with any installer format (MSI, EXE, DMG, etc.)
- **Flexible**: Full regex support with named groups or full matches

## Comparison with http_static

- **url_regex**: Extracts version from URL → downloads file
  - Best for: Version-encoded URLs
- **http_static**: Downloads file → extracts version from file metadata
  - Best for: Fixed URLs with embedded version info

## Breaking Changes
None - fully backward compatible.