### PR TITLE
feat: Add MSIX install scope via run_as_account

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,10 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MSIX installer support** - NAPT now supports `.msix` installers as a third
     installer type alongside MSI and EXE. MSIX metadata (display name, version,
     architecture, package identity) is extracted from `AppxManifest.xml` inside
-    the package. Detection scripts use `Get-AppxPackage` for identity-based
-    matching instead of registry scanning. Install and uninstall commands are
-    auto-generated from manifest metadata (`Add-AppxPackage` / `Remove-AppxPackage`)
-    unless overridden with `psadt.override_msix_commands: true`
+    the package. Detection and requirements scripts query the AppX package
+    database; install and uninstall commands are auto-generated from manifest
+    metadata unless overridden with `psadt.override_msix_commands: true`
+- **MSIX install scope** - `intune.run_as_account` now controls which AppX
+    cmdlets are auto-generated for MSIX installers. `"system"` (default) uses
+    `Add-AppxProvisionedPackage` / `Remove-AppxProvisionedPackage` for
+    all-users provisioned installs. `"user"` uses `Add-AppxPackage` /
+    `Remove-AppxPackage` for per-user installs. Detection and requirements
+    scripts automatically query the correct store (`Get-AppxProvisionedPackage`
+    vs `Get-AppxPackage`) based on the same setting
+- **Scope-based `RequireAdmin` default** - `psadt.app_vars.RequireAdmin`
+    now defaults to `false` when `intune.run_as_account` is `"user"`.
+    PSADT errors if `RequireAdmin` is `true` but the process lacks admin
+    rights. Override explicitly in `psadt.app_vars` if your environment
+    grants local admin to users
 - **`psadt.override_msix_commands` config key** - When `true`, uses recipe
     `psadt.install` and `psadt.uninstall` instead of the auto-generated MSIX
     commands. Required when the default `Add-AppxPackage` / `Remove-AppxPackage`

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -287,9 +287,11 @@ discovery:
   download_url_path: "url"
 
 # No psadt.install or psadt.uninstall needed!
-# NAPT auto-generates from MSIX manifest:
-#   Install:   Add-AppxPackage -Path "$dirFiles\slack.msix"
-#   Uninstall: Get-AppxPackage -Name "com.tinyspeck.slackdesktop" | Remove-AppxPackage
+# NAPT auto-generates from MSIX manifest based on intune.run_as_account:
+#   system (default): Add-AppxProvisionedPackage -Online -PackagePath "..." -SkipLicense
+#                     Get-AppxProvisionedPackage -Online | Where-Object { ... } | Remove-AppxProvisionedPackage -Online
+#   user:             Add-AppxPackage -Path "$($adtSession.DirFiles)\slack.msix"
+#                     Get-AppxPackage -Name "com.tinyspeck.slackdesktop" | Remove-AppxPackage
 
 psadt:
   app_vars:
@@ -307,24 +309,38 @@ napt discover recipes/Slack/slack.yaml --verbose
 **What makes MSIX different:**
 
 - **No `psadt.install` / `psadt.uninstall` needed** - NAPT auto-generates
-  `Add-AppxPackage` and `Remove-AppxPackage` commands from the MSIX manifest
-- **No `intune.detection` needed** - Detection uses `Get-AppxPackage` with
-  the package identity name from the manifest (not registry scanning)
+  commands from the MSIX manifest based on `intune.run_as_account`
+- **No `intune.detection` needed** - Detection queries the AppX package
+  database by identity name (not registry scanning); the store queried
+  matches `intune.run_as_account`
 - **Architecture auto-detected** - Extracted from `ProcessorArchitecture` in
   the MSIX manifest
+- **`RequireAdmin` auto-defaulted** - Defaults to `false` for
+  `run_as_account: "user"` since per-user installs don't require elevation
+
+**Choosing install scope:**
+
+Use `intune.run_as_account` to control whether the install is provisioned for
+all users or installed for the current user only:
+
+```yaml
+intune:
+  run_as_account: "system"  # Default: provisioned (all users)
+  # run_as_account: "user"  # Per-user install
+```
 
 **Overriding auto-generated commands:**
 
-If the default commands are insufficient (e.g., provisioned installs needing
-license files), set `override_msix_commands: true`:
+Only needed for non-standard cases such as license files.
+Set `override_msix_commands: true`:
 
 ```yaml
 psadt:
   override_msix_commands: true
   install: |
-    Add-AppxProvisionedAppxPackage -Online -PackagePath "$dirFiles\app.msix" -LicensePath "$dirFiles\license.xml"
+    Add-AppxProvisionedPackage -Online -PackagePath "$($adtSession.DirFiles)\app.msix" -LicensePath "$($adtSession.DirFiles)\license.xml" -SkipLicense
   uninstall: |
-    Get-AppxProvisionedPackage -Online | Where-Object { $_.PackageName -like "Vendor.App*" } | Remove-AppxProvisionedPackage -Online
+    Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq "Vendor.App" } | Remove-AppxProvisionedPackage -Online
 ```
 
 ## Create a Recipe for a Fixed Download URL

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -359,10 +359,13 @@ When `true`, uses recipe `install` and `uninstall` scripts instead of the
 auto-generated MSIX commands.
 
 **MSIX auto-generation:** For MSIX installers, NAPT auto-generates install and
-uninstall commands from manifest metadata:
+uninstall commands from manifest metadata.
+The commands vary based on `intune.run_as_account`:
 
-- **Install:** `Add-AppxPackage -Path "$dirFiles\{filename}"`
-- **Uninstall:** `Get-AppxPackage -Name "{identity_name}" | Remove-AppxPackage`
+- **Install (`system`, default):** `Add-AppxProvisionedPackage -Online -PackagePath "$($adtSession.DirFiles)\{filename}" -SkipLicense`
+- **Uninstall (`system`, default):** `Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq "{identity_name}" } | Remove-AppxProvisionedPackage -Online`
+- **Install (`user`):** `Add-AppxPackage -Path "$($adtSession.DirFiles)\{filename}"`
+- **Uninstall (`user`):** `Get-AppxPackage -Name "{identity_name}" | Remove-AppxPackage`
 
 These commands are used unless `override_msix_commands: true` is set. If the
 recipe specifies `psadt.install` or `psadt.uninstall` without this flag, a
@@ -375,18 +378,17 @@ warning is logged and the recipe values are ignored.
 - `true` but neither `install` nor `uninstall` set: Error (nothing to override with)
 - Non-MSIX installers: Flag is ignored
 
-**When to use:** Apps that need license files (`Add-AppxProvisionedAppxPackage`),
-apps requiring custom provisioning, or uninstall logic that differs from the
-standard `Remove-AppxPackage` pipeline.
+**When to use:** Apps that require a license file during provisioning or uninstall
+logic that differs from the standard pipeline.
 
 **Example:**
 ```yaml
 psadt:
   override_msix_commands: true
   install: |
-    Add-AppxProvisionedAppxPackage -Online -PackagePath "$dirFiles\app.msix" -LicensePath "$dirFiles\license.xml"
+    Add-AppxProvisionedPackage -Online -PackagePath "$($adtSession.DirFiles)\app.msix" -LicensePath "$($adtSession.DirFiles)\license.xml" -SkipLicense
   uninstall: |
-    Get-AppxProvisionedPackage -Online | Where-Object { $_.PackageName -like "Vendor.App*" } | Remove-AppxProvisionedPackage -Online
+    Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq "Vendor.App" } | Remove-AppxProvisionedPackage -Online
 ```
 
 ### install
@@ -399,7 +401,7 @@ PowerShell script executed during installation. Inserted into the generated
 
 **Available Variables:**
 
-- `$dirFiles`: Path to installer files directory (contains downloaded installer)
+- `$($adtSession.DirFiles)`: Path to installer files directory (contains downloaded installer)
 - `$discovered_version`: Version discovered by NAPT
 - Standard PSADT variables: `$dirApp`, `$dirSupportFiles`, etc.
 - All `app_vars` are available (e.g., `$AppName`, `$AppVersion`)
@@ -558,6 +560,22 @@ Set to `false` to prevent self-service uninstall for this app.
 Execution account for the installer and detection/requirements scripts.
 Use `"system"` for most enterprise deployments.
 Use `"user"` for apps that must be installed in the user's profile context.
+
+**MSIX installers:** This field also controls which AppX cmdlets are
+auto-generated and which package store is queried by detection and
+requirements scripts:
+
+| Value | Install cmdlet | Detection |
+|-------|---------------|-----------|
+| `"system"` (default) | `Add-AppxProvisionedPackage` (all users) | `Get-AppxProvisionedPackage` |
+| `"user"` | `Add-AppxPackage` (current user) | `Get-AppxPackage` |
+
+**`RequireAdmin` default:** For user-context installs, NAPT defaults
+`psadt.app_vars.RequireAdmin` to `false`.
+PSADT will error if `RequireAdmin` is `true` but the process is not running
+as an administrator.
+If your environment grants local admin to users and you want PSADT to enforce
+it, set `RequireAdmin: true` explicitly in `psadt.app_vars`.
 
 ### device_restart_behavior
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,14 +42,14 @@ The build process creates a complete PSADT package from the recipe and downloade
     - `Invoke-AppDeployToolkit.ps1` - Template script (will be overwritten)
 7. **Generate Deployment Script** - Generates `Invoke-AppDeployToolkit.ps1` from template:
     - Substitutes PSADT variables (`$appVendor`, `$appName`, `$appVersion`, etc.) from recipe configuration
-    - Inserts install script from `psadt.install` field (for MSIX, auto-generates `Add-AppxPackage` / `Remove-AppxPackage` commands from manifest unless `override_msix_commands: true`)
+    - Inserts install script from `psadt.install` field (for MSIX, auto-generates install/uninstall commands from manifest based on `intune.run_as_account` unless `override_msix_commands: true`)
     - Inserts uninstall script from `psadt.uninstall` field
     - Sets dynamic values (AppScriptDate, discovered version, PSADT version)
     - Preserves PSADT's structure and comments
 8. **Copy Installer** - Copies downloaded installer file to `Files/` directory:
     - Source: `downloads/{installer_filename}`
     - Destination: `builds/{app_id}/{version}/Files/{installer_filename}`
-    - Installer is accessible in scripts via `$dirFiles` variable
+    - Installer is accessible in scripts via `$($adtSession.DirFiles)` (PSADT 4.x)
 9. **Apply Branding** - Replaces PSADT default assets with custom branding (if configured):
     - Reads `brand_pack` configuration from org/vendor defaults
     - Replaces files in `Assets/` directory (AppIcon.png, Banner.Classic.png, etc.)
@@ -67,8 +67,9 @@ NAPT generates PowerShell scripts used by Intune Win32 app entries to check inst
 
 For MSI and EXE installers, both scripts share the same logic for registry lookup, app name
 resolution, and installer-type filtering; they differ only in how they interpret the version
-comparison (see below). For MSIX installers, scripts use `Get-AppxPackage` for identity-based
-matching instead of registry scanning.
+comparison (see below). For MSIX installers, scripts query the AppX package database by
+identity name instead of registry scanning; which store is queried depends on
+`intune.run_as_account` (see below).
 
 **How the scripts work:**
 
@@ -105,9 +106,11 @@ matching instead of registry scanning.
     - Prevents false matches when both 32-bit and 64-bit versions of the same software are installed
 
 - **MSIX detection (AppX package-based):**
-    - MSIX installers use a completely different detection mechanism: `Get-AppxPackage` queries
-      the Windows AppX package database by package identity name (from `AppxManifest.xml`)
-    - No registry scanning or `DisplayName` matching is used for MSIX
+    - MSIX installers query the Windows AppX package database by package identity name
+      (from `AppxManifest.xml`), not the registry
+    - Which store is queried depends on `intune.run_as_account`:
+        - `"system"` (default): `Get-AppxProvisionedPackage -Online` (provisioned/all-users store)
+        - `"user"`: `Get-AppxPackage -Name` (per-user store)
     - Architecture is auto-detected from the MSIX manifest's `ProcessorArchitecture` attribute
     - The `intune.detection.display_name`, `architecture`, and `override_msi_display_name`
       fields are not used for MSIX installers
@@ -443,7 +446,7 @@ intune:                # Optional: Intune-specific settings
 - **Top-level fields:** `apiVersion` (required), `name` (required), `id` (required),
   `discovery` (required), `psadt` (required), `intune` (optional), `logging` (optional)
 - **Discovery strategies:** See [Discovery Strategies](#discovery-strategies) section above for strategy selection and examples
-- **PSADT scripts:** Use `${discovered_version}` for auto-substituted version, `$dirFiles` for installer path
+- **PSADT scripts:** Use `${discovered_version}` for auto-substituted version, `$($adtSession.DirFiles)` for installer path (PSADT 4.x)
 
 ### Complete Documentation
 

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -679,6 +679,7 @@ def _generate_detection_script(
 
     if installer_ext == ".msix":
         assert msix_metadata is not None
+        run_as_account = config.get("intune", {}).get("run_as_account", "system")
         detection_config = MSIXDetectionConfig(
             identity_name=msix_metadata.identity_name,
             app_name=app_name,
@@ -688,6 +689,7 @@ def _generate_detection_script(
             log_rotation_mb=logging_settings.get("log_rotation_mb", 3),
             exact_match=detection_settings.get("exact_match", False),
             app_id=app_id,
+            install_scope=run_as_account,
         )
         generate_msix_detection_script(detection_config, detection_script_path)
     else:
@@ -772,6 +774,7 @@ def _generate_requirements_script(
 
     if installer_ext == ".msix":
         assert msix_metadata is not None
+        run_as_account = config.get("intune", {}).get("run_as_account", "system")
         requirements_config = MSIXRequirementsConfig(
             identity_name=msix_metadata.identity_name,
             app_name=app_name,
@@ -780,6 +783,7 @@ def _generate_requirements_script(
             log_level=logging_settings.get("log_level", "INFO"),
             log_rotation_mb=logging_settings.get("log_rotation_mb", 3),
             app_id=app_id,
+            install_scope=run_as_account,
         )
         generate_msix_requirements_script(
             requirements_config, requirements_script_path
@@ -882,10 +886,17 @@ def _apply_msix_commands(
 ) -> None:
     """Auto-generates MSIX install/uninstall commands or applies overrides.
 
-    For MSIX installers, generates ``Add-AppxPackage`` and
-    ``Remove-AppxPackage`` commands from manifest metadata. If the recipe
-    specifies ``psadt.install`` or ``psadt.uninstall``, those are ignored
-    unless ``psadt.override_msix_commands`` is set to true.
+    For MSIX installers, generates install/uninstall commands from manifest
+    metadata. The commands vary based on ``intune.run_as_account``:
+
+    - ``"system"`` (default): Uses ``Add-AppxProvisionedPackage`` for
+      all-users provisioned install and ``Remove-AppxProvisionedPackage``
+      for removal.
+    - ``"user"``: Uses ``Add-AppxPackage`` for per-user install and
+      ``Remove-AppxPackage`` for removal.
+
+    If the recipe specifies ``psadt.install`` or ``psadt.uninstall``, those
+    are ignored unless ``psadt.override_msix_commands`` is set to true.
 
     Args:
         config: Recipe configuration (mutated in place to inject
@@ -903,13 +914,26 @@ def _apply_msix_commands(
     recipe_install = psadt_config.get("install")
     recipe_uninstall = psadt_config.get("uninstall")
 
-    auto_install = (
-        f'Add-AppxPackage -Path "$dirFiles\\{installer_file.name}"'
-    )
-    auto_uninstall = (
-        f"Get-AppxPackage -Name "
-        f'"{msix_metadata.identity_name}" | Remove-AppxPackage'
-    )
+    run_as_account = config.get("intune", {}).get("run_as_account", "system")
+    if run_as_account == "user":
+        auto_install = (
+            f'Add-AppxPackage -Path "$($adtSession.DirFiles)\\{installer_file.name}"'
+        )
+        auto_uninstall = (
+            f'Get-AppxPackage -Name "{msix_metadata.identity_name}"'
+            f" | Remove-AppxPackage"
+        )
+    else:
+        auto_install = (
+            f"Add-AppxProvisionedPackage -Online"
+            f' -PackagePath "$($adtSession.DirFiles)\\{installer_file.name}"'
+            f" -SkipLicense"
+        )
+        auto_uninstall = (
+            f"Get-AppxProvisionedPackage -Online"
+            f' | Where-Object {{ $_.DisplayName -eq "{msix_metadata.identity_name}" }}'
+            f" | Remove-AppxProvisionedPackage -Online"
+        )
 
     if override_commands:
         if not recipe_install and not recipe_uninstall:
@@ -946,8 +970,8 @@ def _apply_msix_commands(
             "BUILD",
             "psadt.install is set but will be ignored for MSIX installers. "
             "MSIX manifest is used as the authoritative source for install "
-            "commands (Add-AppxPackage). Set override_msix_commands: true "
-            "to use psadt.install instead.",
+            "commands. Set override_msix_commands: true to use psadt.install "
+            "instead.",
         )
 
     if recipe_uninstall:
@@ -955,8 +979,8 @@ def _apply_msix_commands(
             "BUILD",
             "psadt.uninstall is set but will be ignored for MSIX installers. "
             "MSIX manifest is used as the authoritative source for uninstall "
-            "commands (Remove-AppxPackage). Set override_msix_commands: true "
-            "to use psadt.uninstall instead.",
+            "commands. Set override_msix_commands: true to use psadt.uninstall "
+            "instead.",
         )
 
     config["psadt"]["install"] = auto_install

--- a/napt/build/msix_scripts.py
+++ b/napt/build/msix_scripts.py
@@ -17,16 +17,33 @@
 This module generates PowerShell detection and requirements scripts for
 MSIX packages deployed as Intune Win32 apps. Unlike MSI/EXE installers
 that use registry-based detection, MSIX scripts query the AppX package
-database via ``Get-AppxPackage``.
+database. The query used depends on ``install_scope``:
+
+- ``"system"`` (default): Queries ``Get-AppxProvisionedPackage -Online``
+  for provisioned (all-users) packages.
+- ``"user"``: Queries ``Get-AppxPackage -Name <identity_name>`` for
+  per-user packages.
+
+For system-scope scripts, ``Version`` and ``Architecture`` are parsed from
+``PackageName`` (the package full name) rather than read from object
+properties. The package full name format is
+``Name_Version_Architecture_ResourceId_PublisherId``, where underscore is
+the structural delimiter. The MSIX spec
+(https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/package-identity-overview)
+explicitly prohibits underscores in all five components, so splitting on
+``_`` is safe by design. Reading ``Architecture`` directly from the object
+returns an integer enum value (e.g. ``11`` for neutral) that requires a
+separate mapping step; parsing from ``PackageName`` yields the canonical
+string form directly.
 
 Detection Logic:
-    - Queries ``Get-AppxPackage -Name <identity_name>`` for the package
+    - Queries the appropriate AppX store for the package identity
     - Compares installed version against expected version
     - Supports exact match or minimum version comparison
     - Exits 0 if detected, 1 if not detected
 
 Requirements Logic:
-    - Queries ``Get-AppxPackage -Name <identity_name>`` for the package
+    - Queries the appropriate AppX store for the package identity
     - If installed version < target version: outputs "Required"
     - Otherwise: outputs nothing
     - Always exits 0 so Intune can evaluate STDOUT
@@ -80,8 +97,8 @@ class MSIXDetectionConfig:
     """Configuration for MSIX detection script generation.
 
     Attributes:
-        identity_name: Package identity name for ``Get-AppxPackage``
-            query (e.g., "com.tinyspeck.slackdesktop").
+        identity_name: Package identity name for AppX package query
+            (e.g., "com.tinyspeck.slackdesktop").
         app_name: Human-readable application name for logging and
             component identification.
         version: Expected version string to match.
@@ -91,6 +108,8 @@ class MSIXDetectionConfig:
         exact_match: If True, version must match exactly. If False,
             minimum version comparison (installed >= expected).
         app_id: Application ID (used for fallback identification).
+        install_scope: Whether to query per-user (``"user"``) or
+            provisioned all-users (``"system"``) package store.
 
     """
 
@@ -102,6 +121,7 @@ class MSIXDetectionConfig:
     log_rotation_mb: int = 3
     exact_match: bool = False
     app_id: str = ""
+    install_scope: Literal["system", "user"] = "system"
 
 
 @dataclass(frozen=True)
@@ -109,8 +129,8 @@ class MSIXRequirementsConfig:
     """Configuration for MSIX requirements script generation.
 
     Attributes:
-        identity_name: Package identity name for ``Get-AppxPackage``
-            query (e.g., "com.tinyspeck.slackdesktop").
+        identity_name: Package identity name for AppX package query
+            (e.g., "com.tinyspeck.slackdesktop").
         app_name: Human-readable application name for logging and
             component identification.
         version: Target version string (requirement met if
@@ -119,6 +139,8 @@ class MSIXRequirementsConfig:
         log_level: Minimum log level (INFO, WARNING, ERROR, DEBUG).
         log_rotation_mb: Maximum log file size in MB before rotation.
         app_id: Application ID (used for fallback identification).
+        install_scope: Whether to query per-user (``"user"``) or
+            provisioned all-users (``"system"``) package store.
 
     """
 
@@ -129,6 +151,7 @@ class MSIXRequirementsConfig:
     log_level: LogLevel = "INFO"
     log_rotation_mb: int = 3
     app_id: str = ""
+    install_scope: Literal["system", "user"] = "system"
 
 
 def generate_msix_detection_script(
@@ -171,7 +194,11 @@ def generate_msix_detection_script(
             ```
 
     """
-    from napt.build._ps_templates import _load_ps_template, substitute_ps_template
+    from napt.build._ps_templates import (
+        _TEMPLATES_DIR,
+        _load_ps_template,
+        substitute_ps_template,
+    )
     from napt.logging import get_global_logger
 
     logger = get_global_logger()
@@ -180,7 +207,11 @@ def generate_msix_detection_script(
         "DETECTION", f"Generating MSIX detection script: {output_path.name}"
     )
 
+    helper_name = f"_msix_shared_{config.install_scope}.ps1"
+    helper_content = (_TEMPLATES_DIR / helper_name).read_text(encoding="utf-8")
+
     template = _load_ps_template("msix_detection_script.ps1")
+    template = template.replace("$NaptMsixSharedHelper", helper_content)
     script_content = substitute_ps_template(
         template,
         {
@@ -249,7 +280,11 @@ def generate_msix_requirements_script(
             ```
 
     """
-    from napt.build._ps_templates import _load_ps_template, substitute_ps_template
+    from napt.build._ps_templates import (
+        _TEMPLATES_DIR,
+        _load_ps_template,
+        substitute_ps_template,
+    )
     from napt.logging import get_global_logger
 
     logger = get_global_logger()
@@ -259,7 +294,11 @@ def generate_msix_requirements_script(
         f"Generating MSIX requirements script: {output_path.name}",
     )
 
+    helper_name = f"_msix_shared_{config.install_scope}.ps1"
+    helper_content = (_TEMPLATES_DIR / helper_name).read_text(encoding="utf-8")
+
     template = _load_ps_template("msix_requirements_script.ps1")
+    template = template.replace("$NaptMsixSharedHelper", helper_content)
     script_content = substitute_ps_template(
         template,
         {

--- a/napt/build/templates/_msix_shared_system.ps1
+++ b/napt/build/templates/_msix_shared_system.ps1
@@ -1,0 +1,29 @@
+# Retrieve a provisioned (all-users) AppX package by identity name.
+function Get-InstalledAppxPackage {
+    param(
+        [string]$PackageIdentityName
+    )
+
+    try {
+        $Provisioned = Get-AppxProvisionedPackage -Online -ErrorAction Stop |
+            Where-Object { $_.PackageName -like "$PackageIdentityName_*" } |
+            Sort-Object { [Version]($_.PackageName -split '_')[1] } -Descending |
+            Select-Object -First 1
+        if ($Provisioned) {
+            $Parts = $Provisioned.PackageName -split '_'
+            $Package = [PSCustomObject]@{
+                Name         = $Parts[0]
+                Version      = $Parts[1]
+                Architecture = $Parts[2]
+            }
+            Write-CMTraceLog -Message "[$NaptScriptType] Provisioned package found: $($Package.Name) (Version: $($Package.Version), Arch: $($Package.Architecture))" -Type "INFO"
+            return $Package
+        }
+
+        Write-CMTraceLog -Message "[$NaptScriptType] Provisioned package not found: $PackageIdentityName" -Type "INFO"
+        return $null
+    } catch {
+        Write-CMTraceLog -Message "[$NaptScriptType] Error querying provisioned package $PackageIdentityName : $($_.Exception.Message)" -Type "ERROR"
+        return $null
+    }
+}

--- a/napt/build/templates/_msix_shared_user.ps1
+++ b/napt/build/templates/_msix_shared_user.ps1
@@ -1,11 +1,13 @@
-# Retrieve installed AppX package by identity name
+# Retrieve a per-user installed AppX package by identity name.
 function Get-InstalledAppxPackage {
     param(
         [string]$PackageIdentityName
     )
 
     try {
-        $Package = Get-AppxPackage -Name $PackageIdentityName -ErrorAction Stop
+        $Package = Get-AppxPackage -Name $PackageIdentityName -ErrorAction Stop |
+            Sort-Object { [Version]$_.Version } -Descending |
+            Select-Object -First 1
         if ($Package) {
             Write-CMTraceLog -Message "[$NaptScriptType] Package found: $($Package.Name) (Version: $($Package.Version), Arch: $($Package.Architecture))" -Type "INFO"
             return $Package

--- a/napt/build/templates/msix_detection_script.ps1
+++ b/napt/build/templates/msix_detection_script.ps1
@@ -12,7 +12,7 @@ param(
 
 # <include _shared_functions.ps1>
 
-# <include _msix_shared.ps1>
+$NaptMsixSharedHelper
 
 # Version comparison function
 function Compare-Version {

--- a/napt/build/templates/msix_requirements_script.ps1
+++ b/napt/build/templates/msix_requirements_script.ps1
@@ -11,7 +11,7 @@ param(
 
 # <include _shared_functions.ps1>
 
-# <include _msix_shared.ps1>
+$NaptMsixSharedHelper
 
 # Version comparison function - returns true if Installed < Target
 function Compare-VersionLessThan {

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -67,7 +67,6 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "AppProcessesToClose": [],
             "AppScriptVersion": "1.0.0",
             "AppScriptAuthor": "napt",
-            "RequireAdmin": True,
         },
     },
     # Intune/Win32 settings.

--- a/napt/config/loader.py
+++ b/napt/config/loader.py
@@ -262,23 +262,39 @@ def _resolve_known_paths(
 def _inject_dynamic_values(cfg: dict[str, Any]) -> None:
     """Injects dynamic fields that should be set at load/build time.
 
-    Currently injects psadt.app_vars.AppScriptDate with today's date
-    in YYYY-MM-DD format.
+    Injects the following fields if not already set by a config layer:
+
+    - ``psadt.app_vars.AppScriptDate``: Today's date (YYYY-MM-DD).
+    - ``psadt.app_vars.RequireAdmin``: Defaults to ``True`` for system-context
+      installs and ``False`` for user-context installs (``intune.run_as_account``).
+      User-context installs must not require admin or PSADT will error on
+      non-admin accounts. Override explicitly in the recipe if your environment
+      grants local admin to users and you want PSADT to enforce it.
 
     Args:
         cfg: The configuration dictionary to inject values into.
+
+    Note:
+        ``RequireAdmin`` is derived here rather than in ``DEFAULT_CONFIG``
+        because its correct default depends on ``intune.run_as_account``, and
+        after config layers are merged the two values are indistinguishable.
+        See the defaults centralization work item for the long-term fix.
     """
-    today_str = date.today().strftime("%Y-%m-%d")
     try:
         app_vars = cfg.setdefault("psadt", {}).setdefault("app_vars", {})
-        # Do not overwrite if explicitly set in recipe; only set if absent
+
+        today_str = date.today().strftime("%Y-%m-%d")
         app_vars.setdefault("AppScriptDate", today_str)
+
+        run_as_account = cfg.get("intune", {}).get("run_as_account", "system")
+        require_admin_default = run_as_account != "user"
+        app_vars.setdefault("RequireAdmin", require_admin_default)
     except Exception as err:
         # Be defensive but quiet; dynamic injection is best-effort
         from napt.logging import get_global_logger
 
         logger = get_global_logger()
-        logger.warning("CONFIG", f"Could not inject AppScriptDate: {err}")
+        logger.warning("CONFIG", f"Could not inject dynamic values: {err}")
 
 
 def _print_yaml_content(data: dict[str, Any], indent: int = 0) -> None:

--- a/tests/build/test_msix_scripts.py
+++ b/tests/build/test_msix_scripts.py
@@ -37,6 +37,7 @@ class TestMSIXDetectionConfig:
         assert config.log_rotation_mb == 3
         assert config.exact_match is False
         assert config.app_id == ""
+        assert config.install_scope == "system"
 
     def test_custom_values(self):
         """Tests that custom values are stored correctly."""
@@ -47,12 +48,14 @@ class TestMSIXDetectionConfig:
             log_level="DEBUG",
             exact_match=True,
             app_id="napt-example",
+            install_scope="user",
         )
 
         assert config.identity_name == "com.example.app"
         assert config.log_level == "DEBUG"
         assert config.exact_match is True
         assert config.app_id == "napt-example"
+        assert config.install_scope == "user"
 
 
 class TestMSIXRequirementsConfig:
@@ -73,6 +76,18 @@ class TestMSIXRequirementsConfig:
         assert config.log_level == "INFO"
         assert config.log_rotation_mb == 3
         assert config.app_id == ""
+        assert config.install_scope == "system"
+
+    def test_custom_install_scope(self):
+        """Tests that install_scope is stored correctly."""
+        config = MSIXRequirementsConfig(
+            identity_name="com.example.app",
+            app_name="Example",
+            version="1.0.0.0",
+            install_scope="user",
+        )
+
+        assert config.install_scope == "user"
 
 
 class TestGenerateMSIXDetectionScript:
@@ -120,19 +135,37 @@ class TestGenerateMSIXDetectionScript:
 
         assert "4.49.81.0" in content
 
-    def test_script_uses_get_appxpackage(self, tmp_path):
-        """Tests that script uses Get-AppxPackage for detection."""
+    def test_system_scope_uses_provisioned_query(self, tmp_path):
+        """Tests that system scope generates Get-AppxProvisionedPackage detection."""
         config = MSIXDetectionConfig(
             identity_name="com.tinyspeck.slackdesktop",
             app_name="Slack",
             version="4.49.81.0",
+            install_scope="system",
         )
         output_path = tmp_path / "detection.ps1"
 
         generate_msix_detection_script(config, output_path)
         content = output_path.read_text(encoding="utf-8")
 
-        assert "Get-AppxPackage" in content
+        assert "Get-AppxProvisionedPackage" in content
+        assert "Get-AppxPackage -Name" not in content
+
+    def test_user_scope_uses_per_user_query(self, tmp_path):
+        """Tests that user scope generates Get-AppxPackage detection."""
+        config = MSIXDetectionConfig(
+            identity_name="com.tinyspeck.slackdesktop",
+            app_name="Slack",
+            version="4.49.81.0",
+            install_scope="user",
+        )
+        output_path = tmp_path / "detection.ps1"
+
+        generate_msix_detection_script(config, output_path)
+        content = output_path.read_text(encoding="utf-8")
+
+        assert "Get-AppxPackage -Name" in content
+        assert "Get-AppxProvisionedPackage" not in content
 
     def test_script_exact_match(self, tmp_path):
         """Tests that exact match flag is reflected in script."""
@@ -260,3 +293,35 @@ class TestGenerateMSIXRequirementsScript:
         # Should not call Get-UninstallKeys in the main logic
         main_logic = content.split("# Main requirements logic")[1]
         assert "Get-UninstallKeys" not in main_logic
+
+    def test_system_scope_uses_provisioned_query(self, tmp_path):
+        """Tests that system scope generates Get-AppxProvisionedPackage requirements."""
+        config = MSIXRequirementsConfig(
+            identity_name="com.tinyspeck.slackdesktop",
+            app_name="Slack",
+            version="4.49.81.0",
+            install_scope="system",
+        )
+        output_path = tmp_path / "requirements.ps1"
+
+        generate_msix_requirements_script(config, output_path)
+        content = output_path.read_text(encoding="utf-8")
+
+        assert "Get-AppxProvisionedPackage" in content
+        assert "Get-AppxPackage -Name" not in content
+
+    def test_user_scope_uses_per_user_query(self, tmp_path):
+        """Tests that user scope generates Get-AppxPackage requirements."""
+        config = MSIXRequirementsConfig(
+            identity_name="com.tinyspeck.slackdesktop",
+            app_name="Slack",
+            version="4.49.81.0",
+            install_scope="user",
+        )
+        output_path = tmp_path / "requirements.ps1"
+
+        generate_msix_requirements_script(config, output_path)
+        content = output_path.read_text(encoding="utf-8")
+
+        assert "Get-AppxPackage -Name" in content
+        assert "Get-AppxProvisionedPackage" not in content

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,6 +198,45 @@ class TestDynamicInjection:
         if "AppScriptDate" in app_vars:
             assert app_vars["AppScriptDate"] == today
 
+    def test_require_admin_defaults_true_for_system_scope(self):
+        """Tests that _inject_dynamic_values defaults RequireAdmin to true for system scope."""
+        from napt.config.loader import _inject_dynamic_values
+
+        cfg = {"psadt": {"app_vars": {}}, "intune": {"run_as_account": "system"}}
+        _inject_dynamic_values(cfg)
+
+        assert cfg["psadt"]["app_vars"]["RequireAdmin"] is True
+
+    def test_require_admin_defaults_false_for_user_scope(self):
+        """Tests that _inject_dynamic_values defaults RequireAdmin to false for user scope."""
+        from napt.config.loader import _inject_dynamic_values
+
+        cfg = {"psadt": {"app_vars": {}}, "intune": {"run_as_account": "user"}}
+        _inject_dynamic_values(cfg)
+
+        assert cfg["psadt"]["app_vars"]["RequireAdmin"] is False
+
+    def test_require_admin_explicit_value_not_overridden(self):
+        """Tests that an explicit RequireAdmin value is not overridden by injection."""
+        from napt.config.loader import _inject_dynamic_values
+
+        cfg = {
+            "psadt": {"app_vars": {"RequireAdmin": True}},
+            "intune": {"run_as_account": "user"},
+        }
+        _inject_dynamic_values(cfg)
+
+        assert cfg["psadt"]["app_vars"]["RequireAdmin"] is True
+
+    def test_require_admin_defaults_true_when_no_run_as_account(self):
+        """Tests that RequireAdmin defaults to true when run_as_account is absent."""
+        from napt.config.loader import _inject_dynamic_values
+
+        cfg = {"psadt": {"app_vars": {}}}
+        _inject_dynamic_values(cfg)
+
+        assert cfg["psadt"]["app_vars"]["RequireAdmin"] is True
+
 
 class TestErrorHandling:
     """Tests for error handling in config loading."""


### PR DESCRIPTION
## Description

Extends MSIX support so `intune.run_as_account` controls which AppX cmdlets
are used for install, uninstall, detection, and requirements scripts.

## Motivation

MSIX installers have two fundamentally different deployment models: provisioned
(all-users, requires elevation) and per-user (current user, no elevation needed).
The previous implementation always generated `Add-AppxPackage` / `Remove-AppxPackage`
regardless of context, which was wrong for enterprise deployments where system-context
installs should use `Add-AppxProvisionedPackage`. Detection scripts also needed to
query the correct store to match the install model.

## Changes

- `intune.run_as_account: "system"` (default) generates `Add-AppxProvisionedPackage`
  and `Remove-AppxProvisionedPackage`; detection/requirements query `Get-AppxProvisionedPackage`
- `intune.run_as_account: "user"` generates `Add-AppxPackage` and `Remove-AppxPackage`;
  detection/requirements query `Get-AppxPackage`
- `psadt.app_vars.RequireAdmin` defaults to `false` for user-context installs —
  PSADT errors if `RequireAdmin` is `true` but the process lacks admin rights;
  recipe-explicit values are preserved
- Scope-specific PS1 helpers (`_msix_shared_system.ps1` / `_msix_shared_user.ps1`)
  replace the single `_msix_shared.ps1` to eliminate dead code in generated scripts
- Package identity fields parsed from `PackageName` rather than object properties —
  `Architecture` on `AppxProvisionedPackage` returns an integer enum; `PackageName`
  is a documented Microsoft spec with underscores as structural delimiters (prohibited
  in all five components), making `_` splits safe by design
- Multiple versions of the same package identity handled by sorting on `[Version]`
  and taking the highest installed version
- Fixes `$dirFiles` to `$($adtSession.DirFiles)` for PSADT 4.x compatibility

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed — built Slack MSIX recipe with default (system) scope
  and confirmed generated scripts contain `Get-AppxProvisionedPackage` and
  `Add-AppxProvisionedPackage`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors