### PR TITLE
fix: Use stored file path from cache for cache hits

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,6 +84,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cached installer filename now survives re-runs** - NAPT stores the actual
+    downloaded filename in state after each download. On subsequent runs,
+    cache hits use the stored path instead of re-deriving from the recipe URL.
+    Previously, if the server returned a `Content-Disposition` header or the
+    download URL redirected to a different path, the cached file could not be
+    found and the run would fail
+- **Incomplete or stale cache no longer requires `--stateless`** - If the
+    cache is missing fields or the cached file was deleted, NAPT automatically
+    forces a fresh download instead of failing with a confusing error message
 - **`intune.device_restart_behavior` default corrected to
     `"basedOnReturnCode"`** - Previously an inline fallback used `"allow"`
     instead of the value defined in `DEFAULT_CONFIG`

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -77,41 +77,6 @@ from napt.state import load_state, save_state
 from napt.versioning import is_newer
 
 
-def derive_file_path_from_url(url: str, output_dir: Path, app_id: str) -> Path:
-    """Derives the expected local file path for a download URL.
-
-    Ensures version-first strategies can locate cached files without
-    downloading by following the same naming convention as the download
-    module (app-scoped subdirectory).
-
-    Args:
-        url: Download URL.
-        output_dir: Base downloads directory.
-        app_id: Application identifier used to scope the subdirectory.
-
-    Returns:
-        Expected path to the file under output_dir/app_id/.
-
-    Example:
-        Get expected file path for a download URL:
-            ```python
-            from pathlib import Path
-
-            path = derive_file_path_from_url(
-                "https://example.com/app.msi",
-                Path("./downloads"),
-                "my-app",
-            )
-            # Returns: Path('./downloads/my-app/app.msi')
-            ```
-
-    """
-    from urllib.parse import urlparse
-
-    filename = Path(urlparse(url).path).name
-    return output_dir / app_id / filename
-
-
 def discover_recipe(
     recipe_path: Path,
     output_dir: Path | None = None,
@@ -266,28 +231,29 @@ def discover_recipe(
         if not is_newer(
             version_info.version, cache.get("known_version") if cache else None
         ):
-            # Derive file path from URL using same logic as download_file
-            file_path = derive_file_path_from_url(
-                version_info.download_url, output_dir, app_id
+            cached_file_path = (
+                Path(cache["file_path"]) if cache and cache.get("file_path") else None
             )
 
-            if file_path.exists():
+            if cached_file_path is not None and cached_file_path.exists():
                 # Fast path: version unchanged, file exists, skip download!
                 logger.info(
                     "CACHE",
                     f"Version {version_info.version} unchanged, using cached file",
                 )
                 logger.step(4, 4, "Using cached file...")
+                file_path = cached_file_path
                 sha256 = cache.get("sha256")
                 version = version_info.version
                 version_source = version_info.source
                 headers = {}  # No download occurred, no headers
             else:
-                # File was deleted, re-download
-                logger.warning(
-                    "CACHE",
-                    f"Cached file {file_path} not found, re-downloading",
-                )
+                # File missing or no cached path — re-download
+                if cached_file_path is not None:
+                    logger.warning(
+                        "CACHE",
+                        f"Cached file {cached_file_path} not found, re-downloading",
+                    )
                 logger.step(4, 4, "Downloading installer...")
                 dl = download_file(
                     version_info.download_url,
@@ -350,6 +316,7 @@ def discover_recipe(
                 last_modified if last_modified else None
             ),  # Only useful for url_download
             "sha256": sha256,
+            "file_path": str(file_path),  # Actual filename (may differ from URL)
         }
 
         # Optional fields

--- a/napt/discovery/url_download.py
+++ b/napt/discovery/url_download.py
@@ -196,65 +196,67 @@ class UrlDownloadStrategy:
             )
             file_path, sha256, headers = dl.file_path, dl.sha256, dl.headers
         except NotModifiedError:
-            # File unchanged (HTTP 304), use cached version
-            # Use convention-based path: derive filename from URL
+            # File unchanged (HTTP 304).
             logger.info("CACHE", "File not modified (HTTP 304), using cached version")
 
-            if not cache or "sha256" not in cache:
-                raise NetworkError(
-                    "Cache indicates file not modified, but missing SHA-256. "
-                    "Try running with --stateless to force re-download."
-                ) from None
-
-            # Derive file path from URL (convention-based, schema v2)
-            from urllib.parse import urlparse
-
-            filename = Path(urlparse(url).path).name
-            cached_file = output_dir / app_id / filename
-
-            if not cached_file.exists():
-                raise NetworkError(
-                    f"Cached file {cached_file} not found. "
-                    f"File may have been deleted. Try running with --stateless."
-                ) from None
-
-            # Extract version from cached file (auto-detect by extension)
-            if cached_file.suffix.lower() == ".msi":
-                logger.verbose(
-                    "DISCOVERY", "Auto-detected MSI file, extracting version"
-                )
-                try:
-                    metadata = extract_msi_metadata(cached_file)
-                    version, version_source = metadata.product_version, "url_download"
-                except Exception as err:
-                    raise NetworkError(
-                        f"Failed to extract MSI ProductVersion from cached "
-                        f"file {cached_file}: {err}"
-                    ) from err
-            else:
-                raise ConfigError(
-                    f"Cannot extract version from file type: {cached_file.suffix!r}. "
-                    f"url_download strategy currently supports MSI files only. "
-                    f"For other file types, use a version-first strategy (api_github, "
-                    f"api_json, web_scrape) or ensure the file is an MSI installer."
-                ) from None
-
-            # Return cached info with preserved headers (prevents overwriting ETag)
-            # When 304, no new headers received, so return cached values to
-            # preserve them
-            preserved_headers = {}
-            if cache.get("etag"):
-                preserved_headers["ETag"] = cache["etag"]
-            if cache.get("last_modified"):
-                preserved_headers["Last-Modified"] = cache["last_modified"]
-
-            return (
-                version,
-                version_source,
-                cached_file,
-                cache["sha256"],
-                preserved_headers,
+            cached_file_path = (
+                Path(cache["file_path"]) if cache and cache.get("file_path") else None
             )
+
+            if (
+                cache
+                and cache.get("sha256")
+                and cached_file_path is not None
+                and cached_file_path.exists()
+            ):
+                # Extract version from cached file (auto-detect by extension)
+                if cached_file_path.suffix.lower() == ".msi":
+                    logger.verbose(
+                        "DISCOVERY", "Auto-detected MSI file, extracting version"
+                    )
+                    try:
+                        metadata = extract_msi_metadata(cached_file_path)
+                        version, version_source = (
+                            metadata.product_version,
+                            "url_download",
+                        )
+                    except Exception as err:
+                        raise NetworkError(
+                            f"Failed to extract MSI ProductVersion from cached "
+                            f"file {cached_file_path}: {err}"
+                        ) from err
+                else:
+                    raise ConfigError(
+                        f"Cannot extract version from file type: "
+                        f"{cached_file_path.suffix!r}. "
+                        f"url_download strategy currently supports MSI files only. "
+                        f"For other file types, use a version-first strategy "
+                        f"(api_github, api_json, web_scrape) or ensure the file "
+                        f"is an MSI installer."
+                    ) from None
+
+                # Preserve cached headers (no new headers on 304)
+                preserved_headers = {}
+                if cache.get("etag"):
+                    preserved_headers["ETag"] = cache["etag"]
+                if cache.get("last_modified"):
+                    preserved_headers["Last-Modified"] = cache["last_modified"]
+
+                return (
+                    version,
+                    version_source,
+                    cached_file_path,
+                    cache["sha256"],
+                    preserved_headers,
+                )
+            else:
+                # Cache incomplete or file missing — force unconditional re-download
+                logger.warning(
+                    "CACHE",
+                    "Cache incomplete or cached file not found, forcing re-download",
+                )
+                dl = download_file(url, output_dir / app_id)
+                file_path, sha256, headers = dl.file_path, dl.sha256, dl.headers
         except Exception as err:
             if isinstance(err, (NetworkError, ConfigError)):
                 raise

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,7 +139,7 @@ class TestVersionFirstFastPath:
         # Mock HTML page for web_scrape
         html_content = '<a href="/app-v1.2.3-installer.msi">Download</a>'
 
-        # Mock state with matching version
+        # Mock state with matching version and stored file path
         state = {
             "metadata": {"napt_version": "0.1.0", "schema_version": "2"},
             "apps": {
@@ -147,6 +147,7 @@ class TestVersionFirstFastPath:
                     "url": "https://example.com/app-v1.2.3-installer.msi",
                     "known_version": "1.2.3",
                     "sha256": "abc123" * 8,
+                    "file_path": str(cached_file),
                 }
             },
         }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -309,8 +309,8 @@ class TestCacheAndETagSupport:
         assert file_path == tmp_test_dir / "test-app" / "installer.msi"
         assert file_path.exists()
 
-    def test_cache_with_missing_file_raises(self, tmp_test_dir):
-        """Test that cache with missing file raises helpful error."""
+    def test_cache_with_missing_file_redownloads(self, tmp_test_dir):
+        """Test that 304 with a missing cached file forces a re-download."""
         app_config = {
             "id": "test-app",
             "discovery": {
@@ -321,7 +321,7 @@ class TestCacheAndETagSupport:
 
         strategy = UrlDownloadStrategy()
 
-        # Cache points to non-existent file
+        # Cache points to a file that no longer exists on disk
         cache = {
             "version": "1.0.0",
             "etag": 'W/"abc123"',
@@ -329,14 +329,83 @@ class TestCacheAndETagSupport:
             "sha256": "cached_sha",
         }
 
+        fake_msi = b"re-downloaded MSI content"
+
         with requests_mock.Mocker() as m:
-            # Mock 304 response
-            m.get("https://example.com/installer.msi", status_code=304)
+            # First request (conditional with ETag) returns 304
+            # Second request (forced unconditional re-download) returns 200
+            m.get(
+                "https://example.com/installer.msi",
+                [
+                    {"status_code": 304},
+                    {
+                        "content": fake_msi,
+                        "headers": {"Content-Length": str(len(fake_msi))},
+                    },
+                ],
+            )
 
-            from napt.exceptions import NetworkError
+            with patch(
+                "napt.discovery.url_download.extract_msi_metadata"
+            ) as mock_extract:
+                mock_extract.return_value = MSIMetadata(
+                    product_name="", product_version="1.0.0", architecture="x64"
+                )
 
-            with pytest.raises(NetworkError, match="Cached file.*not found"):
-                strategy.discover_version(app_config, tmp_test_dir, cache=cache)
+                version, version_source, file_path, sha256, headers = (
+                    strategy.discover_version(app_config, tmp_test_dir, cache=cache)
+                )
+
+        assert version == "1.0.0"
+        assert file_path.exists()
+
+    def test_304_uses_cached_file_path_not_url(self, tmp_test_dir):
+        """Test that 304 uses cache's file_path, not the URL-derived filename.
+
+        Covers the bug where Content-Disposition gives a different filename
+        than the URL path. On the next run (304), we must use the stored path.
+        """
+        app_config = {
+            "id": "test-app",
+            "discovery": {
+                "url": "https://example.com/download?token=abc",
+            },
+        }
+
+        strategy = UrlDownloadStrategy()
+
+        # Simulate: original download had Content-Disposition filename
+        # that differs from the URL (no filename in URL path at all)
+        app_dir = tmp_test_dir / "test-app"
+        app_dir.mkdir()
+        cd_named_file = app_dir / "MyApp-Setup-2.1.0.msi"
+        cd_named_file.write_bytes(b"fake msi from cd header")
+
+        cache = {
+            "version": "2.1.0",
+            "etag": 'W/"xyz"',
+            "file_path": str(cd_named_file),
+            "sha256": "deadbeef" * 8,
+        }
+
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com/download", status_code=304)
+
+            with patch(
+                "napt.discovery.url_download.extract_msi_metadata"
+            ) as mock_extract:
+                mock_extract.return_value = MSIMetadata(
+                    product_name="", product_version="2.1.0", architecture="x64"
+                )
+
+                version, version_source, file_path, sha256, headers = (
+                    strategy.discover_version(app_config, tmp_test_dir, cache=cache)
+                )
+
+        # Must use the CD-derived cached path, not "download.bin" from URL
+        assert file_path == cd_named_file
+        assert version == "2.1.0"
+        assert sha256 == "deadbeef" * 8
 
 
 class TestVersionFirstStrategies:


### PR DESCRIPTION
## Description

Fixes a bug where NAPT re-derived the installer filename from the recipe URL
on every run instead of using the actual filename from the previous download.
If the server returned a `Content-Disposition` header (e.g. `MyApp-Setup-2.1.0.msi`)
or the download URL redirected to a path with a different filename, the derived
path would not match the file on disk — causing cache hits to fail silently or
error out.

## Motivation

The download module already handles `Content-Disposition` and final redirect URLs
correctly when writing the file. But the cache-hit path derived the filename from
the *original recipe URL*, so these two could diverge. This PR closes that gap by
persisting the actual filename in state and reading it back on subsequent runs.

## Changes

- Store `file_path` in the state cache entry after every download
- Version-first strategies (`web_scrape`, `api_github`, `api_json`): cache hits
  now read `cache["file_path"]` instead of calling the removed
  `derive_file_path_from_url()`. Falls through to re-download if the field is
  absent or the file is missing
- `url_download` 304 handler: uses `cache["file_path"]` to locate the cached
  file. If the cache is incomplete or the file was deleted, forces an
  unconditional re-download instead of failing with a `--stateless` hint
- Remove `derive_file_path_from_url()` (now dead code)
- Update changelog

## Testing

- Updated `test_version_first_cache_hit_skips_download` to include `file_path`
  in the state fixture (required for the fast path to activate)
- Renamed `test_cache_with_missing_file_raises` →
  `test_cache_with_missing_file_redownloads` and updated it to verify the
  re-download behavior
- Added `test_304_uses_cached_file_path_not_url`: verifies that on a 304 the
  `Content-Disposition`-derived cached path is used, not the URL-derived fallback
- All 428 unit tests passing

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (changelog)
- [x] Tests pass
- [x] No linting errors