### PR TITLE
chore: prepare release 0.3.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-02-03
+
+### Changed
+
+- **PyPI Package Name** - Package renamed from `notapkgtool` to `napt` for simpler installation (`pip install napt`)
+- **Automated PyPI Publishing** - Releases now automatically publish to PyPI via GitHub Actions using Trusted Publisher (OIDC)
+
 ## [0.3.0] - 2026-02-02
 
 ### Added
@@ -80,7 +87,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/RogerCibrian/notapkgtool/releases/tag/0.1.0

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -13,8 +13,6 @@
 
 Best for users who want to use the tool.
 
-> 💡 **Tip:** Install from a tagged release for stability. The main branch may contain breaking changes between releases.
-
 ```powershell
 # Create a project directory
 mkdir napt-workspace
@@ -24,8 +22,8 @@ cd napt-workspace
 python -m venv .venv
 .venv\Scripts\Activate.ps1  # On Linux/macOS: source .venv/bin/activate
 
-# Install from a specific release
-pip install git+https://github.com/RogerCibrian/notapkgtool.git@0.3.0
+# Install from PyPI
+pip install napt
 
 # Verify installation
 napt --version

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -157,8 +157,8 @@ This roadmap is a living document showing potential future directions for NAPT. 
 **Related**: TODO in `napt/build/packager.py` - discovered during testing
 
 #### Recipe Linting & Best Practices
-**Status**: 💡 Idea  
-**Complexity**: High (3-5 days)  
+**Status**: 💡 Idea
+**Complexity**: High (3-5 days)
 **Value**: Medium
 
 **Description**: Advanced recipe validation beyond syntax checking, including PSADT function validation, deprecation warnings, anti-pattern detection, and style guide enforcement.
@@ -171,6 +171,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 - Validates PSADT function names exist in v4
 - Warns on deprecated patterns or old v3 functions
 - Suggests improvements (e.g., use Uninstall-ADTApplication)
+- Warns about unknown fields at app level (e.g., deprecated `detection` vs `win32.installed_check`)
 
 ### Technical Enhancements
 

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.3.0"
+version = "0.3.1"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"

--- a/recipes/Git/git.yaml
+++ b/recipes/Git/git.yaml
@@ -10,8 +10,11 @@ app:
       asset_pattern: "Git-.*-64-bit\\.exe$"
       version_pattern: "v?([0-9.]+)\\.windows"
 
-  detection:
-    display_name: "Git"
+  win32:
+      installed_check:
+          display_name: "Git"
+          architecture: "x64"
+
   psadt:
       app_vars:
         AppName: "Git for Windows"


### PR DESCRIPTION
## Description
Prepares the 0.3.1 release for PyPI publishing.

## Motivation
Publish the renamed `napt` package to PyPI with automated release workflow.

## Changes
- Version bumped to 0.3.1 in pyproject.toml and napt/__init__.py
- Changelog updated with 0.3.1 entry
- Quick-start docs updated to use `pip install napt` from PyPI
- Git recipe updated to use `win32.installed_check` format
- Roadmap updated with validation improvement note

## Testing
How was this tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors