### PR TITLE
test: Add unit tests for upload pipeline

### DIFF
--- a/tests/upload/conftest.py
+++ b/tests/upload/conftest.py
@@ -1,0 +1,105 @@
+"""Shared fixtures and helpers for upload tests."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from napt.upload.intunewin import (
+    DETECTION_XML_PATH,
+    ENCRYPTED_PAYLOAD_PATH,
+    IntunewinMetadata,
+)
+
+_DETECTION_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInfo>
+    <FileName>IntunePackage.intunewin</FileName>
+    <UnencryptedContentSize>12345</UnencryptedContentSize>
+    <EncryptionInfo>
+        <EncryptionKey>dGVzdGVuY3J5cHRpb25rZXk=</EncryptionKey>
+        <MacKey>dGVzdG1hY2tleQ==</MacKey>
+        <InitializationVector>dGVzdGl2</InitializationVector>
+        <Mac>dGVzdG1hYw==</Mac>
+        <ProfileIdentifier>ProfileVersion1</ProfileIdentifier>
+        <FileDigest>dGVzdGRpZ2VzdA==</FileDigest>
+        <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </EncryptionInfo>
+</ApplicationInfo>
+"""
+
+
+def make_intunewin_bytes(xml: str = _DETECTION_XML) -> bytes:
+    """Build a minimal valid .intunewin ZIP as bytes.
+
+    Args:
+        xml: Detection.xml content to embed. Defaults to valid XML with
+            all required fields.
+
+    Returns:
+        Raw bytes of a ZIP file with Detection.xml and a fake encrypted payload.
+
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(DETECTION_XML_PATH, xml)
+        zf.writestr(ENCRYPTED_PAYLOAD_PATH, b"fake-encrypted-payload")
+    return buf.getvalue()
+
+
+def make_package_dir(
+    tmp_path: Path,
+    app_id: str = "test-app",
+    version: str = "1.0.0",
+) -> Path:
+    """Create a minimal fake package directory for upload tests.
+
+    Args:
+        tmp_path: Base directory (typically pytest's tmp_path).
+        app_id: App identifier used in the directory path.
+        version: Version string used in the directory path.
+
+    Returns:
+        Path to the version directory (packages/{app_id}/{version}/).
+
+    """
+    pkg_dir = tmp_path / "packages" / app_id / version
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "Invoke-AppDeployToolkit.intunewin").write_bytes(make_intunewin_bytes())
+    (pkg_dir / "build-manifest.json").write_text(
+        json.dumps({"architecture": "x64"}), encoding="utf-8"
+    )
+    (pkg_dir / f"{app_id}-Detection.ps1").write_text("# detection", encoding="utf-8")
+    (pkg_dir / f"{app_id}-Requirements.ps1").write_text(
+        "# requirements", encoding="utf-8"
+    )
+    return pkg_dir
+
+
+@pytest.fixture
+def fake_intunewin(tmp_path: Path) -> Path:
+    """Write a minimal .intunewin file to tmp_path and return its path."""
+    path = tmp_path / "Invoke-AppDeployToolkit.intunewin"
+    path.write_bytes(make_intunewin_bytes())
+    return path
+
+
+@pytest.fixture
+def fake_metadata() -> IntunewinMetadata:
+    """Return a sample IntunewinMetadata for use in graph and manager tests."""
+    return IntunewinMetadata(
+        encrypted_file_name="IntunePackage.intunewin",
+        unencrypted_content_size=12345,
+        file_digest="dGVzdGRpZ2VzdA==",
+        file_digest_algorithm="SHA256",
+        encryption_key="dGVzdGVuY3J5cHRpb25rZXk=",
+        mac_key="dGVzdG1hY2tleQ==",
+        init_vector="dGVzdGl2",
+        mac="dGVzdG1hYw==",
+        profile_identifier="ProfileVersion1",
+        encrypted_file_size=22,
+    )

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -1,0 +1,37 @@
+"""Tests for napt.upload.auth."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from napt.exceptions import AuthError
+from napt.upload.auth import get_access_token
+
+
+def test_get_access_token_returns_token_on_phase1_success() -> None:
+    """Tests that get_access_token returns the token when Phase 1 succeeds."""
+    mock_token = MagicMock()
+    mock_token.token = "test-bearer-token"
+    mock_credential = MagicMock()
+    mock_credential.get_token.return_value = mock_token
+
+    with patch("napt.upload.auth.get_credential", return_value=mock_credential):
+        result = get_access_token()
+
+    assert result == "test-bearer-token"
+
+
+def test_get_access_token_raises_auth_error_when_all_fail_non_tty() -> None:
+    """Tests that AuthError is raised when Phase 1 fails and stdout is not a TTY."""
+    from azure.core.exceptions import ClientAuthenticationError
+
+    mock_credential = MagicMock()
+    mock_credential.get_token.side_effect = ClientAuthenticationError("no cred")
+
+    with patch("napt.upload.auth.get_credential", return_value=mock_credential):
+        with patch("napt.upload.auth.sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = False
+            with pytest.raises(AuthError):
+                get_access_token()

--- a/tests/upload/test_graph.py
+++ b/tests/upload/test_graph.py
@@ -1,0 +1,207 @@
+"""Tests for napt.upload.graph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests_mock as req_mock
+
+from napt.exceptions import ConfigError, NetworkError
+from napt.upload.graph import (
+    GRAPH_BASE,
+    commit_content_version,
+    commit_content_version_file,
+    create_content_version,
+    create_content_version_file,
+    create_win32_app,
+    upload_to_azure_blob,
+)
+
+TOKEN = "fake-token"
+APP_ID = "app-id-123"
+CV_ID = "cv-id-456"
+FILE_ID = "file-id-789"
+SAS_URI = "https://blob.example.com/test?sv=sig"
+
+_APPS_URL = f"{GRAPH_BASE}/deviceAppManagement/mobileApps"
+_CV_URL = (
+    f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{APP_ID}"
+    f"/microsoft.graph.win32LobApp/contentVersions"
+)
+_FILES_URL = f"{_CV_URL}/{CV_ID}/files"
+_FILE_POLL_URL = f"{_FILES_URL}/{FILE_ID}"
+_COMMIT_FILE_URL = f"{_FILE_POLL_URL}/commit"
+_APP_URL = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{APP_ID}"
+
+
+# --- create_win32_app ---
+
+
+def test_create_win32_app_returns_app_id() -> None:
+    """Tests that create_win32_app returns the app ID from the API response."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, json={"id": APP_ID}, status_code=201)
+        result = create_win32_app(TOKEN, {"displayName": "Test App"})
+
+    assert result == APP_ID
+
+
+def test_create_win32_app_400_raises_config_error() -> None:
+    """Tests that a 400 response raises ConfigError."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, json={"error": "bad request"}, status_code=400)
+        with pytest.raises(ConfigError):
+            create_win32_app(TOKEN, {})
+
+
+# --- create_content_version ---
+
+
+def test_create_content_version_returns_cv_id() -> None:
+    """Tests that create_content_version returns the content version ID."""
+    with req_mock.Mocker() as m:
+        m.post(_CV_URL, json={"id": CV_ID}, status_code=201)
+        result = create_content_version(TOKEN, APP_ID)
+
+    assert result == CV_ID
+
+
+def test_create_content_version_500_raises_network_error() -> None:
+    """Tests that a 500 response raises NetworkError."""
+    with req_mock.Mocker() as m:
+        m.post(_CV_URL, json={}, status_code=500)
+        with pytest.raises(NetworkError):
+            create_content_version(TOKEN, APP_ID)
+
+
+# --- create_content_version_file ---
+
+
+def test_create_content_version_file_returns_file_id_and_sas_uri(
+    fake_metadata,
+) -> None:
+    """Tests that create_content_version_file returns (file_id, sas_uri) after polling."""
+    with req_mock.Mocker() as m:
+        m.post(_FILES_URL, json={"id": FILE_ID}, status_code=201)
+        m.get(
+            _FILE_POLL_URL,
+            [
+                {
+                    "json": {"uploadState": "azureStorageUriRequestPending"},
+                    "status_code": 200,
+                },
+                {
+                    "json": {
+                        "uploadState": "azureStorageUriRequestSuccess",
+                        "azureStorageUri": SAS_URI,
+                    },
+                    "status_code": 200,
+                },
+            ],
+        )
+        with patch("napt.upload.graph.time.sleep"):
+            file_id, sas_uri = create_content_version_file(
+                TOKEN, APP_ID, CV_ID, fake_metadata
+            )
+
+    assert file_id == FILE_ID
+    assert sas_uri == SAS_URI
+
+
+def test_create_content_version_file_error_state_raises_network_error(
+    fake_metadata,
+) -> None:
+    """Tests that an error uploadState during polling raises NetworkError."""
+    with req_mock.Mocker() as m:
+        m.post(_FILES_URL, json={"id": FILE_ID}, status_code=201)
+        m.get(
+            _FILE_POLL_URL,
+            json={"uploadState": "azureStorageUriRequestError"},
+            status_code=200,
+        )
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError, match="error state"):
+                create_content_version_file(TOKEN, APP_ID, CV_ID, fake_metadata)
+
+
+# --- upload_to_azure_blob ---
+
+
+def test_upload_to_azure_blob_uploads_blocks_and_commits(tmp_path: Path) -> None:
+    """Tests that upload_to_azure_blob PUTs all blocks then commits the block list."""
+    payload = tmp_path / "IntunePackage.intunewin"
+    payload.write_bytes(b"fake payload data for block upload test")
+
+    with req_mock.Mocker() as m:
+        m.put(req_mock.ANY, status_code=201)
+        upload_to_azure_blob(SAS_URI, payload)
+
+    # At least one block PUT + one block list PUT
+    assert m.call_count >= 2
+
+
+def test_upload_to_azure_blob_block_failure_raises_network_error(
+    tmp_path: Path,
+) -> None:
+    """Tests that a failed block PUT raises NetworkError."""
+    payload = tmp_path / "payload.intunewin"
+    payload.write_bytes(b"data")
+
+    with req_mock.Mocker() as m:
+        m.put(req_mock.ANY, status_code=500)
+        with pytest.raises(NetworkError, match="block upload failed"):
+            upload_to_azure_blob(SAS_URI, payload)
+
+
+# --- commit_content_version_file ---
+
+
+def test_commit_content_version_file_polls_until_committed(fake_metadata) -> None:
+    """Tests that commit_content_version_file posts commit then polls for success."""
+    with req_mock.Mocker() as m:
+        m.post(_COMMIT_FILE_URL, json={}, status_code=200)
+        m.get(
+            _FILE_POLL_URL,
+            json={"uploadState": "commitFileSuccess"},
+            status_code=200,
+        )
+        with patch("napt.upload.graph.time.sleep"):
+            commit_content_version_file(TOKEN, APP_ID, CV_ID, FILE_ID, fake_metadata)
+
+
+def test_commit_content_version_file_error_state_raises_network_error(
+    fake_metadata,
+) -> None:
+    """Tests that a failed commit uploadState raises NetworkError."""
+    with req_mock.Mocker() as m:
+        m.post(_COMMIT_FILE_URL, json={}, status_code=200)
+        m.get(
+            _FILE_POLL_URL,
+            json={"uploadState": "commitFileFailed"},
+            status_code=200,
+        )
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError, match="error state"):
+                commit_content_version_file(
+                    TOKEN, APP_ID, CV_ID, FILE_ID, fake_metadata
+                )
+
+
+# --- commit_content_version ---
+
+
+def test_commit_content_version_patches_app() -> None:
+    """Tests that commit_content_version sends a PATCH to the app endpoint."""
+    with req_mock.Mocker() as m:
+        m.patch(_APP_URL, json={}, status_code=204)
+        commit_content_version(TOKEN, APP_ID, CV_ID)
+
+
+def test_commit_content_version_500_raises_network_error() -> None:
+    """Tests that a 500 from commit_content_version raises NetworkError."""
+    with req_mock.Mocker() as m:
+        m.patch(_APP_URL, json={}, status_code=500)
+        with pytest.raises(NetworkError):
+            commit_content_version(TOKEN, APP_ID, CV_ID)

--- a/tests/upload/test_intunewin.py
+++ b/tests/upload/test_intunewin.py
@@ -1,0 +1,76 @@
+"""Tests for napt.upload.intunewin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from napt.exceptions import PackagingError
+from napt.upload.intunewin import extract_encrypted_payload, parse_intunewin
+from tests.upload.conftest import _DETECTION_XML, make_intunewin_bytes
+
+
+def test_parse_intunewin_returns_all_fields(fake_intunewin: Path) -> None:
+    """Tests that parse_intunewin extracts all metadata fields from Detection.xml."""
+    metadata = parse_intunewin(fake_intunewin)
+
+    assert metadata.encrypted_file_name == "IntunePackage.intunewin"
+    assert metadata.unencrypted_content_size == 12345
+    assert metadata.encryption_key == "dGVzdGVuY3J5cHRpb25rZXk="
+    assert metadata.mac_key == "dGVzdG1hY2tleQ=="
+    assert metadata.init_vector == "dGVzdGl2"
+    assert metadata.mac == "dGVzdG1hYw=="
+    assert metadata.profile_identifier == "ProfileVersion1"
+    assert metadata.file_digest == "dGVzdGRpZ2VzdA=="
+    assert metadata.file_digest_algorithm == "SHA256"
+    assert metadata.encrypted_file_size > 0
+
+
+def test_parse_intunewin_not_a_zip_raises_packaging_error(tmp_path: Path) -> None:
+    """Tests that a non-ZIP file raises PackagingError."""
+    bad = tmp_path / "bad.intunewin"
+    bad.write_bytes(b"not a zip file")
+
+    with pytest.raises(PackagingError, match="invalid ZIP archive"):
+        parse_intunewin(bad)
+
+
+def test_parse_intunewin_missing_encryption_key_raises_packaging_error(
+    tmp_path: Path,
+) -> None:
+    """Tests that a missing EncryptionKey field raises PackagingError."""
+    xml = _DETECTION_XML.replace(
+        "<EncryptionKey>dGVzdGVuY3J5cHRpb25rZXk=</EncryptionKey>", ""
+    )
+    path = tmp_path / "app.intunewin"
+    path.write_bytes(make_intunewin_bytes(xml))
+
+    with pytest.raises(PackagingError, match="EncryptionKey"):
+        parse_intunewin(path)
+
+
+def test_extract_encrypted_payload_returns_extracted_path(
+    fake_intunewin: Path, tmp_path: Path
+) -> None:
+    """Tests that extract_encrypted_payload extracts the payload and returns its path."""
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    result = extract_encrypted_payload(fake_intunewin, dest)
+
+    assert result.exists()
+    assert result.read_bytes() == b"fake-encrypted-payload"
+
+
+def test_extract_encrypted_payload_not_a_zip_raises_packaging_error(
+    tmp_path: Path,
+) -> None:
+    """Tests that a non-ZIP file raises PackagingError on extract."""
+    bad = tmp_path / "bad.intunewin"
+    bad.write_bytes(b"not a zip file")
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    with pytest.raises(PackagingError, match="invalid ZIP archive"):
+        extract_encrypted_payload(bad, dest)

--- a/tests/upload/test_manager.py
+++ b/tests/upload/test_manager.py
@@ -1,0 +1,91 @@
+"""Tests for napt.upload.manager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from napt.exceptions import NetworkError
+from napt.upload.manager import upload_package
+from tests.upload.conftest import make_package_dir
+
+
+def _fake_config(
+    app_id: str = "test-app", app_name: str = "Test App"
+) -> dict[str, Any]:
+    return {
+        "id": app_id,
+        "name": app_name,
+        "intune": {},
+    }
+
+
+def test_upload_package_returns_upload_result(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that upload_package orchestrates the full pipeline and returns UploadResult."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path)
+
+    recipe_path = tmp_path / "recipes" / "Vendor" / "test-app.yaml"
+    recipe_path.parent.mkdir(parents=True)
+    recipe_path.touch()
+
+    with (
+        patch(
+            "napt.upload.manager.load_effective_config",
+            return_value=_fake_config(),
+        ),
+        patch("napt.upload.manager.get_access_token", return_value="fake-token"),
+        patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch(
+            "napt.upload.manager.extract_encrypted_payload",
+            return_value=tmp_path / "payload",
+        ),
+        patch("napt.upload.manager.create_win32_app", return_value="intune-app-123"),
+        patch("napt.upload.manager.create_content_version", return_value="cv-1"),
+        patch(
+            "napt.upload.manager.create_content_version_file",
+            return_value=("file-1", "https://sas.example.com"),
+        ),
+        patch("napt.upload.manager.upload_to_azure_blob"),
+        patch("napt.upload.manager.commit_content_version_file"),
+        patch("napt.upload.manager.commit_content_version"),
+    ):
+        result = upload_package(recipe_path)
+
+    assert result.intune_app_id == "intune-app-123"
+    assert result.app_id == "test-app"
+    assert result.app_name == "Test App"
+    assert result.version == "1.0.0"
+    assert result.status == "success"
+
+
+def test_upload_package_propagates_network_error(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that a NetworkError from the Graph API propagates out of upload_package."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path)
+
+    recipe_path = tmp_path / "recipes" / "Vendor" / "test-app.yaml"
+    recipe_path.parent.mkdir(parents=True)
+    recipe_path.touch()
+
+    with (
+        patch(
+            "napt.upload.manager.load_effective_config",
+            return_value=_fake_config(),
+        ),
+        patch("napt.upload.manager.get_access_token", return_value="fake-token"),
+        patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch(
+            "napt.upload.manager.create_win32_app",
+            side_effect=NetworkError("Graph API down"),
+        ),
+    ):
+        with pytest.raises(NetworkError, match="Graph API down"):
+            upload_package(recipe_path)


### PR DESCRIPTION
## Description

Adds unit tests for the four previously untested upload modules: `auth`, `graph`, `intunewin`, and `manager`.

## Motivation

The upload pipeline had no test coverage. These tests establish a baseline before adding more upload features.

## Changes

- Add `tests/upload/conftest.py` with shared helpers (`make_intunewin_bytes`, `make_package_dir`) and fixtures (`fake_intunewin`, `fake_metadata`)
- Add `tests/upload/test_intunewin.py` — parse and extract tests using real in-memory ZIP files, no mocking
- Add `tests/upload/test_auth.py` — token acquisition and auth failure paths, `azure.identity` mocked
- Add `tests/upload/test_graph.py` — all six Graph API / Azure Blob functions tested with `requests-mock`, including polling loop behavior
- Add `tests/upload/test_manager.py` — orchestrator happy path and error propagation, mocked at function boundaries

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

21 tests, all passing. `requests-mock` for HTTP; `unittest.mock.patch` for azure.identity and graph function boundaries. Manager tests use `monkeypatch.chdir` with a real fake package directory on disk.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated
- [x] Tests pass
- [x] No linting errors