### PR TITLE
chore: prepare release 0.4.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-08
+
 ### Added
 
 - **`napt upload <recipe>`** - New command uploads `.intunewin` packages directly to Microsoft Intune via the Graph API. Authentication tries service principal (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`), then managed identity, then device code (requires `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` set and a TTY)
@@ -119,7 +121,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.1...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.1.0...0.2.0

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.3.1"
+version = "0.4.0"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

Prepares the 0.4.0 release.

## Motivation

Several significant features and breaking changes have accumulated since 0.3.1 and are ready to ship.

## Changes

- Version bumped to 0.4.0 in `pyproject.toml` and `napt/__init__.py`
- Changelog `[Unreleased]` promoted to `[0.4.0] - 2026-03-08` with fresh `[Unreleased]` section and updated comparison links

This release includes (from the three merged PRs):
- `napt upload` command for direct Intune deployment via Graph API
- `napt init` command to scaffold project structure
- `napt package --version VERSION` flag to target specific builds
- Code-based defaults — zero-config after `pip install napt`
- Configurable directory defaults for all pipeline commands
- **BREAKING:** `napt package` now takes `<recipe>` instead of `<build_dir>`
- **BREAKING:** Four-layer configuration system

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass (283 passed)
- [x] No linting errors