### PR TITLE
feat: Add IntuneWinAppUtil.exe version pinning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`intunewin.release` config key** - Pin `IntuneWinAppUtil.exe` to a specific
+    release for reproducible builds (e.g., `release: "1.8.6"`). Defaults to
+    `"latest"`, which resolves the current release via GitHub API. Each version
+    is cached independently under `cache/tools/{version}/`
 - **`logging:` top-level section** - New optional section for per-recipe logging
     configuration. Supports `log_format` (`cmtrace`, `text`), `log_level`
     (`verbose`, `debug`), and `log_rotation_mb`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -156,7 +156,10 @@ recipe's app:
     - `Files/` directory
     - `Invoke-AppDeployToolkit.ps1` script
     - `Invoke-AppDeployToolkit.exe` launcher
-3. **Get IntuneWinAppUtil** - Downloads/caches `IntuneWinAppUtil.exe` from Microsoft's GitHub repository if not already cached
+3. **Get IntuneWinAppUtil** - Downloads/caches `IntuneWinAppUtil.exe` from Microsoft's GitHub
+   repository. The release is controlled by `intunewin.release` in `defaults/org.yaml`
+   (default: `"latest"`). The tool is cached under `cache/tools/{version}/` so each
+   pinned release is stored independently
 4. **Create Package** - Runs `IntuneWinAppUtil.exe` to create `.intunewin` file:
     - Input: `packagefiles/` subdirectory of the build (PSADT structure)
     - Output: `Invoke-AppDeployToolkit.intunewin` in `packages/{app_id}/{version}/`
@@ -600,6 +603,28 @@ napt discover recipes/Google/chrome.yaml
 # Overrides for this run only
 napt discover recipes/Google/chrome.yaml --output-dir /tmp/downloads
 napt build recipes/Google/chrome.yaml --downloads-dir /tmp/downloads
+```
+
+### IntuneWinAppUtil Release Pinning
+
+By default NAPT always resolves `"latest"` for `IntuneWinAppUtil.exe` by querying
+the GitHub releases API and caching the resolved version.
+To pin to a specific release for reproducible builds, set `intunewin.release` in
+`defaults/org.yaml`:
+
+```yaml
+intunewin:
+  release: "1.8.6"   # pin to a specific release
+```
+
+The tool is cached under `cache/tools/{version}/` — each pinned release lives in
+its own subdirectory, so switching versions just downloads once and caches both.
+
+Use `"latest"` to always resolve the current release:
+
+```yaml
+intunewin:
+  release: "latest"  # default; resolves via GitHub API on each run if not cached
 ```
 
 ## Cross-Platform Support

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -522,6 +522,7 @@ recipe.yaml                         <- recipe-specific overrides
 - Config files only override what you need to change
 - Missing fields always fall back to code defaults
 - Old configs never break when NAPT adds new features
+- Any setting can be overridden at any layer — org, vendor, or recipe
 
 ### The Three Override Layers
 
@@ -559,8 +560,9 @@ id: "napt-chrome"
 discovery:
   strategy: url_download
   url: "https://dl.google.com/..."
+psadt:
+  release: "4.1.7"   # overrides org default of "latest" for this recipe only
 # AppVendor will be "Google LLC" (from vendor defaults)
-# psadt.release will be "latest" (from org defaults)
 ```
 
 ### Directory Flag Defaults

--- a/napt/build/packager.py
+++ b/napt/build/packager.py
@@ -49,17 +49,71 @@ import requests
 from napt.exceptions import ConfigError, NetworkError, PackagingError
 from napt.results import PackageResult
 
-# TODO: Add version tracking for IntuneWinAppUtil.exe
-# Currently downloads from master branch (always latest), with no version tracking.
-# Future enhancements:
-#   - Track tool version in cache metadata
-#   - Allow pinning to specific commit/release
-#   - Auto-detect when tool updates are available
-#   - Optional: Add config setting for tool version/source
-INTUNEWIN_TOOL_URL = (
-    "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool"
-    "/raw/master/IntuneWinAppUtil.exe"
+INTUNEWIN_REPO = "microsoft/Microsoft-Win32-Content-Prep-Tool"
+INTUNEWIN_GITHUB_API = (
+    f"https://api.github.com/repos/{INTUNEWIN_REPO}/releases/latest"
 )
+INTUNEWIN_DOWNLOAD_URL = (
+    f"https://github.com/{INTUNEWIN_REPO}/raw/{{tag}}/IntuneWinAppUtil.exe"
+)
+
+
+def fetch_latest_intunewin_version() -> str:
+    """Fetch the latest IntuneWinAppUtil.exe release version from GitHub.
+
+    Queries the GitHub API for the latest release and extracts the version
+    number from the tag name (e.g., "1.8.6" from tag "v1.8.6").
+
+    Returns:
+        Version number without "v" prefix (e.g., "1.8.6").
+
+    Raises:
+        NetworkError: If the GitHub API request fails or the version cannot
+            be extracted from the response.
+
+    Example:
+        Get latest IntuneWinAppUtil version from GitHub:
+            ```python
+            version = fetch_latest_intunewin_version()
+            print(version)  # Output: "1.8.6"
+            ```
+
+    Note:
+        Uses GitHub's public API (60 requests/hour limit without auth).
+        Set GITHUB_TOKEN environment variable for higher rate limits.
+    """
+    import os
+    import re
+
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    logger.verbose("PACKAGE", f"Querying GitHub API: {INTUNEWIN_GITHUB_API}")
+
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = requests.get(INTUNEWIN_GITHUB_API, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as err:
+        raise NetworkError(
+            f"Failed to fetch latest IntuneWinAppUtil version: {err}"
+        ) from err
+
+    tag = data.get("tag_name", "")
+    match = re.match(r"v?(\d+(?:\.\d+)+)", tag)
+    if not match:
+        raise NetworkError(
+            f"Could not extract version from IntuneWinAppUtil release tag: {tag!r}"
+        )
+
+    version = match.group(1)
+    logger.verbose("PACKAGE", f"Latest IntuneWinAppUtil release: {version}")
+    return version
 
 
 def _verify_build_structure(build_dir: Path) -> None:
@@ -90,41 +144,68 @@ def _verify_build_structure(build_dir: Path) -> None:
         )
 
 
-def _get_intunewin_tool(cache_dir: Path) -> Path:
-    """Download and cache IntuneWinAppUtil.exe.
+def _get_intunewin_tool(cache_dir: Path, release: str) -> Path:
+    """Download and cache IntuneWinAppUtil.exe for a specific release.
+
+    Resolves "latest" to the current release via the GitHub API, then
+    downloads and caches the tool under a versioned subdirectory.
 
     Args:
-        cache_dir: Directory to cache the tool.
+        cache_dir: Base directory for caching tool releases.
+        release: Release specifier — either "latest" or a specific version
+            (e.g., "1.8.6" or "v1.8.6").
 
     Returns:
-        Path to the IntuneWinAppUtil.exe tool.
+        Path to the cached IntuneWinAppUtil.exe.
 
     Raises:
-        NetworkError: If download fails.
+        NetworkError: If the GitHub API query or download fails.
     """
     from napt.logging import get_global_logger
 
     logger = get_global_logger()
-    tool_path = cache_dir / "IntuneWinAppUtil.exe"
+
+    if release == "latest":
+        logger.verbose("PACKAGE", "Resolving 'latest' IntuneWinAppUtil release...")
+        version = fetch_latest_intunewin_version()
+    else:
+        version = release.lstrip("v")
+
+    tool_path = cache_dir / version / "IntuneWinAppUtil.exe"
 
     if tool_path.exists():
-        logger.verbose("PACKAGE", f"Using cached IntuneWinAppUtil: {tool_path}")
+        logger.info("PACKAGE", f"Using cached IntuneWinAppUtil.exe {version}")
         return tool_path
 
-    logger.verbose("PACKAGE", "Downloading IntuneWinAppUtil.exe...")
+    logger.info("PACKAGE", f"Downloading IntuneWinAppUtil.exe {version}...")
 
-    # Download the tool
-    try:
-        response = requests.get(INTUNEWIN_TOOL_URL, timeout=60)
-        response.raise_for_status()
-    except requests.RequestException as err:
-        raise NetworkError(f"Failed to download IntuneWinAppUtil.exe: {err}") from err
+    # The repo uses inconsistent tag formats (e.g. "v1.8.6" and "1.8.3"),
+    # so try both and use whichever resolves.
+    response = None
+    for tag in [f"v{version}", version]:
+        url = INTUNEWIN_DOWNLOAD_URL.format(tag=tag)
+        try:
+            r = requests.get(url, timeout=60)
+            if r.status_code == 404:
+                continue
+            r.raise_for_status()
+            response = r
+            break
+        except requests.RequestException as err:
+            raise NetworkError(
+                f"Failed to download IntuneWinAppUtil.exe {version}: {err}"
+            ) from err
 
-    # Save to cache
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    if response is None:
+        raise NetworkError(
+            f"IntuneWinAppUtil.exe {version} not found "
+            f"(tried tags v{version} and {version})"
+        )
+
+    tool_path.parent.mkdir(parents=True, exist_ok=True)
     tool_path.write_bytes(response.content)
 
-    logger.verbose("PACKAGE", f"[OK] IntuneWinAppUtil.exe cached: {tool_path}")
+    logger.info("PACKAGE", f"IntuneWinAppUtil.exe {version} cached successfully")
 
     return tool_path
 
@@ -211,6 +292,7 @@ def create_intunewin(
     build_dir: Path,
     output_dir: Path | None = None,
     clean_source: bool = False,
+    tool_release: str = "latest",
 ) -> PackageResult:
     """Create a .intunewin package from a PSADT build version directory.
 
@@ -233,6 +315,8 @@ def create_intunewin(
             in org.yaml).
         clean_source: If True, remove the build version directory
             after packaging. Default is False.
+        tool_release: IntuneWinAppUtil.exe release to use — "latest" or a
+            specific version (e.g., "1.8.6"). Default is "latest".
 
     Returns:
         Package metadata including .intunewin path, app ID, and version.
@@ -304,7 +388,7 @@ def create_intunewin(
     # Get IntuneWinAppUtil tool
     logger.step(2, 5, "Getting IntuneWinAppUtil tool...")
     tool_cache = Path("cache/tools")
-    tool_path = _get_intunewin_tool(tool_cache)
+    tool_path = _get_intunewin_tool(tool_cache, tool_release)
 
     # Create .intunewin package
     logger.step(3, 5, "Creating .intunewin package...")

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -437,11 +437,14 @@ def cmd_package(args: argparse.Namespace) -> int:
         print(f"Error: {err}")
         return 1
 
-    if args.output_dir:
-        output_dir = Path(args.output_dir)
-    else:
-        config = load_effective_config(recipe_path)
-        output_dir = Path(config["directories"]["package"])
+    config = load_effective_config(recipe_path)
+
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else Path(config["directories"]["package"])
+    )
+    tool_release = config.get("intunewin", {}).get("release", "latest")
 
     print(f"Creating .intunewin package from: {build_dir}")
     print(f"Output directory: {output_dir}")
@@ -452,6 +455,7 @@ def cmd_package(args: argparse.Namespace) -> int:
             build_dir,
             output_dir=output_dir,
             clean_source=args.clean_source,
+            tool_release=tool_release,
         )
     except (ConfigError, NetworkError, PackagingError) as err:
         print(f"Error: {err}")

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -99,6 +99,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "log_level": "INFO",
         "log_rotation_mb": 3,
     },
+    # IntuneWinAppUtil.exe version pinning.
+    # Controls which release of Microsoft's packaging tool is downloaded and cached.
+    "intunewin": {
+        "release": "latest",
+    },
 }
 
 
@@ -183,4 +188,8 @@ apiVersion: napt/v1
 #   discover: "downloads"
 #   build: "builds"
 #   package: "packages"
+
+# intunewin:
+#   # IntuneWinAppUtil.exe release: "latest" or specific version (e.g., "v1.8.6.0")
+#   release: "latest"
 """

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -190,6 +190,6 @@ apiVersion: napt/v1
 #   package: "packages"
 
 # intunewin:
-#   # IntuneWinAppUtil.exe release: "latest" or specific version (e.g., "v1.8.6.0")
+#   # IntuneWinAppUtil.exe release: "latest" or specific version (e.g., "1.8.6")
 #   release: "latest"
 """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -310,6 +310,7 @@ id: test-app
             ("intune", "build_types"),
             ("intune", "detection"),
             ("logging", "log_format"),
+            ("intunewin", "release"),
         ]
 
         for parent, key in nested_checks:

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -18,10 +18,13 @@ from unittest.mock import patch
 import pytest
 
 from napt.build.packager import (
+    INTUNEWIN_GITHUB_API,
+    _get_intunewin_tool,
     _verify_build_structure,
     create_intunewin,
+    fetch_latest_intunewin_version,
 )
-from napt.exceptions import ConfigError, PackagingError
+from napt.exceptions import ConfigError, NetworkError, PackagingError
 
 # All tests in this file are unit tests (fast, mocked)
 
@@ -57,6 +60,141 @@ def _make_build_dir(
     if requirements:
         (version_dir / f"{app_id}-Requirements.ps1").write_text("requirements script")
     return version_dir
+
+
+_DOWNLOAD_URL_PREFIX = (
+    "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw"
+)
+
+
+class TestFetchLatestIntunewinVersion:
+    """Tests for fetching latest IntuneWinAppUtil version from GitHub."""
+
+    def test_fetch_latest_success_bare_tag(self, requests_mock):
+        """Tests version extraction when tag has no v prefix."""
+        requests_mock.get(INTUNEWIN_GITHUB_API, json={"tag_name": "1.8.6"})
+
+        assert fetch_latest_intunewin_version() == "1.8.6"
+
+    def test_fetch_latest_success_v_prefix(self, requests_mock):
+        """Tests that v prefix is stripped from tag name."""
+        requests_mock.get(INTUNEWIN_GITHUB_API, json={"tag_name": "v1.8.6"})
+
+        assert fetch_latest_intunewin_version() == "1.8.6"
+
+    def test_fetch_latest_api_error(self, requests_mock):
+        """Tests NetworkError on GitHub API failure."""
+        requests_mock.get(INTUNEWIN_GITHUB_API, status_code=500)
+
+        with pytest.raises(NetworkError, match="Failed to fetch latest IntuneWinAppUtil"):
+            fetch_latest_intunewin_version()
+
+    def test_fetch_latest_invalid_tag(self, requests_mock):
+        """Tests NetworkError when tag name cannot be parsed."""
+        requests_mock.get(INTUNEWIN_GITHUB_API, json={"tag_name": "not-a-version"})
+
+        with pytest.raises(NetworkError, match="Could not extract version"):
+            fetch_latest_intunewin_version()
+
+
+class TestGetIntunewinTool:
+    """Tests for _get_intunewin_tool version resolution and caching."""
+
+    def test_cache_hit_returns_path(self, tmp_path):
+        """Tests that a cached tool is returned without downloading."""
+        cache_dir = tmp_path / "tools"
+        tool_path = cache_dir / "1.8.6" / "IntuneWinAppUtil.exe"
+        tool_path.parent.mkdir(parents=True)
+        tool_path.write_bytes(b"fake exe")
+
+        result = _get_intunewin_tool(cache_dir, "1.8.6")
+
+        assert result == tool_path
+
+    @patch("napt.build.packager.fetch_latest_intunewin_version")
+    def test_latest_resolves_via_api(self, mock_fetch, tmp_path, requests_mock):
+        """Tests that 'latest' calls fetch_latest_intunewin_version."""
+        mock_fetch.return_value = "1.8.6"
+        cache_dir = tmp_path / "tools"
+
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/v1.8.6/IntuneWinAppUtil.exe",
+            content=b"fake exe",
+        )
+
+        _get_intunewin_tool(cache_dir, "latest")
+
+        mock_fetch.assert_called_once()
+
+    def test_v_prefix_stripped_from_release(self, tmp_path, requests_mock):
+        """Tests that a user-specified v prefix is normalised."""
+        cache_dir = tmp_path / "tools"
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/v1.8.6/IntuneWinAppUtil.exe",
+            content=b"fake exe",
+        )
+
+        result = _get_intunewin_tool(cache_dir, "v1.8.6")
+
+        assert result == cache_dir / "1.8.6" / "IntuneWinAppUtil.exe"
+
+    def test_download_uses_v_prefix_tag_first(self, tmp_path, requests_mock):
+        """Tests that download tries v{version} before bare tag."""
+        cache_dir = tmp_path / "tools"
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/v1.8.6/IntuneWinAppUtil.exe",
+            content=b"fake exe",
+        )
+
+        result = _get_intunewin_tool(cache_dir, "1.8.6")
+
+        assert result.exists()
+        assert result == cache_dir / "1.8.6" / "IntuneWinAppUtil.exe"
+
+    def test_download_falls_back_to_bare_tag(self, tmp_path, requests_mock):
+        """Tests fallback to bare tag when v-prefixed tag 404s."""
+        cache_dir = tmp_path / "tools"
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/v1.8.3/IntuneWinAppUtil.exe",
+            status_code=404,
+        )
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/1.8.3/IntuneWinAppUtil.exe",
+            content=b"fake exe",
+        )
+
+        result = _get_intunewin_tool(cache_dir, "1.8.3")
+
+        assert result.exists()
+        assert result == cache_dir / "1.8.3" / "IntuneWinAppUtil.exe"
+
+    def test_both_tags_404_raises_network_error(self, tmp_path, requests_mock):
+        """Tests NetworkError when both tag formats return 404."""
+        cache_dir = tmp_path / "tools"
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/v9.9.9/IntuneWinAppUtil.exe",
+            status_code=404,
+        )
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/9.9.9/IntuneWinAppUtil.exe",
+            status_code=404,
+        )
+
+        with pytest.raises(NetworkError, match="not found"):
+            _get_intunewin_tool(cache_dir, "9.9.9")
+
+    def test_download_cached_on_disk(self, tmp_path, requests_mock):
+        """Tests downloaded tool is written to the versioned cache path."""
+        cache_dir = tmp_path / "tools"
+        requests_mock.get(
+            f"{_DOWNLOAD_URL_PREFIX}/v1.8.6/IntuneWinAppUtil.exe",
+            content=b"fake exe content",
+        )
+
+        result = _get_intunewin_tool(cache_dir, "1.8.6")
+
+        assert result.read_bytes() == b"fake exe content"
+        assert result.parent == cache_dir / "1.8.6"
 
 
 class TestVerifyBuildStructure:

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -273,3 +273,22 @@ class TestCreateIntunewin:
 
         assert not build_dir.exists()
         assert result.status == "success"
+
+    @patch("napt.build.packager._get_intunewin_tool")
+    @patch("napt.build.packager._execute_packaging")
+    def test_tool_release_forwarded_to_get_tool(
+        self, mock_execute, mock_get_tool, tmp_path
+    ):
+        """Tests that tool_release is forwarded to _get_intunewin_tool."""
+        build_dir = _make_build_dir(tmp_path)
+        packages_dir = tmp_path / "packages"
+
+        mock_get_tool.return_value = Path("tool/IntuneWinAppUtil.exe")
+        mock_execute.return_value = (
+            packages_dir / "test-app" / "1.0.0" / "Invoke-AppDeployToolkit.intunewin"
+        )
+
+        create_intunewin(build_dir, output_dir=packages_dir, tool_release="1.8.6")
+
+        _, call_release = mock_get_tool.call_args[0]
+        assert call_release == "1.8.6"


### PR DESCRIPTION
## Description

Adds `intunewin.release` config key to pin `IntuneWinAppUtil.exe` to a specific
release for reproducible builds. Previously the tool was always downloaded from
the `master` branch with no version tracking — a bad upstream release could
silently break packaging.

## Motivation

A bad upstream release of `IntuneWinAppUtil.exe` could silently break `napt package`
with no way to pin to a known-good version. This follows the same pattern already
used by `psadt.release`.

## Changes

- Add `intunewin.release` to `DEFAULT_CONFIG` and `ORG_YAML_TEMPLATE` (default: `"latest"`)
- Add `fetch_latest_intunewin_version()` — resolves `"latest"` via GitHub releases API
- Rewrite `_get_intunewin_tool()` with versioned caching under `cache/tools/{version}/`;
  handles the repo's inconsistent tag formats (`v1.8.6` and `1.8.3`) by trying both on download
- Add `tool_release` param to `create_intunewin()`; `napt package` reads the value from config
- Update `docs/user-guide.md` with `intunewin.release` config docs and clarification that
  any setting can be overridden at any config layer (org, vendor, or recipe)
- Update `docs/changelog.md`

## Testing

- Manually tested `1.7`, `1.8.3` (bare tag), and `1.8.6` (v-prefixed tag) — all resolve and
  cache correctly
- Added `TestFetchLatestIntunewinVersion` (4 tests): bare tag, v-prefix stripping, API error,
  invalid tag format
- Added `TestGetIntunewinTool` (7 tests): cache hit, `"latest"` resolution, v-prefix
  normalisation, v-prefix tag tried first, bare tag fallback, both tags 404, disk write
- Added `test_tool_release_forwarded_to_get_tool` to verify release value passes through
  `create_intunewin()`
- Updated `test_org_yaml_template_covers_all_sections` to cover the new `intunewin` section

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors