### PR TITLE
chore: consolidate Claude rules into single CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,250 @@
+# NAPT Project Rules
+
+## Project Principles
+
+**NAPT does:** Discovery, packaging, deployment, state management.
+
+**NAPT does not:** Git operations, PR creation, CI/CD workflow logic. Don't add `--create-pr` flags or git commands.
+
+**No backward compatibility (pre-release):** Implement cleanest solutions directly. Remove deprecated code immediately. No migration paths or fallback logic. After v1.0.0, standard semver applies.
+
+---
+
+## Development Environment
+
+- **Python:** 3.13.5
+- **Virtual environment:** `.venv/`
+- **Shell:** PowerShell 5.1
+
+**Run Python tools directly:**
+```powershell
+.venv\Scripts\python.exe -m ruff check --fix notapkgtool/ tests/
+.venv\Scripts\python.exe -m black notapkgtool/ tests/
+.venv\Scripts\python.exe -m pytest tests/
+```
+
+**Never use `&&`** in PowerShell 5.1. Use `;` or separate commands.
+
+---
+
+## Code Quality
+
+Use **ruff** + **black**. Fix all errors before committing. Never ignore errors. Configuration is in `pyproject.toml`.
+
+```powershell
+.venv\Scripts\python.exe -m ruff check --fix notapkgtool/ tests/
+.venv\Scripts\python.exe -m black notapkgtool/ tests/
+.venv\Scripts\python.exe -m ruff check notapkgtool/ tests/
+```
+
+**Line length:** 88 chars max. Break with parentheses or multiple lines.
+
+---
+
+## Docstrings
+
+Use [Google Python Style Guide 3.8](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) with:
+
+- **Descriptive style:** "Fetches rows" not "Fetch rows"
+- **Omit types:** MkDocs extracts from signatures
+- **4-space indentation** after section headers
+- **Section order:** Summary → Description → Args → Returns → Raises → Example → Note
+- **Note is singular:** `Note:` never `Notes:`
+
+**Example section** requires subtitle before code fence:
+```python
+Example:
+    Basic usage:
+        ```python
+        result = my_function("test")
+        ```
+```
+
+**Bullet lists in sections:** Indent 4 spaces. In main description: no extra indent, blank line before list.
+
+**Collapsible box (intentional only):** No blank line + 4-space indented bullets:
+```python
+"""Provides discovery functionality.
+
+Key Features:
+    - First item
+    - Second item
+"""
+```
+
+**Complex Returns:** Indent continuation lines to avoid mkdocstrings parsing as definition list:
+```python
+Returns:
+    A dict (key1, key2, key3), where
+        key1 is the first thing,
+        key2 is the second thing.
+```
+
+**Module docstrings:** Required for all modules. First line is summary, then blank line, then details.
+
+**Test docstrings:** Use `"""Tests that <condition>."""` format. Keep brief.
+
+**Validate rendering:**
+```powershell
+.venv\Scripts\python.exe -m mkdocs serve
+```
+
+---
+
+## License Header
+
+All `notapkgtool/**/*.py` files require before docstring:
+
+```python
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+```
+
+**Not required:** `tests/`, generated files. **Copyright year:** Always 2025.
+
+**File order:** Shebang (if needed) → License → Module docstring → Imports → Code
+
+---
+
+## Exceptions
+
+| Exception | Use For |
+|-----------|---------|
+| `ConfigError` | Recipe/YAML errors, missing fields, invalid config |
+| `NetworkError` | HTTP failures, API errors, download issues |
+| `PackagingError` | PSADT errors, MSI extraction, build failures |
+
+**Public API / user-facing:** Use custom exceptions. **Private helpers / bugs:** Use built-in.
+
+**Always chain:** `raise ConfigError(...) from err`
+
+**Creating new types:** Only if existing types don't fit. Define in `notapkgtool/exceptions.py`. Include clear docstring explaining when to use.
+
+---
+
+## results.py Scope
+
+`notapkgtool/results.py` is for **public API return types only** (`DiscoverResult`, `BuildResult`, `PackageResult`, `ValidationResult`).
+
+Domain types and internal types stay co-located with their logic.
+
+---
+
+## Documentation
+
+Update docs when code changes affect user-facing behavior.
+
+| File | Purpose |
+|------|---------|
+| **index.md** | Landing page (synced to README.md) |
+| **quick-start.md** | Installation, basic commands |
+| **user-guide.md** | Full reference |
+| **common-tasks.md** | Copy-paste workflows |
+| **recipe-reference.md** | Complete recipe schema |
+
+**README.md sync:** ONE-WAY from index.md. Transform relative links to full URLs.
+
+**What to update:** New feature → user-guide, common-tasks, changelog. CLI change → same. Recipe schema → recipe-reference, common-tasks, changelog.
+
+**Formatting:** Use sentence case for headings. One sentence per line in source. Wrap at 80 chars for prose.
+
+**Validate:** Run `mkdocs serve` before committing doc changes.
+
+---
+
+## Git & Releases
+
+See `docs/branching.md` for full workflow. PR template at `.github/PULL_REQUEST_TEMPLATE.md`. GitHub CLI (`gh`) is available.
+
+**Commits:** `type: subject` (feat, fix, docs, refactor, test, chore, perf). Under 50 chars, imperative, capitalized, no period.
+
+**Branches:** `type/description-in-lowercase`
+
+**PRs:** Title in conventional commit format. Use `gh pr create` to create PRs from CLI.
+
+**Releases:** [Semver 2.0.0](https://semver.org/spec/v2.0.0.html), no "v" prefix.
+
+1. Create PR `chore/prepare-release-X.Y.Z` updating versions and changelog
+2. Squash and merge
+3. Tag: `git tag -a X.Y.Z -m "Release X.Y.Z"` then `git push origin X.Y.Z`
+4. Release: `gh release create X.Y.Z --title "NAPT X.Y.Z" --notes-file RELEASE_NOTES.md`
+
+---
+
+## Changelog
+
+Follow [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Focus on user impact, not implementation.
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Feature Name** - What users can now do
+
+### Changed
+- **BREAKING: Change** - Migration path
+    - Sub-item (4-space indent)
+
+### Fixed
+- Fixed symptom description
+```
+
+- Breaking changes: prefix `**BREAKING:**`
+- One feature = one bullet
+- Don't include: test updates, refactors without user impact
+
+**On release:** Move items from `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`. Add comparison link at bottom.
+
+---
+
+## Roadmap
+
+Update `docs/roadmap.md` when user mentions deferred features ("add to roadmap", "let's do this later").
+
+```markdown
+### Feature Name
+
+**Status:** 💡 Idea
+**Complexity:** Low | Medium | High | Very High
+**Value:** Low | Medium | High | Very High
+
+**Description:** What problem it solves.
+**Benefits:** Why we'd want this.
+```
+
+Status progression: 💡 Idea → 🔬 Investigating → 📋 Ready → 🚧 In Progress → ✅ Completed
+
+**Categories:** Group by: Discovery, Packaging, Deployment, CLI, Developer Experience.
+
+**Don't add:** Bug reports (use issues), small enhancements (just do them), vague ideas without clear value.
+
+---
+
+## Console Output
+
+Use ASCII-only in console output. Windows (cp1252, cp437) causes `UnicodeEncodeError` with Unicode.
+
+**Avoid:** ✓ ✔ ✗ ✘ ⚠️ → ← • ●
+
+**Alternatives:** `[OK]`, `[FAIL]`, `[WARNING]`, `->`, `-`
+
+**Applies to:** print(), logging, CLI output. **Not:** docs, JSON/YAML, comments.
+
+---
+
+## PSADT Reference
+
+For PSAppDeployToolkit work, reference: `.claude_context/PSADT Reference Documentation 11.5.25/`
+
+134+ functions, deployment concepts, config settings, exit codes. Covers v3.10.2, v4.0.0, latest.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m ruff check:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(ruff check:*)",
+      "Bash(black:*)"
+    ]
+  }
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+Brief description of what this PR does.
+
+## Motivation
+Why is this change needed?
+
+## Changes
+- Bullet list of key changes
+- Include any breaking changes
+
+## Testing
+How was this tested?
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing performed
+
+## Checklist
+- [ ] Code follows project conventions
+- [ ] Documentation updated
+- [ ] Tests pass
+- [ ] No linting errors

--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,4 @@ state/*.json
 .DS_Store
 
 # IDE files
-.cursor/
-.cursor_context
-.claude/
+.claude_context

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -153,31 +153,7 @@ git commit -m "WIP"                   # Too vague
 
 ## Pull Request Process
 
-### Pull Request Description Template
-
-```markdown
-## Description
-Brief description of what this PR does.
-
-## Motivation
-Why is this change needed?
-
-## Changes
-- Bullet list of key changes
-- Include any breaking changes
-
-## Testing
-How was this tested?
-- [ ] Unit tests added/updated
-- [ ] Integration tests added/updated
-- [ ] Manual testing performed
-
-## Checklist
-- [ ] Code follows project conventions
-- [ ] Documentation updated
-- [ ] Tests pass
-- [ ] No linting errors
-```
+When creating a PR, the [PR template](/.github/PULL_REQUEST_TEMPLATE.md) auto-populates with sections for Description, Motivation, Changes, Testing, and Checklist.
 
 ## Merge Strategy
 


### PR DESCRIPTION
## Description
Consolidates all Cursor rules into a single `.claude/CLAUDE.md` file for Claude Code compatibility.

## Motivation
Claude Code uses a single CLAUDE.md file rather than multiple .mdc rule files. This consolidation optimizes the rules for Claude's understanding and removes Cursor-specific frontmatter.

## Changes
- Add `.claude/CLAUDE.md` with all project rules (13 sections)
- Add `.claude/settings.json` with pre-approved tool permissions
- Add `.github/PULL_REQUEST_TEMPLATE.md` for standardized PRs
- Update `docs/branching.md` to reference PR template instead of duplicating it

## Testing
- [x] Manual testing performed
- [x] Verified CLAUDE.md is read correctly by Claude Code

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] No linting errors