### PR TITLE
fix: Correct invalid PSADT cmdlets in sample recipes

### DIFF
--- a/recipes/7-Zip/7zip-x64-exe.yaml
+++ b/recipes/7-Zip/7zip-x64-exe.yaml
@@ -23,7 +23,7 @@ psadt:
   install: |
     # Install 7-Zip EXE with system-wide deployment
     # Note: Filename uses compact version (e.g., 7z2501-x64.exe for v25.01)
-    Start-ADTExecutable -Path "$dirFiles\7z*-x64.exe" -Parameters "/S"
+    Start-ADTProcess -FilePath "7z*-x64.exe" -ArgumentList "/S"
   uninstall: |
     # Uninstall 7-Zip automatically (handles registry lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/7-Zip/7zip-x64-msi.yaml
+++ b/recipes/7-Zip/7zip-x64-msi.yaml
@@ -23,7 +23,7 @@ psadt:
   install: |
     # Install 7-Zip MSI with system-wide deployment
     # Note: Filename uses compact version (e.g., 7z2501-x64.msi for v25.01)
-    Start-ADTMsiProcess -Action Install -Path "$dirFiles\7z*-x64.msi" -Parameters "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "7z*-x64.msi" -ArgumentList "ALLUSERS=1"
   uninstall: |
     # Uninstall 7-Zip automatically (handles MSI ProductCode lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/7-Zip/7zip-x86-exe.yaml
+++ b/recipes/7-Zip/7zip-x86-exe.yaml
@@ -23,7 +23,7 @@ psadt:
   install: |
     # Install 7-Zip EXE with system-wide deployment
     # Note: Filename uses compact version (e.g., 7z2501.exe for v25.01)
-    Start-ADTExecutable -Path "$dirFiles\7z*.exe" -Parameters "/S"
+    Start-ADTProcess -FilePath "7z*.exe" -ArgumentList "/S"
   uninstall: |
     # Uninstall 7-Zip automatically (handles registry lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/7-Zip/7zip-x86-msi.yaml
+++ b/recipes/7-Zip/7zip-x86-msi.yaml
@@ -23,7 +23,7 @@ psadt:
   install: |
     # Install 7-Zip MSI with system-wide deployment
     # Note: Filename uses compact version (e.g., 7z2501.msi for v25.01)
-    Start-ADTMsiProcess -Action Install -Path "$dirFiles\7z*.msi" -Parameters "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "7z*.msi" -ArgumentList "ALLUSERS=1"
   uninstall: |
     # Uninstall 7-Zip automatically (handles MSI ProductCode lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/Git/git.yaml
+++ b/recipes/Git/git.yaml
@@ -20,7 +20,7 @@ psadt:
     AppVersion: "${discovered_version}"
   install: |
     # Git for Windows silent install with default options
-    Start-ADTProcess -Path "$dirFiles\Git-${discovered_version}-64-bit.exe" -Parameters "/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /COMPONENTS=`"icons,ext\reg\shellhere,assoc,assoc_sh`""
+    Start-ADTProcess -FilePath "Git-${discovered_version}-64-bit.exe" -ArgumentList "/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /COMPONENTS=`"icons,ext\reg\shellhere,assoc,assoc_sh`""
   uninstall: |
     # Git for Windows uninstall (handles Inno Setup uninstaller automatically)
     Uninstall-ADTApplication -Name "Git"

--- a/recipes/Google/chrome.yaml
+++ b/recipes/Google/chrome.yaml
@@ -13,7 +13,7 @@ psadt:
     AppVersion: "${discovered_version}"
   install: |
     # Install Chrome MSI with system-wide deployment
-    Start-ADTMsiProcess -Action Install -Path "$dirFiles\googlechromestandaloneenterprise64.msi" -Parameters "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "googlechromestandaloneenterprise64.msi" -ArgumentList "ALLUSERS=1"
   uninstall: |
     # Uninstall Chrome automatically (handles MSI ProductCode lookup)
     Uninstall-ADTApplication -Name "Google Chrome"

--- a/recipes/Microsoft/vscode.yaml
+++ b/recipes/Microsoft/vscode.yaml
@@ -26,7 +26,7 @@ psadt:
     AppVendor: "Microsoft"
   install: |
     # VS Code system installer - silent install for all users
-    Start-ADTExecutable -Path "$dirFiles\VSCodeSetup-x64-${discovered_version}.exe" -Parameters "/VERYSILENT /NORESTART /MERGETASKS=!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath"
+    Start-ADTProcess -FilePath "VSCodeSetup-x64-${discovered_version}.exe" -ArgumentList "/VERYSILENT /NORESTART /MERGETASKS=!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath"
   uninstall: |
     # VS Code uninstall via registry (Inno Setup uninstaller)
     Uninstall-ADTApplication -Name "Microsoft Visual Studio Code"

--- a/recipes/Slack/slack-msix.yaml
+++ b/recipes/Slack/slack-msix.yaml
@@ -10,7 +10,7 @@ discovery:
   download_url_path: "download_url"
 
 # MSIX installers auto-generate install/uninstall commands from manifest:
-#   Install:   Add-AppxPackage -Path "$dirFiles\<filename>"
+#   Install:   Add-AppxPackage -Path "$($adtSession.DirFiles)\<filename>"
 #   Uninstall: Get-AppxPackage -Name "<identity_name>" | Remove-AppxPackage
 # Set psadt.override_msix_commands: true to use custom commands instead.
 


### PR DESCRIPTION
## Description
Fixes the install commands in eight sample recipes that referenced PSADT cmdlets and parameters that don't exist.

## Motivation
The recipes used `Start-ADTExecutable` (which is not a real cmdlet in either PSADT v3 or v4) and combined it with PSADT v3 parameter names (`-Path`, `-Parameters`) and the v3 `$dirFiles` variable. None of these install commands would have actually run successfully against PSADT v4 — they would error on the unknown cmdlet or unknown parameter. Anyone copying these as starting templates would inherit broken install logic.

## Changes
- Replace `Start-ADTExecutable` with `Start-ADTProcess` (the real PSADT v4 cmdlet)
- Rename parameters `-Path` → `-FilePath` and `-Parameters` → `-ArgumentList` (PSADT v4 names)
- Drop the `$dirFiles\` path prefix from `-FilePath` arguments — PSADT v4's `Start-ADTProcess` and `Start-ADTMsiProcess` resolve unqualified filenames against the Files directory automatically
- Fix an outdated comment block in `recipes/Slack/slack-msix.yaml` that described the auto-generated MSIX command using `$dirFiles` instead of `$($adtSession.DirFiles)` (the generated command itself in `napt/build/manager.py` was already correct)

Affected recipes: 7-Zip (x86/x64, EXE/MSI), Git, Chrome, VS Code, Slack (comment only).

No code changes — recipe YAML only. Sample recipes do not ship with the `napt` Python package; they live in the repo as reference templates.

## Testing
- [x] Unit tests added/updated (n/a — recipe YAML only)
- [x] Integration tests added/updated (n/a — existing 19 integration tests pass)
- [ ] Manual testing performed (recipe install commands not executed against a target machine — change is mechanical syntax correction verified against PSADT v4 reference docs at `.claude_context/PSADT Reference Documentation 11.5.25/`)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (n/a — sample recipes are reference templates, not user-facing shipped behavior; no changelog entry per Keep a Changelog scope)
- [x] Tests pass (443 unit + 19 integration)
- [x] No linting errors