### PR TITLE
chore: Prepare release 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Recipes are YAML configuration files that define how to discover, download, and 
 - **[git.yaml](https://github.com/RogerCibrian/notapkgtool/blob/main/recipes/Git/git.yaml)** - api_github strategy for GitHub Releases
 - **[7zip-x64-msi.yaml](https://github.com/RogerCibrian/notapkgtool/blob/main/recipes/7-Zip/7zip-x64-msi.yaml)** - web_scrape strategy for vendor download pages
 
+**Note:** The `recipes/` and `defaults/` directories in this repository are
+working examples used for development and testing.
+They are not included in the pip package.
+Run `napt init` to create your own workspace with a starter `org.yaml`.
+
 NAPT supports multiple discovery strategies (url_download, web_scrape, api_github, api_json) - see the [Discovery Strategies](https://rogercibrian.github.io/notapkgtool/user-guide/#discovery-strategies) guide for detailed configuration and more examples.
 
 ## Contributing

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-05
+
 ### Added
 
 - **Automatic recipe validation in pipeline commands** - `napt discover`,
@@ -17,31 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     config layer (code default, org.yaml, vendor defaults, or recipe) set
     each value. Helps debug unexpected configuration by tracing the full
     merge history
-- **`intune.is_featured` config key** - Controls whether the app is featured
-    in Company Portal. Configurable at org, vendor, or recipe level.
-    Defaults to `false`
-- **MSIX installer support** - NAPT now supports `.msix` installers as a third
-    installer type alongside MSI and EXE. MSIX metadata (display name, version,
-    architecture, package identity) is extracted from `AppxManifest.xml` inside
-    the package. Detection and requirements scripts query the AppX package
-    database; install and uninstall commands are auto-generated from manifest
-    metadata unless overridden with `psadt.override_msix_commands: true`
-- **MSIX install scope** - `intune.run_as_account` now controls which AppX
-    cmdlets are auto-generated for MSIX installers. `"system"` (default) uses
-    `Add-AppxProvisionedPackage` / `Remove-AppxProvisionedPackage` for
-    all-users provisioned installs. `"user"` uses `Add-AppxPackage` /
-    `Remove-AppxPackage` for per-user installs. Detection and requirements
-    scripts automatically query the correct store (`Get-AppxProvisionedPackage`
-    vs `Get-AppxPackage`) based on the same setting
-- **Scope-based `RequireAdmin` default** - `psadt.app_vars.RequireAdmin`
-    now defaults to `false` when `intune.run_as_account` is `"user"`.
-    PSADT errors if `RequireAdmin` is `true` but the process lacks admin
-    rights. Override explicitly in `psadt.app_vars` if your environment
-    grants local admin to users
-- **`psadt.override_msix_commands` config key** - When `true`, uses recipe
-    `psadt.install` and `psadt.uninstall` instead of the auto-generated MSIX
-    commands. Required when the default `Add-AppxPackage` / `Remove-AppxPackage`
-    commands are insufficient (e.g., apps needing license files or provisioning)
+- **MSIX installer support** - NAPT now supports `.msix` installers alongside
+    MSI and EXE. Metadata (display name, version, architecture, package
+    identity) is extracted from `AppxManifest.xml` inside the package.
+    Detection and requirements scripts query the AppX package database; install
+    and uninstall commands are auto-generated from manifest metadata unless
+    overridden with `psadt.override_msix_commands: true`. Install scope is
+    controlled by `intune.run_as_account`: `"system"` (default) uses
+    provisioned cmdlets (`Add-AppxProvisionedPackage` /
+    `Remove-AppxProvisionedPackage`); `"user"` uses per-user cmdlets
+    (`Add-AppxPackage` / `Remove-AppxPackage`). Detection and requirements
+    scripts automatically query the correct store based on the same setting.
+    `psadt.app_vars.RequireAdmin` defaults to `false` when scope is `"user"`
 - **`intunewin.release` config key** - Pin `IntuneWinAppUtil.exe` to a specific
     release for reproducible builds (e.g., `release: "1.8.6"`). Defaults to
     `"latest"`, which resolves the current release via GitHub API. Each version
@@ -49,14 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`logging:` top-level section** - New optional section for per-recipe logging
     configuration. Supports `log_format` (`cmtrace`, `text`), `log_level`
     (`verbose`, `debug`), and `log_rotation_mb`
-- **New `intune:` fields** - `developer`, `owner`, `notes`, `logo_path`,
-    `minimum_supported_windows_release`, `install_command`, and
-    `uninstall_command` are now supported in the `intune:` section
-- **Configurable upload settings** - New `intune:` fields control Intune Graph
-    API upload behavior: `is_featured`, `allow_available_uninstall`,
-    `run_as_account`, `device_restart_behavior`, `max_run_time_minutes`,
-    `enforce_signature_check`, and `run_as_32_bit`. All fields are validated and
-    configurable at org, vendor, or recipe level
+- **New `intune:` fields** - Expanded metadata and upload behavior fields,
+    all configurable at org, vendor, or recipe level: `developer`, `owner`,
+    `notes`, `logo_path`, `minimum_supported_windows_release`,
+    `install_command`, `uninstall_command`, `is_featured` (Company Portal
+    featured app, defaults to `false`), `allow_available_uninstall`,
+    `device_restart_behavior`, `max_run_time_minutes`,
+    `enforce_signature_check`, and `run_as_32_bit`
 - **Sample recipe: `recipes/Microsoft/vscode.yaml`** - New example recipe for
     Visual Studio Code using the `api_json` strategy
 
@@ -103,9 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `update_name_prefix`) are now each created, uploaded, and committed in
     sequence. Single-entry behavior for `"app_only"` and `"update_only"` is
     unchanged
-- Version cache check now uses semantic comparison instead of string equality,
-    so versions with a `v` prefix (e.g., `v1.2.3` vs `1.2.3`) are correctly
-    recognized as matching and won't re-download unnecessarily
+- **Version cache uses semantic comparison** - Versions with a `v` prefix
+    (e.g., `v1.2.3` vs `1.2.3`) are now correctly recognized as matching
+    and won't re-download unnecessarily
 
 ## [0.4.0] - 2026-03-08
 
@@ -221,7 +209,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.2.0...0.3.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,11 @@ Recipes are YAML configuration files that define how to discover, download, and 
 - **[git.yaml](https://github.com/RogerCibrian/notapkgtool/blob/main/recipes/Git/git.yaml)** - api_github strategy for GitHub Releases
 - **[7zip-x64-msi.yaml](https://github.com/RogerCibrian/notapkgtool/blob/main/recipes/7-Zip/7zip-x64-msi.yaml)** - web_scrape strategy for vendor download pages
 
+**Note:** The `recipes/` and `defaults/` directories in this repository are
+working examples used for development and testing.
+They are not included in the pip package.
+Run `napt init` to create your own workspace with a starter `org.yaml`.
+
 NAPT supports multiple discovery strategies (url_download, web_scrape, api_github, api_json) - see the [Discovery Strategies](user-guide.md#discovery-strategies) guide for detailed configuration and more examples.
 
 ## Contributing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -429,10 +429,11 @@ and [Recipe Reference - Intune Configuration](recipe-reference.md#intune-configu
 
 ---
 
-**v0.4.0** - Intune upload (`napt upload`), `napt init`, and four-layer configuration
-**v0.3.1** - PyPI rename to `napt` and automated publishing
-**v0.3.0** - Detection and requirements scripts, Win32 validation, architecture-aware detection
-**v0.2.0** - PSADT building, `.intunewin` packaging, and new discovery strategies
-**v0.1.0** - Core validation, discovery, and configuration system
+**0.5.0** - MSIX support, recipe schema flattening, and centralized config defaults
+**0.4.0** - Intune upload (`napt upload`), `napt init`, and four-layer configuration
+**0.3.1** - PyPI rename to `napt` and automated publishing
+**0.3.0** - Detection and requirements scripts, Win32 validation, architecture-aware detection
+**0.2.0** - PSADT building, `.intunewin` packaging, and new discovery strategies
+**0.1.0** - Core validation, discovery, and configuration system
 
 See [CHANGELOG.md](changelog.md) for detailed release history.

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1364,4 +1364,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "8ebf5c6c80a60cb5a7e3359aac1ef90195f913f12e511c03a645feb561ffcfcf"
+content-hash = "56d55ee061d9437edf332e12e1ac1af42aef93a3fdd8bc21dd3f7e78c357b6f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.4.0"
+version = "0.5.0"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

Prepares the 0.5.0 release: version bumps, changelog finalization, and minor
documentation updates.

## Motivation

0.5.0 introduces MSIX installer support, a flattened recipe schema, centralized
config defaults, and several other features and fixes accumulated since 0.4.0.

## Changes

- Bump version to `0.5.0` in `pyproject.toml` and `napt/__init__.py`
- Regenerate `poetry.lock`
- Promote `[Unreleased]` changelog entries to `[0.5.0] - 2026-04-05`; condense
  overlapping `intune:` bullets and four MSIX bullets into single entries; fix
  unformatted version cache entry; add fresh `[Unreleased]` section and
  comparison link
- Add note to `docs/index.md` and `README.md` clarifying that `recipes/` and
  `defaults/` are dev examples not included in the pip package
- Add `0.5.0` entry to `docs/roadmap.md` release history; remove `v` prefix
  from all version entries

## Testing

- [x] Unit tests pass (428 passed, 15 deselected)
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors