### PR TITLE
chore: prepare release 0.3.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-02-02
+
 ### Added
 
 - **Win32 Configuration Validation** - Recipe validation now checks `win32` configuration fields for correct types and values, with typo detection suggesting similar field names (e.g., "Did you mean 'display_name'?")
@@ -78,7 +80,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/RogerCibrian/notapkgtool/releases/tag/0.1.0
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -11,19 +11,21 @@
 
 #### Option 1: pip (For Using NAPT)
 
-Best for users who just want to use the tool without extra tooling.
+Best for users who want to use the tool.
+
+> 💡 **Tip:** Install from a tagged release for stability. The main branch may contain breaking changes between releases.
 
 ```powershell
-# Clone repository
-git clone https://github.com/RogerCibrian/notapkgtool.git
-cd notapkgtool
+# Create a project directory
+mkdir napt-workspace
+cd napt-workspace
 
 # Create and activate virtual environment (recommended)
 python -m venv .venv
 .venv\Scripts\Activate.ps1  # On Linux/macOS: source .venv/bin/activate
 
-# Install
-pip install -e .
+# Install from a specific release
+pip install git+https://github.com/RogerCibrian/notapkgtool.git@0.3.0
 
 # Verify installation
 napt --version
@@ -31,7 +33,9 @@ napt --version
 
 #### Option 2: Poetry (For Development)
 
-Best for development and contributing to NAPT.
+Best for contributing to NAPT.
+
+> ℹ️ **Note:** Clones the main branch so you're working with the latest code.
 
 **Prerequisites:** Poetry must be installed. See [Poetry Installation Guide](https://python-poetry.org/docs/#installation)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notapkgtool"
-version = "0.2.0"
+version = "0.3.0"
 description = "NAPT - Not a Pkg Tool for Windows/Intune packaging with PSADT"
 authors = ["Roger Cibrian"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Prepares NAPT for version 0.3.0 release.

## Changes

- Bump version in pyproject.toml from 0.2.0 to 0.3.0
- Move changelog entries from [Unreleased] to [0.3.0]
- Update install instructions to use `pip install git+...@0.3.0` for users
- Add workspace directory creation step for pip installs
- Add note about main branch for development workflow

## Release Highlights

**Breaking Changes:**
- Non-MSI architecture now required (`win32.installed_check.architecture`)
- Uniform strategy naming (`http_static` → `url_download`, etc.)
- Simplified version types (`msi_product_version_from_file` → `msi`)
- Recipe format change (`apps:` → `app:`)

**New Features:**
- Win32 configuration validation with typo detection
- Detection script generation for Intune Win32 apps
- Requirements script generation for Intune Update apps
- Architecture-aware detection (explicit registry views)
- MSI display name override with wildcard support