### PR TITLE
chore: add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalize all text files to LF on checkout
+* text=auto eol=lf
+
+# Python diff heuristic for better hunk headers
+*.py diff=python
+
+# PowerShell scripts keep CRLF
+*.ps1 text eol=crlf


### PR DESCRIPTION
## Description
Adds a `.gitattributes` file to enforce consistent line endings across the repo.

## Motivation
Mixed CRLF/LF line endings were causing diff display issues in the IDE. Files checked out on Windows were getting CRLF due to `core.autocrlf=true`, while others remained LF.

## Changes
- Add `* text=auto eol=lf` to normalize all text files to LF going forward
- Keep `.ps1` files as CRLF (Windows requirement)
- Add `*.py diff=python` for better hunk headers in diffs (shows function/class names)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

No functional code changes — line endings and diff settings only.

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors