### PR TITLE
refactor: Move core.py to discovery/manager.py, wire versioning cache check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install mkdocs mkdocs-material 'mkdocstrings[python]'
+          pip install mkdocs mkdocs-material 'mkdocstrings[python]' ruff
 
       - name: Build and deploy documentation
         run: |

--- a/docs/api/build.md
+++ b/docs/api/build.md
@@ -1,8 +1,3 @@
-# build
+# manager
 
 ::: napt.build.manager
-
-::: napt.build.template
-
-::: napt.build.packager
-

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,4 +1,3 @@
-# core
+# discovery.manager
 
-::: napt.core
-
+::: napt.discovery.manager

--- a/docs/api/packager.md
+++ b/docs/api/packager.md
@@ -1,0 +1,3 @@
+# packager
+
+::: napt.build.packager

--- a/docs/api/template.md
+++ b/docs/api/template.md
@@ -1,0 +1,3 @@
+# template
+
+::: napt.build.template

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,6 +1,6 @@
 # versioning
 
-::: napt.versioning.keys
+::: napt.versioning.compare
 
 ::: napt.versioning.msi
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `directories.discover`, `directories.build`, and `directories.package`.
     Update `defaults/org.yaml` if you set these keys
 
+### Fixed
+
+- Version cache check now uses semantic comparison instead of string equality,
+    so versions with a `v` prefix (e.g., `v1.2.3` vs `1.2.3`) are correctly
+    recognized as matching and won't re-download unnecessarily
+
 ## [0.4.0] - 2026-03-08
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,22 +82,25 @@ nav:
   - Developer Reference:
     - Overview: api/index.md
     - cli: api/cli.md
-    - core: api/core.md
-    - detection: api/detection.md
-    - requirements: api/requirements.md
     - exceptions: api/exceptions.md
     - logging: api/logging.md
     - results: api/results.md
     - validation: api/validation.md
-    - Modules:
-      - build: api/build.md
-      - config: api/config.md
+    - build:
+      - manager: api/build.md
+      - template: api/template.md
+      - packager: api/packager.md
+      - detection: api/detection.md
+      - requirements: api/requirements.md
+    - config: api/config.md
+    - discovery:
       - discovery: api/discovery.md
-      - download: api/download.md
-      - upload: api/upload.md
-      - psadt: api/psadt.md
-      - state: api/state.md
-      - versioning: api/versioning.md
+      - manager: api/core.md
+    - download: api/download.md
+    - psadt: api/psadt.md
+    - state: api/state.md
+    - upload: api/upload.md
+    - versioning: api/versioning.md
   - About:
     - Changelog: changelog.md
     - Roadmap: roadmap.md

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -51,7 +51,7 @@ __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"
 
 # Re-export commonly used functions for convenience
 from napt.config import load_effective_config
-from napt.core import discover_recipe
+from napt.discovery.manager import discover_recipe
 from napt.download import download_file
 from napt.exceptions import (
     ConfigError,

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -19,7 +19,7 @@ packages from recipes and downloaded installers.
 
 Design Principles:
     - Filesystem is source of truth for version information
-    - Entire PSADT Template_v4 structure copied pristine
+    - Entire PSADT Template_v4 structure copied unmodified
     - Invoke-AppDeployToolkit.ps1 is generated from template (not copied)
     - Build directories are versioned: {app_id}/{version}/
     - Branding applied by replacing files in root Assets/ directory (v4 structure)
@@ -309,8 +309,8 @@ def _create_build_directory(base_dir: Path, app_id: str, version: str) -> Path:
     return packagefiles_dir
 
 
-def _copy_psadt_pristine(psadt_cache_dir: Path, build_dir: Path) -> None:
-    """Copy PSADT template files from cache to build directory (pristine, unmodified).
+def _copy_psadt_template(psadt_cache_dir: Path, build_dir: Path) -> None:
+    """Copy PSADT template files from cache to build directory without modification.
 
     Copies the entire v4 template structure including:
     - PSAppDeployToolkit/ (module)
@@ -778,7 +778,7 @@ def build_package(
     3. Extracts version from installer (filesystem is truth)
     4. Gets/downloads PSADT release
     5. Creates build directory structure
-    6. Copies PSADT files (pristine)
+    6. Copies PSADT files unmodified
     7. Generates Invoke-AppDeployToolkit.ps1 from template
     8. Copies installer to Files/
     9. Applies custom branding
@@ -821,7 +821,7 @@ def build_package(
         Requires installer to be downloaded first (run 'napt discover').
         Version extracted from installer file, not state cache.
         Overwrites existing build directory if it exists.
-        PSADT files are copied pristine from cache.
+        PSADT files are copied unmodified from cache.
         Invoke-AppDeployToolkit.ps1 is generated (not copied).
         Scripts are generated as siblings to the packagefiles directory
         (not included in .intunewin package - must be uploaded separately to Intune).
@@ -888,8 +888,8 @@ def build_package(
     logger.step(5, 8, "Creating build structure...")
     build_dir = _create_build_directory(output_dir, app_id, version)
 
-    # Copy PSADT files (pristine)
-    _copy_psadt_pristine(psadt_cache_dir, build_dir)
+    # Copy PSADT files
+    _copy_psadt_template(psadt_cache_dir, build_dir)
 
     # Generate Invoke-AppDeployToolkit.ps1
     from .template import generate_invoke_script

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -86,7 +86,7 @@ import sys
 from napt.build import build_package, create_intunewin
 from napt.config import load_effective_config
 from napt.config.defaults import ORG_YAML_TEMPLATE
-from napt.core import discover_recipe
+from napt.discovery.manager import discover_recipe
 from napt.exceptions import (
     AuthError,
     ConfigError,

--- a/napt/config/loader.py
+++ b/napt/config/loader.py
@@ -109,10 +109,6 @@ import yaml
 from napt.config.defaults import DEFAULT_CONFIG
 from napt.exceptions import ConfigError
 
-# -------------------------------
-# Data types
-# -------------------------------
-
 
 @dataclass(frozen=True)
 class LoadContext:
@@ -125,11 +121,6 @@ class LoadContext:
     vendor_name: str | None
     org_defaults_path: Path | None
     vendor_defaults_path: Path | None
-
-
-# -------------------------------
-# YAML helpers
-# -------------------------------
 
 
 def _load_yaml_file(p: Path) -> Any:
@@ -154,11 +145,6 @@ def _load_yaml_file(p: Path) -> Any:
     if data is None:
         raise ConfigError(f"YAML file is empty: {p}")
     return data
-
-
-# -------------------------------
-# Merge logic
-# -------------------------------
 
 
 def _deep_merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -187,11 +173,6 @@ def _deep_merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str
             # Replace lists and scalars entirely
             result[k] = v
     return result
-
-
-# -------------------------------
-# Defaults discovery
-# -------------------------------
 
 
 def _find_defaults_root(start_dir: Path) -> Path | None:
@@ -245,11 +226,6 @@ def _detect_vendor(recipe_path: Path, recipe_obj: dict[str, Any]) -> str | None:
     return parent_name or vendor_from_recipe
 
 
-# -------------------------------
-# Path resolution
-# -------------------------------
-
-
 def _resolve_known_paths(
     cfg: dict[str, Any], recipe_dir: Path, defaults_root: Path | None = None
 ) -> None:
@@ -283,11 +259,6 @@ def _resolve_known_paths(
         pass
 
 
-# -------------------------------
-# Dynamic injection
-# -------------------------------
-
-
 def _inject_dynamic_values(cfg: dict[str, Any]) -> None:
     """Injects dynamic fields that should be set at load/build time.
 
@@ -310,11 +281,6 @@ def _inject_dynamic_values(cfg: dict[str, Any]) -> None:
         logger.warning("CONFIG", f"Could not inject AppScriptDate: {err}")
 
 
-# -------------------------------
-# Verbose helpers
-# -------------------------------
-
-
 def _print_yaml_content(data: dict[str, Any], indent: int = 0) -> None:
     """Print YAML content in a readable format for debug mode."""
     import yaml
@@ -329,11 +295,6 @@ def _print_yaml_content(data: dict[str, Any], indent: int = 0) -> None:
     for line in yaml_str.split("\n"):
         if line.strip():  # Skip empty lines
             logger.debug("CONFIG", " " * indent + line)
-
-
-# -------------------------------
-# Public API
-# -------------------------------
 
 
 def load_effective_config(

--- a/napt/discovery/__init__.py
+++ b/napt/discovery/__init__.py
@@ -67,10 +67,10 @@ Example:
             }
         }
 
-        discovered, file_path, sha256 = strategy.discover_version(
+        version, source, file_path, sha256, headers = strategy.discover_version(
             app_config, Path("./downloads")
         )
-        print(f"Version: {discovered.version}")
+        print(f"Version: {version}")
 
 """
 
@@ -82,5 +82,6 @@ from . import (
     web_scrape,  # noqa: F401
 )
 from .base import DiscoveryStrategy, get_strategy
+from .manager import discover_recipe
 
-__all__ = ["DiscoveryStrategy", "get_strategy"]
+__all__ = ["DiscoveryStrategy", "discover_recipe", "get_strategy"]

--- a/napt/discovery/api_github.py
+++ b/napt/discovery/api_github.py
@@ -125,7 +125,7 @@ Example:
     From Python (using core orchestration):
         ```python
         from pathlib import Path
-        from napt.core import discover_recipe
+        from napt.discovery import discover_recipe
 
         # Automatically uses version-first optimization
         result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
@@ -149,8 +149,8 @@ from typing import Any
 
 import requests
 
-from napt.exceptions import ConfigError, NetworkError
 from napt.discovery.base import RemoteVersion
+from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy
 

--- a/napt/discovery/api_json.py
+++ b/napt/discovery/api_json.py
@@ -149,7 +149,7 @@ Example:
     From Python (using core orchestration):
         ```python
         from pathlib import Path
-        from napt.core import discover_recipe
+        from napt.discovery import discover_recipe
 
         # Automatically uses version-first optimization
         result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
@@ -175,8 +175,8 @@ from typing import Any
 from jsonpath_ng import parse as jsonpath_parse
 import requests
 
-from napt.exceptions import ConfigError, NetworkError
 from napt.discovery.base import RemoteVersion
+from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy
 

--- a/napt/discovery/base.py
+++ b/napt/discovery/base.py
@@ -75,10 +75,6 @@ from typing import Any, Protocol
 
 from napt.exceptions import ConfigError
 
-# ----------------------------
-# Discovery DTOs
-# ----------------------------
-
 
 @dataclass(frozen=True)
 class RemoteVersion:
@@ -89,9 +85,6 @@ class RemoteVersion:
     fetching the file first. This allows the core pipeline to skip the download
     entirely when the version is unchanged.
 
-    Contrast with DiscoveredVersion (napt.versioning), which is produced after
-    a file has been obtained and its version extracted locally.
-
     Attributes:
         version: Raw version string (e.g., "140.0.7339.128").
         download_url: URL to download the installer.
@@ -101,11 +94,6 @@ class RemoteVersion:
     version: str
     download_url: str
     source: str
-
-
-# -------------------------------
-# Strategy Protocol
-# -------------------------------
 
 
 class DiscoveryStrategy(Protocol):
@@ -175,10 +163,6 @@ class DiscoveryStrategy(Protocol):
         """
         ...
 
-
-# -------------------------------
-# Strategy Registry
-# -------------------------------
 
 _STRATEGY_REGISTRY: dict[str, type[DiscoveryStrategy]] = {}
 

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Core orchestration for NAPT.
+"""Discovery pipeline orchestration for NAPT.
 
-This module provides high-level orchestration functions that coordinate the
-complete workflow for recipe validation, package building, and deployment.
+This module provides high-level orchestration for the discovery workflow,
+coordinating config loading, strategy selection, version checking, downloading,
+and state management.
 
 Two-Path Architecture:
 
@@ -42,10 +43,10 @@ Design Principles:
 - Configuration is immutable once loaded
 
 Example:
-    Programmatic usage:
+    Basic version discovery:
         ```python
         from pathlib import Path
-        from napt.core import discover_recipe
+        from napt.discovery import discover_recipe
 
         result = discover_recipe(
             recipe_path=Path("recipes/Google/chrome.yaml"),
@@ -67,20 +68,21 @@ from pathlib import Path
 
 from napt import __version__
 from napt.config.loader import load_effective_config
-from napt.discovery import get_strategy
+from napt.discovery.base import get_strategy
 from napt.download import download_file
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import DiscoverResult
 from napt.state import load_state, save_state
+from napt.versioning import is_newer
 
 
 def derive_file_path_from_url(url: str, output_dir: Path, app_id: str) -> Path:
-    """Derive file path from URL using same logic as download_file.
+    """Derives the expected local file path for a download URL.
 
-    This function ensures version-first strategies can locate cached files
-    without downloading by following the same naming convention as the
-    download module (app-scoped subdirectory).
+    Ensures version-first strategies can locate cached files without
+    downloading by following the same naming convention as the download
+    module (app-scoped subdirectory).
 
     Args:
         url: Download URL.
@@ -232,12 +234,6 @@ def discover_recipe(
         raise ConfigError(f"No 'discovery.strategy' defined for app: {app_name}")
 
     # 4. Get the strategy implementation
-    # Import strategies to ensure they're registered
-    import napt.discovery.api_github  # noqa: F401
-    import napt.discovery.api_json  # noqa: F401
-    import napt.discovery.url_download  # noqa: F401
-    import napt.discovery.web_scrape  # noqa: F401
-
     strategy = get_strategy(strategy_name)
 
     # Get cache for this recipe from state
@@ -264,10 +260,10 @@ def discover_recipe(
         version_info = strategy.get_version_info(config)
         download_url = version_info.download_url  # Save for state file
 
-        logger.verbose("DISCOVERY", f"Version discovered: {version_info.version}")
+        logger.info("DISCOVERY", f"Version discovered: {version_info.version}")
 
         # Check if we can use cached file (version match + file exists)
-        if cache and cache.get("known_version") == version_info.version:
+        if not is_newer(version_info.version, cache.get("known_version") if cache else None):
             # Derive file path from URL using same logic as download_file
             file_path = derive_file_path_from_url(
                 version_info.download_url, output_dir, app_id

--- a/napt/discovery/url_download.py
+++ b/napt/discovery/url_download.py
@@ -97,7 +97,7 @@ Example:
 From Python (using core orchestration):
     ```python
     from pathlib import Path
-    from napt.core import discover_recipe
+    from napt.discovery import discover_recipe
 
     # Automatically uses ETag optimization
     result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))

--- a/napt/discovery/web_scrape.py
+++ b/napt/discovery/web_scrape.py
@@ -145,7 +145,7 @@ Example:
     From Python (using core orchestration):
         ```python
         from pathlib import Path
-        from napt.core import discover_recipe
+        from napt.discovery import discover_recipe
 
         # Automatically uses version-first optimization
         result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
@@ -172,8 +172,8 @@ from urllib.parse import urljoin
 from bs4 import BeautifulSoup
 import requests
 
-from napt.exceptions import ConfigError, NetworkError
 from napt.discovery.base import RemoteVersion
+from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy
 

--- a/napt/exceptions.py
+++ b/napt/exceptions.py
@@ -21,7 +21,7 @@ callers to catch all NAPT errors with a single except clause if needed.
 Example:
     Catching specific error types:
         ```python
-        from napt.core import discover_recipe
+        from napt.discovery import discover_recipe
         from napt.exceptions import ConfigError, NetworkError
 
         try:

--- a/napt/results.py
+++ b/napt/results.py
@@ -25,7 +25,7 @@ Example:
     Using result types:
         ```python
         from pathlib import Path
-        from napt.core import discover_recipe
+        from napt.discovery import discover_recipe
         from napt.results import DiscoverResult
 
         result: DiscoverResult = discover_recipe(

--- a/tests/build/test_manager.py
+++ b/tests/build/test_manager.py
@@ -21,7 +21,7 @@ import pytest
 from napt.build.manager import (
     _apply_branding,
     _copy_installer,
-    _copy_psadt_pristine,
+    _copy_psadt_template,
     _create_build_directory,
     _find_installer_file,
     _write_build_manifest,
@@ -156,7 +156,7 @@ class TestCopyPSADTPristine:
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(fake_psadt_template, build_dir)
+        _copy_psadt_template(fake_psadt_template, build_dir)
 
         # Verify v4 structure copied
         assert (build_dir / "PSAppDeployToolkit" / "PSAppDeployToolkit.psd1").exists()
@@ -175,7 +175,7 @@ class TestCopyPSADTPristine:
         from napt.exceptions import PackagingError
 
         with pytest.raises(PackagingError, match="PSADT.*not found"):
-            _copy_psadt_pristine(cache_dir, build_dir)
+            _copy_psadt_template(cache_dir, build_dir)
 
 
 class TestCopyInstaller:
@@ -207,7 +207,7 @@ class TestApplyBranding:
         # Create build with fake template
         build_dir = tmp_path / "build"
         build_dir.mkdir()
-        _copy_psadt_pristine(fake_psadt_template, build_dir)
+        _copy_psadt_template(fake_psadt_template, build_dir)
 
         brand_dir, config = fake_brand_pack
 

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -20,7 +20,7 @@ import pytest
 from napt.build.manager import (
     _apply_branding,
     _copy_installer,
-    _copy_psadt_pristine,
+    _copy_psadt_template,
 )
 
 
@@ -72,7 +72,7 @@ class TestCopyPSADTWithRealTemplate:
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         # Verify all root files copied
         assert (build_dir / "Invoke-AppDeployToolkit.exe").exists()
@@ -94,7 +94,7 @@ class TestCopyPSADTWithRealTemplate:
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         module_dir = build_dir / "PSAppDeployToolkit"
         assert (module_dir / "PSAppDeployToolkit.psd1").exists()
@@ -109,7 +109,7 @@ class TestCopyPSADTWithRealTemplate:
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         files_dir = build_dir / "Files"
         assert files_dir.exists()
@@ -128,7 +128,7 @@ class TestBrandingWithRealTemplate:
         build_dir.mkdir()
 
         # Copy real template
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         brand_dir, config = fake_brand_pack
 
@@ -153,7 +153,7 @@ class TestBrandingWithRealTemplate:
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
         brand_dir, config = fake_brand_pack
 
         _apply_branding(config, build_dir)
@@ -175,7 +175,7 @@ class TestInstallerCopyWithRealTemplate:
         build_dir.mkdir()
 
         # Copy real template
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         # Create fake installer
         installer = tmp_path / "app.msi"
@@ -196,7 +196,7 @@ class TestInstallerCopyWithRealTemplate:
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         files_dir = build_dir / "Files"
         assert files_dir.is_dir()

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 import pytest
 import requests_mock
 
-from napt.core import discover_recipe
+from napt.discovery.manager import discover_recipe
 from napt.exceptions import NetworkError
 from napt.versioning.msi import MSIMetadata
 

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -55,13 +55,13 @@ class TestBuildStructureValidation:
 
     def test_verify_valid_real_build(self, real_psadt_template: Path, tmp_path: Path):
         """Test validation passes for real PSADT build."""
-        from napt.build.manager import _copy_psadt_pristine
+        from napt.build.manager import _copy_psadt_template
 
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
         # Create real build structure
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         # Should not raise - real template has everything needed
         _verify_build_structure(build_dir)
@@ -70,12 +70,12 @@ class TestBuildStructureValidation:
         self, real_psadt_template: Path, tmp_path: Path
     ):
         """Test validation fails when Invoke-AppDeployToolkit.exe missing."""
-        from napt.build.manager import _copy_psadt_pristine
+        from napt.build.manager import _copy_psadt_template
 
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         # Remove the exe
         (build_dir / "Invoke-AppDeployToolkit.exe").unlink()
@@ -91,12 +91,12 @@ class TestBuildStructureValidation:
         """Test validation fails when PSAppDeployToolkit directory missing."""
         import shutil
 
-        from napt.build.manager import _copy_psadt_pristine
+        from napt.build.manager import _copy_psadt_template
 
         build_dir = tmp_path / "build"
         build_dir.mkdir()
 
-        _copy_psadt_pristine(real_psadt_template, build_dir)
+        _copy_psadt_template(real_psadt_template, build_dir)
 
         # Remove PSAppDeployToolkit module
         shutil.rmtree(build_dir / "PSAppDeployToolkit")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
-from napt.core import discover_recipe
+from napt.discovery.manager import discover_recipe
 from napt.exceptions import ConfigError
 
 
@@ -35,7 +35,7 @@ class TestDiscoverRecipe:
         recipe_path = create_yaml_file("recipe.yaml", recipe_data)
 
         # Mock the discovery strategy (url_download - file-first)
-        with patch("napt.core.get_strategy") as mock_get_strategy:
+        with patch("napt.discovery.manager.get_strategy") as mock_get_strategy:
             mock_strategy = mock_get_strategy.return_value
             # Ensure it doesn't have get_version_info (file-first strategy)
             del mock_strategy.get_version_info
@@ -156,11 +156,11 @@ class TestVersionFirstFastPath:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download.html", text=html_content)
 
-            with patch("napt.core.load_state") as mock_load_state:
+            with patch("napt.discovery.manager.load_state") as mock_load_state:
                 mock_load_state.return_value = state
 
-                with patch("napt.core.save_state"):
-                    with patch("napt.core.download_file") as mock_download:
+                with patch("napt.discovery.manager.save_state"):
+                    with patch("napt.discovery.manager.download_file") as mock_download:
                         result = discover_recipe(
                             recipe_path, tmp_test_dir, state_file=Path("state.json")
                         )
@@ -214,11 +214,11 @@ class TestVersionFirstFastPath:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download.html", text=html_content)
 
-            with patch("napt.core.load_state") as mock_load_state:
+            with patch("napt.discovery.manager.load_state") as mock_load_state:
                 mock_load_state.return_value = state
 
-                with patch("napt.core.save_state"):
-                    with patch("napt.core.download_file") as mock_download:
+                with patch("napt.discovery.manager.save_state"):
+                    with patch("napt.discovery.manager.download_file") as mock_download:
                         from napt.results import DownloadResult
 
                         mock_download.return_value = DownloadResult(
@@ -287,10 +287,10 @@ class TestVersionFirstFastPath:
                 headers={"Content-Length": str(len(fake_content))},
             )
 
-            with patch("napt.core.load_state") as mock_load_state:
+            with patch("napt.discovery.manager.load_state") as mock_load_state:
                 mock_load_state.return_value = state
 
-                with patch("napt.core.save_state"):
+                with patch("napt.discovery.manager.save_state"):
                     result = discover_recipe(
                         recipe_path, tmp_test_dir, state_file=Path("state.json")
                     )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -17,12 +17,11 @@ import requests_mock
 
 from napt.discovery.api_github import ApiGithubStrategy
 from napt.discovery.api_json import ApiJsonStrategy
-from napt.discovery.base import get_strategy, register_strategy
+from napt.discovery.base import RemoteVersion, get_strategy, register_strategy
 from napt.discovery.url_download import UrlDownloadStrategy
 from napt.discovery.web_scrape import WebScrapeStrategy
 from napt.exceptions import ConfigError, NetworkError
 from napt.versioning.msi import MSIMetadata
-from napt.discovery.base import RemoteVersion
 
 
 class TestStrategyRegistry:
@@ -50,7 +49,7 @@ class TestStrategyRegistry:
         class CustomStrategy:
             def discover_version(self, app_config, output_dir):
                 return (
-                    DiscoveredVersion(version="1.0.0", source="custom"),
+                    RemoteVersion(version="1.0.0", source="custom"),
                     Path("/fake/path"),
                     "fakehash",
                     {},  # HTTP headers


### PR DESCRIPTION
## Description

Reorganizes the discovery module and improves the version cache check logic.

## Motivation

`napt/core.py` was only ever used for discovery orchestration, so it belongs in the discovery package alongside `base.py`. The cache check was also using `==` string equality; This was meant to be temporary measure while I developed some of the other napt commands. Semantic versioning is now used instead.

## Changes

- Move `napt/core.py` -> `napt/discovery/manager.py` to match the `build/manager.py` and `upload/manager.py` conventions
- Use `is_newer()` for the cache version check instead of `==` equality; handles `v`-prefix normalization and `None` on first run correctly
- Upgrade "Version discovered" log from `verbose` to `info` so it appears on first run before any cache branch is entered
- Remove redundant explicit strategy imports inside `discover_recipe`; `napt/discovery/__init__.py` loads them at import time
- Remove all `# ---` section separator comments from `base.py`, `loader.py`, and `build/manager.py`
- Rename `_copy_psadt_pristine` -> `_copy_psadt_template`
- Restructure mkdocs nav to mirror folder layout; split `build.md` into per-module pages consistent with discovery
- Fix broken mkdocs references: `napt.versioning.keys` -> `napt.versioning.compare`, `napt.core` -> `napt.discovery.manager`
- Add `ruff` to docs workflow to silence mkdocstrings formatter warning

## Testing

- [ ] Unit tests updated (patch paths updated from `napt.core.*` to `napt.discovery.manager.*`)
- [ ] Integration tests updated and passing
- [ ] 390 tests pass, 0 failures