### PR TITLE
fix: version type naming migration and improve platform documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,19 @@ flowchart TD
 
 See the [User Guide](https://rogercibrian.github.io/notapkgtool/user-guide/) for detailed architecture information and the [API Reference](https://rogercibrian.github.io/notapkgtool/api/core/) for code-level documentation.
 
-## Cross-Platform Support
+## Platform Support
 
-NAPT works on Windows, Linux, and macOS with full feature parity.
+**NAPT is a Windows tool** for Microsoft Intune packaging. Discovery and building work on Linux and macOS, with final packaging on Windows.
 
-| Platform | Status |
-|----------|--------|
-| **Windows** | ✅ Fully Supported |
-| **Linux** | ✅ Fully Supported |
-| **macOS** | ✅ Fully Supported |
+| Command | Windows | Linux/macOS |
+|---------|---------|-------------|
+| `napt discover` | ✅ | ✅ |
+| `napt build` | ✅ | ✅ |
+| `napt package` | ✅ | ⚫ Windows Only |
 
-See the [Cross-Platform Support](https://rogercibrian.github.io/notapkgtool/user-guide/#cross-platform-support) section for technical details on MSI extraction backends.
+This design makes sense: Intune deploys to Windows endpoints, most Intune administrators have Windows infrastructure, and CI/CD platforms offer Windows runners. The cross-platform discovery and build commands support modern development workflows.
+
+See the [Cross-Platform Support](https://rogercibrian.github.io/notapkgtool/user-guide/#cross-platform-support) section for detailed workflows and CI/CD examples.
 
 ## Creating Recipes
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-NAPT is a Python-based CLI tool that automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune. It eliminates repetitive manual work through declarative YAML-based recipes and intelligent version discovery.
+NAPT is a Python-based CLI tool that automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune. It runs on Windows, Linux, and macOS, though packaging (.intunewin creation) requires Windows.
 
 📚 **[Full Documentation](https://rogercibrian.github.io/notapkgtool/)** | [Quick Start](https://rogercibrian.github.io/notapkgtool/quick-start/) | [User Guide](https://rogercibrian.github.io/notapkgtool/user-guide/) | [API Reference](https://rogercibrian.github.io/notapkgtool/api/core/)
 
@@ -75,17 +75,13 @@ flowchart TD
 
 See the [User Guide](https://rogercibrian.github.io/notapkgtool/user-guide/) for detailed architecture information and the [API Reference](https://rogercibrian.github.io/notapkgtool/api/core/) for code-level documentation.
 
-## Platform Support
-
-**NAPT is a Windows tool** for Microsoft Intune packaging. Discovery and building work on Linux and macOS, with final packaging on Windows.
+## Cross-Platform Support
 
 | Command | Windows | Linux/macOS |
 |---------|---------|-------------|
 | `napt discover` | ✅ | ✅ |
 | `napt build` | ✅ | ✅ |
 | `napt package` | ✅ | ⚫ Windows Only |
-
-This design makes sense: Intune deploys to Windows endpoints, most Intune administrators have Windows infrastructure, and CI/CD platforms offer Windows runners. The cross-platform discovery and build commands support modern development workflows.
 
 See the [Cross-Platform Support](https://rogercibrian.github.io/notapkgtool/user-guide/#cross-platform-support) section for detailed workflows and CI/CD examples.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@ Have an idea for NAPT? Check [docs/roadmap.md](roadmap.md) to see what's planned
 
 ### Development Setup
 
-```bash
+```powershell
 # Clone and install with dev dependencies
 git clone https://github.com/RogerCibrian/notapkgtool.git
 cd notapkgtool
@@ -23,7 +23,7 @@ napt --version
 
 ### Running Tests
 
-```bash
+```powershell
 # Run all tests
 poetry run pytest tests/
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-NAPT is a Python-based CLI tool that automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune. It eliminates repetitive manual work through declarative YAML-based recipes and intelligent version discovery.
+NAPT is a Python-based CLI tool that automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune. It runs on Windows, Linux, and macOS, though packaging (.intunewin creation) requires Windows.
 
 ### Key Features
 
@@ -73,17 +73,13 @@ flowchart TD
 
 See the [User Guide](user-guide.md) for detailed architecture information and the [API Reference](api/core.md) for code-level documentation.
 
-## Platform Support
-
-**NAPT is a Windows tool** for Microsoft Intune packaging. Discovery and building work on Linux and macOS, with final packaging on Windows.
+## Cross-Platform Support
 
 | Command | Windows | Linux/macOS |
 |---------|---------|-------------|
 | `napt discover` | ✅ | ✅ |
 | `napt build` | ✅ | ✅ |
 | `napt package` | ✅ | ⚫ Windows Only |
-
-This design makes sense: Intune deploys to Windows endpoints, most Intune administrators have Windows infrastructure, and CI/CD platforms offer Windows runners. The cross-platform discovery and build commands support modern development workflows.
 
 See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for detailed workflows and CI/CD examples.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,17 +73,19 @@ flowchart TD
 
 See the [User Guide](user-guide.md) for detailed architecture information and the [API Reference](api/core.md) for code-level documentation.
 
-## Cross-Platform Support
+## Platform Support
 
-NAPT works on Windows, Linux, and macOS with full feature parity.
+**NAPT is a Windows tool** for Microsoft Intune packaging. Discovery and building work on Linux and macOS, with final packaging on Windows.
 
-| Platform | Status |
-|----------|--------|
-| **Windows** | ✅ Fully Supported |
-| **Linux** | ✅ Fully Supported |
-| **macOS** | ✅ Fully Supported |
+| Command | Windows | Linux/macOS |
+|---------|---------|-------------|
+| `napt discover` | ✅ | ✅ |
+| `napt build` | ✅ | ✅ |
+| `napt package` | ✅ | ⚫ Windows Only |
 
-See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for technical details on MSI extraction backends.
+This design makes sense: Intune deploys to Windows endpoints, most Intune administrators have Windows infrastructure, and CI/CD platforms offer Windows runners. The cross-platform discovery and build commands support modern development workflows.
+
+See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for detailed workflows and CI/CD examples.
 
 ## Creating Recipes
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -71,7 +71,7 @@ brew install msitools
 
 **Packaging requires Windows.** NAPT uses Microsoft's IntuneWinAppUtil.exe for creating .intunewin packages, which is Windows-only.
 
-**Discovery and building work on all platforms.** The cross-platform commands let you develop on your preferred OS and package on Windows when ready.
+**Discovery and building work on all platforms.** Develop on your preferred OS and package on Windows when ready.
 
 See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for CI/CD workflows and detailed examples.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -65,7 +65,15 @@ sudo dnf install msitools
 brew install msitools
 ```
 
-> **Note:** Windows users don't need msitools - NAPT uses native PowerShell COM API for MSI extraction.
+> **💡 Note:** Windows users don't need msitools - NAPT uses native PowerShell COM API for MSI extraction.
+
+### Platform Requirements
+
+**Packaging requires Windows.** NAPT uses Microsoft's IntuneWinAppUtil.exe for creating .intunewin packages, which is Windows-only.
+
+**Discovery and building work on all platforms.** The cross-platform commands let you develop on your preferred OS and package on Windows when ready.
+
+See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for CI/CD workflows and detailed examples.
 
 ## Basic Usage
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -15,14 +15,14 @@ Get up and running with NAPT in minutes!
 
 Best for users who just want to use the tool without extra tooling.
 
-```bash
+```powershell
 # Clone repository
 git clone https://github.com/RogerCibrian/notapkgtool.git
 cd notapkgtool
 
 # Create and activate virtual environment (recommended)
 python -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+.venv\Scripts\Activate.ps1  # On Linux/macOS: source .venv/bin/activate
 
 # Install
 pip install -e .
@@ -37,7 +37,7 @@ Best for contributors and developers who want reproducible builds and dependency
 
 **Prerequisites:** Poetry must be installed. See [Poetry Installation Guide](https://python-poetry.org/docs/#installation)
 
-```bash
+```powershell
 # Clone and install
 git clone https://github.com/RogerCibrian/notapkgtool.git
 cd notapkgtool
@@ -52,7 +52,9 @@ napt --version
 
 ### Platform-Specific Requirements
 
-**Linux/macOS** - Install msitools for MSI version extraction:
+**Windows:** No additional requirements - NAPT uses native PowerShell COM API for MSI extraction.
+
+**Linux/macOS:** Install msitools for MSI version extraction:
 
 ```bash
 # Debian/Ubuntu
@@ -64,8 +66,6 @@ sudo dnf install msitools
 # macOS
 brew install msitools
 ```
-
-> **💡 Note:** Windows users don't need msitools - NAPT uses native PowerShell COM API for MSI extraction.
 
 ### Platform Requirements
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -380,7 +380,7 @@ apps:
 
 ## Cross-Platform Support
 
-**NAPT is a Windows tool** for Microsoft Intune packaging. The discovery and build commands work on Linux and macOS to support modern development workflows.
+**NAPT is a Windows tool** for Microsoft Intune packaging. Develop on any platform, package on Windows.
 
 ### Platform Compatibility Matrix
 
@@ -392,13 +392,19 @@ apps:
 
 ### Why Windows for Packaging?
 
-The `napt package` command uses Microsoft's [IntuneWinAppUtil.exe](https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool), which is a Windows-only .NET application. This is the official tool for creating .intunewin packages, and there's no cross-platform alternative.
-
-This makes sense in context: Intune deploys to Windows endpoints, most Intune administrators have Windows infrastructure available, and CI/CD platforms offer Windows runners. The cross-platform discovery and build commands handle the development-heavy work, with packaging as a final Windows-based step.
+The `napt package` command uses Microsoft's [IntuneWinAppUtil.exe](https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool), which is a Windows-only .NET application. This is the official tool for creating .intunewin packages.
 
 ### Recommended Workflows
 
-#### Workflow 1: Mixed Platform Development
+#### Workflow 1: All-Windows (Simplest)
+```bash
+# Run everything on Windows
+napt discover recipes/Google/chrome.yaml
+napt build recipes/Google/chrome.yaml
+napt package builds/napt-chrome/142.0.7444.163/
+```
+
+#### Workflow 2: Mixed Platform Development
 ```bash
 # On Linux/macOS: Discovery and build
 napt discover recipes/Google/chrome.yaml
@@ -406,36 +412,6 @@ napt build recipes/Google/chrome.yaml
 
 # Transfer build directory to Windows (or use shared drive)
 # On Windows: Package
-napt package builds/napt-chrome/142.0.7444.163/
-```
-
-#### Workflow 2: CI/CD with Windows Runners
-```yaml
-# .github/workflows/package.yml
-jobs:
-  discover-and-build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: napt discover recipes/app.yaml
-      - run: napt build recipes/app.yaml
-      - uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: builds/
-
-  package:
-    runs-on: windows-latest  # Windows for packaging
-    needs: discover-and-build
-    steps:
-      - uses: actions/download-artifact@v3
-      - run: napt package builds/app-name/1.0.0/
-```
-
-#### Workflow 3: All-Windows
-```bash
-# Simplest: Just use Windows for everything
-napt discover recipes/Google/chrome.yaml
-napt build recipes/Google/chrome.yaml
 napt package builds/napt-chrome/142.0.7444.163/
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -535,7 +535,7 @@ fi
 
 **Problem**: "Command not found: napt"
 
-```bash
+```powershell
 # Solution 1: Activate Poetry shell
 poetry shell
 
@@ -563,15 +563,18 @@ napt discover recipes/app.yaml --stateless
 
 **Problem**: GitHub API rate limit
 
-```bash
-# Solution: Use authentication token
-# In recipe:
+```yaml
+# Solution: Use authentication token in recipe
 source:
   strategy: api_github
   token: "${GITHUB_TOKEN}"
+```
 
-# Set environment variable
-export GITHUB_TOKEN="your_token_here"
+```powershell
+# Set environment variable (Windows)
+$env:GITHUB_TOKEN="your_token_here"
+
+# On Linux/macOS: export GITHUB_TOKEN="your_token_here"
 ```
 
 ### Debug Mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,13 +29,18 @@ theme:
         name: Switch to dark mode
 
 markdown_extensions:
-  - pymdownx.tasklist:
-      custom_checkbox: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tasklist:
+      custom_checkbox: true
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
   features:
     - navigation.tabs        
     - navigation.tabs.sticky 
+    - content.code.copy
   palette:
     # Dark mode (default)
     - scheme: slate

--- a/notapkgtool/build/manager.py
+++ b/notapkgtool/build/manager.py
@@ -111,7 +111,7 @@ def _get_installer_version(
                 "No version.type specified in recipe. Add source.version.type or ensure state file exists."
             )
 
-    if version_type == "msi_product_version_from_file":
+    if version_type == "msi":
         try:
             discovered = version_from_msi_product_version(installer_file)
             print_verbose("BUILD", f"Extracted version: {discovered.version}")
@@ -122,8 +122,7 @@ def _get_installer_version(
             ) from err
     else:
         raise ValueError(
-            f"Unsupported version type for build: {version_type!r}. "
-            f"Supported: msi_product_version_from_file"
+            f"Unsupported version type for build: {version_type!r}. " f"Supported: msi"
         )
 
 

--- a/notapkgtool/versioning/keys.py
+++ b/notapkgtool/versioning/keys.py
@@ -44,8 +44,7 @@ class DiscoveredVersion:
 
     Attributes:
         version: Raw version string (e.g., "140.0.7339.128").
-        source: Where it came from (e.g., "regex_in_url",
-            "msi_product_version_from_file").
+        source: Where it came from (e.g., "regex_in_url", "msi").
 
     """
 

--- a/notapkgtool/versioning/msi.py
+++ b/notapkgtool/versioning/msi.py
@@ -54,7 +54,7 @@ Example:
         from notapkgtool.versioning.msi import version_from_msi_product_version
         discovered = version_from_msi_product_version("chrome.msi")
         print(f"{discovered.version} from {discovered.source}")
-        # 141.0.7390.123 from msi_product_version_from_file
+        # 141.0.7390.123 from msi
 
     Error handling:
 
@@ -119,7 +119,7 @@ def version_from_msi_product_version(
     if not p.exists():
         raise FileNotFoundError(f"MSI not found: {p}")
 
-    print_verbose("VERSION", "Strategy: msi_product_version_from_file")
+    print_verbose("VERSION", "Strategy: msi")
     print_verbose("VERSION", f"Extracting version from: {p.name}")
 
     # Try msilib first (standard library on Windows)
@@ -140,9 +140,7 @@ def version_from_msi_product_version(
             if not version:
                 raise RuntimeError("Empty ProductVersion in MSI Property table.")
             print_verbose("VERSION", f"Success! Extracted: {version} (via msilib)")
-            return DiscoveredVersion(
-                version=version, source="msi_product_version_from_file"
-            )
+            return DiscoveredVersion(version=version, source="msi")
         except Exception as err:
             print_debug("VERSION", "msilib failed, trying next backend...")
             raise RuntimeError(
@@ -176,9 +174,7 @@ def version_from_msi_product_version(
                 view.Close()
                 db.Close()
                 print_verbose("VERSION", f"Success! Extracted: {version} (via _msi)")
-                return DiscoveredVersion(
-                    version=version, source="msi_product_version_from_file"
-                )
+                return DiscoveredVersion(version=version, source="msi")
             except Exception as err:
                 print_debug("VERSION", "_msi failed, trying next backend...")
                 raise RuntimeError(
@@ -214,9 +210,7 @@ if ($record) {{
                 print_verbose(
                     "VERSION", f"Success! Extracted: {version} (via PowerShell COM)"
                 )
-                return DiscoveredVersion(
-                    version=version, source="msi_product_version_from_file"
-                )
+                return DiscoveredVersion(version=version, source="msi")
         except subprocess.CalledProcessError as err:
             print_debug("VERSION", "PowerShell COM failed, trying next backend...")
             raise RuntimeError(f"PowerShell MSI query failed: {err}") from err
@@ -245,9 +239,7 @@ if ($record) {{
             if not version_str:
                 raise RuntimeError("ProductVersion not found in MSI Property output.")
             print_verbose("VERSION", f"Success! Extracted: {version_str} (via msiinfo)")
-            return DiscoveredVersion(
-                version=version_str, source="msi_product_version_from_file"
-            )
+            return DiscoveredVersion(version=version_str, source="msi")
         except subprocess.CalledProcessError as err:
             print_debug("VERSION", "msiinfo failed")
             raise RuntimeError(f"msiinfo failed: {err}") from err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def sample_recipe_data() -> dict[str, Any]:
                     "strategy": "url_download",
                     "url": "https://example.com/installer.msi",
                     "version": {
-                        "type": "msi_product_version_from_file",
+                        "type": "msi",
                     },
                 },
                 "psadt": {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,7 +77,7 @@ class TestEndToEndWorkflow:
                 "notapkgtool.discovery.url_download.version_from_msi_product_version"
             ) as mock_extract:
                 mock_extract.return_value = DiscoveredVersion(
-                    version="1.2.3", source="msi_product_version_from_file"
+                    version="1.2.3", source="msi"
                 )
 
                 result = discover_recipe(recipe_path, output_dir)


### PR DESCRIPTION
### Summary
Fixes the "Unsupported version type for build: 'msi'" error and significantly improves documentation clarity with honest Windows-first positioning. This completes the v0.2.1 breaking change migration and repositions NAPT's platform messaging to be transparent and accurate.

### Changes

**Bug Fix:**
- Update build manager to accept `msi` instead of `msi_product_version_from_file`
- Update MSI versioning module to return `source="msi"` in all backends (msilib, _msi, PowerShell COM, msiinfo)
- Update test fixtures and expectations to use simplified naming
- Completes the breaking change migration from v0.2.1

**Documentation - Platform Messaging:**
- Replace "near-complete feature parity" with clearer Windows focused language
- Add platform requirement to Overview section 
- Simplify platform support tables and remove redundant explanations
- Change section heading from "Platform Support" to "Cross-Platform Support"

**Documentation - Windows-First Examples:**
- Update all installation examples from `bash` to `powershell`
- Show Windows syntax first (`.venv\Scripts\Activate.ps1`), Linux/macOS as comments
- Update environment variable examples to use PowerShell (`$env:` syntax)
- Reorder platform-specific requirements (Windows first, then Linux/macOS)
- Split YAML and shell examples where appropriate

**MkDocs Improvements:**
- Add `pymdownx.highlight` and `pymdownx.inlinehilite` for syntax highlighting
- Add `content.code.copy` feature for copy-to-clipboard button on code blocks
- Reorder workflows: All-Windows first (simplest), Mixed Platform second

### Why These Changes?

**Bug Context:**
The v0.2.1 changelog documented simplifying `msi_product_version_from_file` → `msi`, but the build manager and versioning module weren't updated, causing `napt build` to fail.

**Documentation Context:**
After attempting Wine support for cross-platform packaging, we determined Wine + .NET Framework is unreliable for enterprise use. Rather than hide this limitation, the docs now honestly position NAPT as a Windows tool with cross-platform development support - which aligns with Intune's Windows-centric ecosystem.

### Testing Performed
- ✅ All 190 tests pass
- ✅ `napt build recipes/Google/chrome.yaml` works correctly
- ✅ `mkdocs build` succeeds without errors
- ✅ Syntax highlighting verified in local build
- ✅ All linters pass (ruff + black)

### Breaking Changes
None. This fixes a bug introduced in v0.2.1 and only updates documentation.

### Checklist
- [x] Code follows project style guidelines (ruff + black)
- [x] All tests passing (190/190)
- [x] Documentation updated and simplified
- [x] README.md ↔ docs/index.md synced
- [x] MkDocs builds without errors
- [x] Commit messages follow conventional commit format