### PR TITLE
chore: Add napt-reviewer agent and enable ruff D rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,7 +14,7 @@
 
 - **Python:** 3.13.5
 - **Virtual environment:** `.venv/`
-- **Shell:** PowerShell 5.1
+- **Shell:** PowerShell 7
 
 **Run Python tools directly:**
 ```powershell
@@ -26,13 +26,13 @@
 
 **Integration tests** (`tests/integration/`) require network access and download real dependencies. They are marked `@pytest.mark.integration`. Run unit tests during development; run the full suite before opening a PR.
 
-**Never use `&&`** in PowerShell 5.1. Use `;` or separate commands.
-
 ---
 
 ## Code Quality
 
 Use **ruff** + **black**. Fix all errors before committing. Never ignore errors. Configuration is in `pyproject.toml`.
+
+**Auto-formatting:** A `PostToolUse` hook (`.claude/hooks/lint_edited.py`) runs `ruff --fix` and `black` on every edit to `napt/**/*.py` and `tests/**/*.py`. Don't manually run the formatters on individual files after an Edit/Write — they've already been applied. The commands below are for bulk reformats and the final pre-commit `ruff check` verification.
 
 ```powershell
 .venv\Scripts\python.exe -m ruff check --fix napt/ tests/
@@ -125,6 +125,8 @@ All `napt/**/*.py` files require before docstring:
 
 **File order:** Shebang (if needed) → License → Module docstring → Imports → Code
 
+**Auto-injection:** A `PreToolUse` hook (`.claude/hooks/check_license_header.py`) auto-prepends the header to `Write` calls on `napt/**/*.py` when it's missing. The hook is shebang-aware (inserts after the shebang line if present). No manual action needed.
+
 ---
 
 ## Exceptions
@@ -175,103 +177,7 @@ Update docs when code changes affect user-facing behavior.
 
 ## Recipe Schema Changes
 
-When adding new recipe fields or modifying the YAML schema:
-
-### 1. Update Validation
-
-Add field to schema in `napt/validation.py`:
-
-```python
-_INSTALLED_CHECK_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
-    "new_field": (str, ["value1", "value2"], "field description"),
-    # type, allowed_values (or None), description
-}
-```
-
-### 2. Document in recipe-reference.md
-
-Add field documentation following the standard format:
-
-```markdown
-#### field_name
-
-**Type:** `string`
-**Required:** No
-**Default:** `"default_value"`
-**Allowed values:** `"value1"`, `"value2"`
-
-Description of what the field does and when to use it.
-```
-
-**Field documentation order:** Type → Required → Default (if applicable) → Allowed values (if applicable) → Description → Examples (if helpful)
-
-### 3. Categorize the new setting
-
-Every config value belongs to exactly one category. Use this flowchart:
-
-```
-Is this field set the same way across all/most recipes?
-  YES → Would an org admin configure it in org.yaml?
-    YES → Org-policy
-    NO  → Is it required for the feature to work?
-      YES → Recipe-required
-      NO  → Absent-means-skip
-  NO  → Is it specific to a discovery/build strategy?
-    YES → Strategy-specific
-    NO  → Does it depend on other config values?
-      YES → Computed/derived
-      NO  → Absent-means-skip
-```
-
-### 4. Follow the checklist for that category
-
-**Org-policy** (`run_as_account`, `log_format`, `build_types`):
-- [ ] Add to `DEFAULT_CONFIG` in `napt/config/defaults.py`
-- [ ] Add to `ORG_YAML_TEMPLATE` in `napt/config/defaults.py`
-- [ ] Add validation in `napt/validation.py`
-- [ ] Access with `config["section"]["key"]` (no fallback)
-- [ ] Document in `docs/recipe-reference.md`
-
-A test (`test_org_yaml_template_covers_all_sections`) validates that all sections
-in `DEFAULT_CONFIG` are mentioned in `ORG_YAML_TEMPLATE`.
-
-**Strategy-specific** (`timeout`, `prerelease`, `method`):
-- [ ] Add module constant `_DEFAULT_X` at top of the strategy module
-- [ ] Access with `source.get("key", _DEFAULT_X)`
-- [ ] Add to strategy's `validate_config()` if required for that strategy
-- [ ] Document in `docs/recipe-reference.md`
-
-**Recipe-required** (`name`, `id`, `discovery.strategy`):
-- [ ] Add validation in `napt/validation.py` (error if missing)
-- [ ] Access with `config["key"]` (no fallback — KeyError = validation bug)
-- [ ] Document as required in `docs/recipe-reference.md`
-
-**Absent-means-skip** (`description`, `logo_path`, `notes`):
-- [ ] Access with `config.get("key")` or `if "key" in config:`
-- [ ] Add validation in `napt/validation.py` (type/value checks, not presence)
-- [ ] Document as optional in `docs/recipe-reference.md`
-
-**Computed/derived** (`RequireAdmin`, `AppScriptDate`):
-- [ ] Add logic to `_inject_dynamic_values` in `napt/config/loader.py`
-- [ ] Use provenance to detect explicit overrides vs defaults
-- [ ] Document the computed behavior in `docs/recipe-reference.md`
-
-### 5. Verify Implementation
-
-Check these files to ensure the field is actually used:
-- Search codebase: `grep -r "new_field" napt/`
-- Verify it's read from config in relevant modules
-- Check if field exists in defaults but isn't used (planned feature)
-
-### 6. Update Examples
-
-Add field to example recipes in `docs/common-tasks.md` if it's commonly used,
-or note it as optional in relevant strategy examples.
-
-**Important:** All documented fields should either:
-- Be validated in `validation.py` AND used in the code
-- Be clearly marked as planned/future functionality
-- Be removed if no longer needed
+When adding a new recipe field or modifying the YAML schema, run `/add-recipe-field <name>`. The skill walks validation (`napt/validation.py`), documentation (`docs/recipe-reference.md`), categorization (org-policy / strategy-specific / recipe-required / absent-means-skip / computed), and the per-category checklist.
 
 ---
 
@@ -285,62 +191,7 @@ See `docs/branching.md` for full workflow. PR template at `.github/PULL_REQUEST_
 
 **PRs:** Title in conventional commit format. Use `gh pr create` to create PRs from CLI. PR descriptions should describe what changed and why, not include setup instructions or how-to guides.
 
-### Release Workflow
-
-[Semver 2.0.0](https://semver.org/spec/v2.0.0.html), no "v" prefix.
-
-**Pre-release checklist:**
-- [ ] Version updated in `pyproject.toml`
-- [ ] Version updated in `napt/__init__.py`
-- [ ] `docs/changelog.md` updated following [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
-- [ ] `docs/changelog.md` has `[Unreleased]` section ready for next version
-- [ ] All tests passing
-- [ ] PR merged to main
-- [ ] Git tag created and pushed
-
-**Release steps:**
-1. Create PR `chore/prepare-release-X.Y.Z` updating versions and changelog
-2. Squash and merge
-3. Tag: `git tag -a X.Y.Z -m "Release X.Y.Z"` then `git push origin X.Y.Z`
-4. Create release: `gh release create X.Y.Z --title "NAPT X.Y.Z" --body "..."`
-
-### Release Notes Template
-
-**Title:** `NAPT {version}` (e.g., "NAPT 0.3.0")
-
-**Required sections (in order):**
-1. **Hero statement** - One sentence describing the release theme
-2. **⚠️ Breaking Changes** - With migration notes (omit if none)
-3. **✨ What's New** - Features from changelog, grouped by category
-4. **🐛 Bug Fixes** - Important fixes (omit if none)
-5. **🔗 Links** - Quick start, full changelog, documentation
-
-**Optional sections:**
-- **🚀 Quick Start** - Code examples for major new capabilities
-- **📦 What You Can Do Now** - Workflow checklist (for major releases)
-
-**Emoji categories for features:**
-- 🔨 Build & Packaging
-- 🔍 Discovery
-- 📋 Recipes/Configuration
-
-**Writing style:**
-- Use active voice and present tense
-- Be concise - summarize changelog, don't copy verbatim
-- Include code examples for major features
-- Highlight breaking changes clearly with migration instructions
-
-**What NOT to include:**
-- Internal refactorings (unless user-facing)
-- Trivial fixes (unless security/critical)
-- Work-in-progress features
-- Overly technical implementation details
-
-**Links to include:**
-- [Quick Start Guide](https://rogercibrian.github.io/notapkgtool/quick-start/)
-- [Full Changelog](https://rogercibrian.github.io/notapkgtool/changelog/)
-- [Documentation](https://rogercibrian.github.io/notapkgtool/)
-- [Sample Recipes](https://github.com/RogerCibrian/notapkgtool/tree/main/recipes)
+**Releases:** Run `/release X.Y.Z`. Phase 1 opens the release PR (version bumps in `pyproject.toml` + `napt/__init__.py`, changelog promotion). Phase 2 (after the PR is squash-merged) tags and publishes the GitHub release. The skill includes the release notes template ([Semver 2.0.0](https://semver.org/spec/v2.0.0.html), no `v` prefix).
 
 ---
 
@@ -372,49 +223,7 @@ Follow [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Focus on 
 
 ## Roadmap
 
-Update `docs/roadmap.md` when user mentions deferred features ("add to roadmap", "let's do this later").
-
-```markdown
-#### Feature Name
-
-**Status**: 💡 Idea
-**Complexity**: Low (few hours to 1 day)
-**Value**: High
-
-**Description**: One-paragraph description of what the feature does and
-why it matters. Wrap at 80 chars.
-
-**Benefits**:
-
-- Benefit 1
-- Benefit 2
-
-**Prerequisites**: (optional — external things that must exist before work starts)
-
-- Item 1
-
-**Dependencies**: (optional — NAPT features or technical blockers)
-
-- Item 1
-
-**Related**: Link or inline note (no bullet list)
-```
-
-**Field rules:**
-- Use `####` (H4) headings — no status emoji in the header
-- `**Status**`, `**Complexity**`, `**Value**` have no blank lines between them; blank line after the group
-- Complexity always includes a time estimate for active/idea entries: `Low (few hours to 1 day)`, `Medium (1-3 days)`, `High (3-5 days)`, `Very High (5-10 days)`. Omit the estimate for completed entries (e.g., just `High`)
-- `**Benefits**:` always has a blank line before the bullet list
-- `**Prerequisites**:` — things that must exist externally before starting (e.g., Azure CLI, stable schema)
-- `**Dependencies**:` — technical blockers or other NAPT features that must be built first
-- `**Related**:` — inline note or link, no bullet list
-- For completed entries use `**Changes**:` (what was done) or `**Notes**:` (implementation details) instead of Benefits
-
-Status progression: 💡 Idea → 🔬 Investigating → 📋 Ready → 🚧 In Progress → ✅ Completed
-
-**Categories:** Group by: User-Facing Features, Code Quality & Validation, Technical Enhancements.
-
-**Don't add:** Bug reports (use issues), small enhancements (just do them), vague ideas without clear value.
+When the user mentions deferred features ("add to roadmap", "let's do this later"), run `/roadmap`. The skill enforces the standard entry structure (Status / Complexity / Value / Description / Benefits / Prerequisites / Dependencies / Related), the status-progression vocabulary, and category placement (User-Facing Features / Code Quality & Validation / Technical Enhancements) in `docs/roadmap.md`.
 
 ---
 

--- a/.claude/agents/napt-reviewer.md
+++ b/.claude/agents/napt-reviewer.md
@@ -1,0 +1,139 @@
+---
+name: napt-reviewer
+description: Reviews NAPT code changes against CLAUDE.md conventions, documentation requirements, and project principles. Defaults to current branch vs main; pass `pr=<number>` to review a specific PR instead. Catches judgment-heavy rules that ruff can't enforce. Reports findings — does not modify code.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a NAPT code reviewer. Review a diff against project conventions in CLAUDE.md, documentation requirements, and project principles, then report findings. You do not modify code.
+
+## Step 1 — Determine the target
+
+The caller tells you what to review:
+
+- **Branch review (default):** all commits on the current branch that are not on `main`.
+- **PR review:** if the caller's prompt contains `pr=<N>` (or equivalent), review that PR.
+
+## Step 2 — Fetch the diff and context
+
+**Branch review:** review the full delta between `main` and the current working tree (includes uncommitted changes, so this works whether the branch has been committed yet or not):
+
+```
+git diff main
+git log main..HEAD --oneline
+git status --short
+```
+
+Use `git diff main...HEAD` (three-dot) instead only if the caller explicitly asks for "committed changes only."
+
+**PR review:**
+```
+gh pr view <N> --json title,body,baseRefName,headRefName,files
+gh pr diff <N>
+```
+
+Categorize changed files: code (`napt/**/*.py`), tests (`tests/**/*.py`), docs (`docs/**`), recipes (`recipes/**`), config (`pyproject.toml`, `.claude/**`, other).
+
+## Step 3 — Read the project rules
+
+Read both of these at runtime — they are the authoritative sources and may have changed since the last review. Do not rely on prior knowledge.
+
+- **`.claude/CLAUDE.md`** — project conventions (docstrings, logging, exceptions, scope rules, principles)
+- **`pyproject.toml`** — specifically the `[tool.ruff]` and `[tool.ruff.lint]` sections. This tells you which ruff rule categories are currently enforced mechanically (e.g. `D` for docstring mechanics under Google convention, `B` for bugbear including `B904` exception chaining, `I` for imports, `UP` for pyupgrade). You must respect this in two ways: don't flag things ruff catches, and don't suggest reverting changes made to satisfy ruff rules.
+
+## Step 4 — Review the diff
+
+Flag only real violations **in the diff**. Do not flag pre-existing issues outside the diff.
+
+**Ruff deference.** The ruff categories selected in `pyproject.toml` are enforced mechanically by lint. Two guardrails follow from that:
+
+1. **Don't flag what ruff catches.** Import order, line length, D-rule docstring mechanics, B904 exception chaining, UP rules, etc. — those are lint's job, not yours.
+2. **Don't suggest reverting changes made to satisfy ruff.** If the diff adds an `r"""` prefix, inserts a blank line after a summary, reorders imports, or otherwise looks "redundant" at a syntactic level, assume it was required by a ruff rule. Reversing it would re-trigger the violation.
+
+If you're unsure whether a syntactic reversal would re-trigger a rule, run `.venv/Scripts/python.exe -m ruff check <file>` on the changed file(s) to verify before reporting.
+
+For each category below, consult the referenced CLAUDE.md section for the authoritative rule text. Do not rely on memory — CLAUDE.md may have changed since your last run.
+
+### Code conventions (napt/**/*.py)
+
+Review the diff against the rules in these CLAUDE.md sections:
+
+- **`Docstrings`** — section order, descriptive mood, section-specific rules (`Note:` singular, `Example:` format, complex `Returns:` indentation, dataclass `Returns:` style, module docstring format)
+- **`Logging Levels`** — is each new log call at the right level for what it communicates? (main test: "what happened" vs. "how it happened")
+- **`Exceptions`** — is each `raise` using the right type for the error domain? Is public API using custom types and private helpers using built-ins?
+- **`results.py Scope`** — only public API return types allowed in `napt/results.py`
+- **`Console Output`** — ASCII-only applies to print(), logger, CLI strings (not docstrings / comments / JSON / YAML)
+
+### Project principles
+
+Review against the `Project Principles` section of CLAUDE.md. Current principles include the "NAPT does not do" list and the no-backward-compatibility rule pre-v1.0.0 — consult the section for the current authoritative text.
+
+### Test conventions (tests/**)
+
+Consult the `Docstrings` section's test-docstring guidance. Ruff D rules are disabled for tests, so docstring presence and format are your check.
+
+### Documentation compliance
+
+Judge whether the diff warrants doc and changelog updates. Consult CLAUDE.md's `Documentation` and `Changelog` sections for the authoritative file-purpose map and format rules.
+
+**Changelog (`docs/changelog.md`):**
+
+Does the change warrant a `[Unreleased]` entry?
+
+- YES: new features, CLI changes, recipe schema changes, user-visible behavior changes, bug fixes with user-visible impact
+- NO: refactors without user impact, internal test updates, doc-only changes, **recipe-only changes** (recipes don't ship in the package — standing project rule), **contributor-tooling changes** (ruff/lint config, pre-commit, CI, `.claude/`, pyproject dev-deps — the changelog is for NAPT users, not NAPT contributors)
+
+If YES and no corresponding `[Unreleased]` entry is present → `[BLOCKING]`. Don't flag borderline cases — if it isn't clearly user-facing, it doesn't need an entry.
+
+**Relevant docs:** Cross-reference the changed surface against CLAUDE.md's `Documentation` file table (index.md / quick-start.md / user-guide.md / common-tasks.md / recipe-reference.md) and flag missing updates. If `docs/index.md` changed, verify `README.md` was synced (one-way, relative links → full URLs).
+
+Missing doc updates for user-facing behavior → `[SUGGESTION]` or `[BLOCKING]` depending on prominence.
+
+### Forward-looking consequences
+
+Consider whether the changes in this diff will create future pain: maintenance burden, coupling that will be hard to unwind, API surface we will regret being locked into (especially given the pre-v1.0.0 no-backcompat rule), hard-coded choices that should be configurable, schemas or interfaces that will force a breaking migration later, abstractions that will constrain future options.
+
+Only flag concerns that follow **directly from what this diff is changing** — not unrelated hypotheticals or "you could also build X." If you can't name the specific line or construct that creates the future cost, skip it.
+
+Severity: typically `[SUGGESTION]`. Escalate to `[BLOCKING]` when the change would lock in a design that actively conflicts with stated project direction (e.g. adding backcompat fallback, adding git/CI logic to napt, introducing a result type to `results.py` that isn't a public API return).
+
+## Step 5 — Output format
+
+Group findings by severity, then by rule category. Each finding includes `file:line`, what's wrong, and a one-line fix hint.
+
+```
+[BLOCKING] <rule category> — <short description>
+  file:line — <what's wrong>
+  fix: <one-line suggestion>
+
+[SUGGESTION] <rule category> — <short description>
+  file:line — <what's wrong>
+  fix: <one-line suggestion>
+
+[NIT] <rule category> — <short description>
+  file:line — <what's wrong>
+```
+
+**Severity guidance:**
+
+- `[BLOCKING]` — project-principle violation, wrong exception type, missing changelog for a clearly user-facing change, `results.py` scope violation, ASCII rule violation in console output, backward-compat shim, git/CI logic added to napt.
+- `[SUGGESTION]` — logging level feels wrong, docstring section order off, docs could be updated but aren't strictly required, test docstring format deviation.
+- `[NIT]` — phrasing, minor inconsistency.
+
+**End with a single verdict line:**
+
+- `VERDICT: ship` — no blocking issues (suggestions/nits OK)
+- `VERDICT: revise` — one or more blocking issues, fix before merging
+
+If the diff is clean, state it explicitly: `VERDICT: ship — no findings.`
+
+## What NOT to report
+
+- Anything ruff already catches (consult `pyproject.toml` for the active rule set)
+- Reversals of changes made to satisfy ruff rules (see "Ruff deference" in Step 4)
+- Pre-existing issues outside the diff
+- Style preferences not documented in CLAUDE.md
+- Future concerns unrelated to what this diff is changing (the `Forward-looking consequences` category is only for pain that follows directly from changed lines)
+- **Any changes under `.claude/`** (hooks, skills, agents, settings, CLAUDE.md itself). These are tooling/infrastructure, not NAPT package source. CLAUDE.md's code rules apply to `napt/` — not to the Claude Code harness.
+
+Keep findings concrete, diff-scoped, and actionable.

--- a/.claude/hooks/check_license_header.py
+++ b/.claude/hooks/check_license_header.py
@@ -1,0 +1,84 @@
+"""Pre-Write hook: auto-prepend Apache 2.0 license header to napt/**/*.py.
+
+Reads the Claude Code PreToolUse JSON payload from stdin. If the tool is
+`Write` to a file under `napt/` (excluding `tests/`) and the content lacks
+the Apache 2.0 marker, rewrite `tool_input.content` with the header
+inserted before the module docstring (or after the shebang, if present).
+
+Implementation note: uses `hookSpecificOutput.updatedInput` so the Write
+proceeds with the normalized content. The model sees the tool succeed
+normally — no wasted turn.
+"""
+
+import json
+from pathlib import Path
+import sys
+
+LICENSE_MARKER = "Licensed under the Apache License, Version 2.0"
+
+LICENSE_HEADER = """# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License."""
+
+
+def needs_header(file_path: str, content: str) -> bool:
+    if not file_path.endswith(".py"):
+        return False
+    parts = Path(file_path).parts
+    if "napt" not in parts or "tests" in parts:
+        return False
+    return LICENSE_MARKER not in content
+
+
+def prepend_header(content: str) -> str:
+    """Insert LICENSE_HEADER after the shebang (if any), before everything else."""
+    if content.startswith("#!"):
+        shebang, sep, rest = content.partition("\n")
+        if sep:
+            return f"{shebang}\n{LICENSE_HEADER}\n\n{rest}"
+        # Shebang-only file with no newline — append a newline then header
+        return f"{shebang}\n{LICENSE_HEADER}\n"
+    return f"{LICENSE_HEADER}\n\n{content}"
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool_input = data.get("tool_input") or {}
+    file_path = tool_input.get("file_path") or ""
+    content = tool_input.get("content") or ""
+
+    if not needs_header(file_path, content):
+        return 0
+
+    updated_input = dict(tool_input)
+    updated_input["content"] = prepend_header(content)
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "updatedInput": updated_input,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/lint_edited.py
+++ b/.claude/hooks/lint_edited.py
@@ -1,0 +1,43 @@
+"""Post-edit hook: lint and format edited Python files in napt/ or tests/.
+
+Reads the Claude Code PostToolUse JSON payload from stdin, extracts the
+edited file path, and runs ruff --fix + black on it if it lives under
+napt/ or tests/. Silent on success; never blocks the tool call.
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+PY = ".venv/Scripts/python.exe"
+TARGET = re.compile(r"[/\\](napt|tests)[/\\].*\.py$")
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    path = (
+        data.get("tool_response", {}).get("filePath")
+        or data.get("tool_input", {}).get("file_path")
+        or ""
+    )
+    if not path or not TARGET.search(path):
+        return 0
+
+    subprocess.run(
+        [PY, "-m", "ruff", "check", "--fix", path],
+        capture_output=True,
+    )
+    subprocess.run(
+        [PY, "-m", "black", "-q", path],
+        capture_output=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,36 @@
       "Bash(python -m ruff check:*)",
       "Bash(python -m pytest:*)",
       "Bash(ruff check:*)",
-      "Bash(black:*)"
+      "Bash(black:*)",
+      "Bash(.venv/Scripts/python.exe -m pytest *)",
+      "Bash(.venv/Scripts/python.exe -m ruff check *)",
+      "Bash(.venv/Scripts/python.exe -m black *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".venv/Scripts/python.exe .claude/hooks/check_license_header.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".venv/Scripts/python.exe .claude/hooks/lint_edited.py",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "Bash(python -m ruff check:*)",
-      "Bash(python -m pytest:*)",
-      "Bash(ruff check:*)",
-      "Bash(black:*)",
-      "Bash(.venv/Scripts/python.exe -m pytest *)",
-      "Bash(.venv/Scripts/python.exe -m ruff check *)",
-      "Bash(.venv/Scripts/python.exe -m black *)"
+      "Bash(.venv/Scripts/python.exe -m pytest:*)",
+      "Bash(.venv/Scripts/python.exe -m ruff check:*)",
+      "Bash(.venv/Scripts/python.exe -m black:*)"
     ]
   },
   "hooks": {

--- a/.claude/skills/add-recipe-field/SKILL.md
+++ b/.claude/skills/add-recipe-field/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: add-recipe-field
+description: Add a new field to the NAPT recipe YAML schema. Walks through validation, documentation, categorization (org-policy / strategy-specific / required / optional / computed), and the per-category checklist.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Read Edit Write Glob Grep Bash(*python* -m *)
+argument-hint: "field name (and optionally a brief description)"
+---
+
+You are adding a new field to the NAPT recipe schema. Follow every step in order.
+
+## Step 1: Update validation
+
+Add the field to the schema in `napt/validation.py`. For installed-check fields, use the `_INSTALLED_CHECK_FIELDS` pattern:
+
+```python
+_INSTALLED_CHECK_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
+    "new_field": (str, ["value1", "value2"], "field description"),
+    # type, allowed_values (or None), description
+}
+```
+
+For other fields, add type/value validation in the appropriate `validate_*` function.
+
+## Step 2: Document in `docs/recipe-reference.md`
+
+Add field documentation following the standard format:
+
+```markdown
+#### field_name
+
+**Type:** `string`
+**Required:** No
+**Default:** `"default_value"`
+**Allowed values:** `"value1"`, `"value2"`
+
+Description of what the field does and when to use it.
+```
+
+**Field documentation order:** Type → Required → Default (if applicable) → Allowed values (if applicable) → Description → Examples (if helpful)
+
+## Step 3: Categorize the new setting
+
+Every config value belongs to exactly one category. Use this flowchart:
+
+```
+Is this field set the same way across all/most recipes?
+  YES → Would an org admin configure it in org.yaml?
+    YES → Org-policy
+    NO  → Is it required for the feature to work?
+      YES → Recipe-required
+      NO  → Absent-means-skip
+  NO  → Is it specific to a discovery/build strategy?
+    YES → Strategy-specific
+    NO  → Does it depend on other config values?
+      YES → Computed/derived
+      NO  → Absent-means-skip
+```
+
+Tell the user which category you've assigned and why.
+
+## Step 4: Follow the checklist for that category
+
+**Org-policy** (e.g., `run_as_account`, `log_format`, `build_types`):
+- [ ] Add to `DEFAULT_CONFIG` in `napt/config/defaults.py`
+- [ ] Add to `ORG_YAML_TEMPLATE` in `napt/config/defaults.py`
+- [ ] Add validation in `napt/validation.py`
+- [ ] Access with `config["section"]["key"]` (no fallback)
+- [ ] Document in `docs/recipe-reference.md`
+
+A test (`test_org_yaml_template_covers_all_sections`) validates that all sections in `DEFAULT_CONFIG` are mentioned in `ORG_YAML_TEMPLATE`.
+
+**Strategy-specific** (e.g., `timeout`, `prerelease`, `method`):
+- [ ] Add module constant `_DEFAULT_X` at top of the strategy module
+- [ ] Access with `source.get("key", _DEFAULT_X)`
+- [ ] Add to strategy's `validate_config()` if required for that strategy
+- [ ] Document in `docs/recipe-reference.md`
+
+**Recipe-required** (e.g., `name`, `id`, `discovery.strategy`):
+- [ ] Add validation in `napt/validation.py` (error if missing)
+- [ ] Access with `config["key"]` (no fallback — KeyError = validation bug)
+- [ ] Document as required in `docs/recipe-reference.md`
+
+**Absent-means-skip** (e.g., `description`, `logo_path`, `notes`):
+- [ ] Access with `config.get("key")` or `if "key" in config:`
+- [ ] Add validation in `napt/validation.py` (type/value checks, not presence)
+- [ ] Document as optional in `docs/recipe-reference.md`
+
+**Computed/derived** (e.g., `RequireAdmin`, `AppScriptDate`):
+- [ ] Add logic to `_inject_dynamic_values` in `napt/config/loader.py`
+- [ ] Use provenance to detect explicit overrides vs defaults
+- [ ] Document the computed behavior in `docs/recipe-reference.md`
+
+## Step 5: Verify implementation
+
+Check these to ensure the field is actually used:
+- Search codebase: grep for the field name in `napt/`
+- Verify it's read from config in relevant modules
+- Check if field exists in defaults but isn't used (planned feature — flag this)
+
+## Step 6: Update examples
+
+Add the field to example recipes in `docs/common-tasks.md` if it's commonly used, or note it as optional in relevant strategy examples.
+
+## Final invariants
+
+All documented fields should either:
+- Be validated in `validation.py` AND used in the code, OR
+- Be clearly marked as planned/future functionality, OR
+- Be removed if no longer needed
+
+Never leave a field that's documented but unimplemented without a "planned" note.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,8 +31,8 @@ Report which phase you detected before proceeding.
 
 3. **Run lint and tests** sequentially:
    ```
-   .venv\Scripts\python.exe -m ruff check napt/ tests/
-   .venv\Scripts\python.exe -m pytest tests/ -q
+   .venv/Scripts/python.exe -m ruff check napt/ tests/
+   .venv/Scripts/python.exe -m pytest tests/ -q
    ```
    If anything fails, stop and report. Do not continue.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: release
+description: Prepare and ship a NAPT release. Phase 1 opens the release PR (version bumps + changelog promotion). Phase 2 (after merge) tags and publishes the GitHub release. Detects phase automatically.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Glob Grep
+argument-hint: "version: X.Y.Z"
+---
+
+You are preparing a NAPT release. Semver (no `v` prefix). Follow every step in order.
+
+## Step 1: Validate argument and detect phase
+
+The user passes the target version as `X.Y.Z`. If absent, ask before proceeding.
+
+Check current state to decide which phase to run:
+- `git tag -l X.Y.Z` — does the tag already exist? If yes, stop — release already published.
+- `git branch --show-current` — current branch
+- `git log -1 --format=%s` — last commit subject
+
+**Phase 1 (open release PR):** Tag does not exist; we are on `main` or any non-release branch.
+**Phase 2 (tag and publish):** Tag does not exist; we are on `main` and the last commit subject is `chore: Prepare release X.Y.Z` (i.e., the release PR was just squash-merged).
+
+Report which phase you detected before proceeding.
+
+## Phase 1: Open the release PR
+
+1. **Verify clean state.** Run `git status`. If unstaged changes unrelated to the release exist, stop and ask the user how to handle them.
+
+2. **Check `[Unreleased]` has content.** Read `docs/changelog.md`. If the `[Unreleased]` section is empty, stop — there is nothing to release.
+
+3. **Run lint and tests** sequentially:
+   ```
+   .venv\Scripts\python.exe -m ruff check napt/ tests/
+   .venv\Scripts\python.exe -m pytest tests/ -q
+   ```
+   If anything fails, stop and report. Do not continue.
+
+4. **Create branch:** `git checkout -b chore/prepare-release-X.Y.Z`
+
+5. **Bump version in two places** — both must match exactly:
+   - `pyproject.toml` → `version = "X.Y.Z"` under `[tool.poetry]`
+   - `napt/__init__.py` → `__version__ = "X.Y.Z"`
+
+6. **Promote changelog** in `docs/changelog.md`:
+   - Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (today's date in absolute form, not "today")
+   - Insert a fresh empty `## [Unreleased]` section above it
+   - Add a comparison link at the bottom of the file: `[X.Y.Z]: https://github.com/RogerCibrian/notapkgtool/compare/PREV...X.Y.Z` (PREV = the previous release tag)
+
+7. **Stage and commit** specific files only:
+   ```
+   git add pyproject.toml napt/__init__.py docs/changelog.md
+   git commit -m "chore: Prepare release X.Y.Z"
+   ```
+
+8. **Push and open PR.** Push the branch, then open the PR using the project template at `.github/PULL_REQUEST_TEMPLATE.md`. Read that file first and follow its sections (Description / Motivation / Changes / Testing / Checklist).
+
+   ```
+   git push -u origin chore/prepare-release-X.Y.Z
+   gh pr create --title "chore: Prepare release X.Y.Z" --body "$(cat <<'EOF'
+   ## Description
+   Release PR for NAPT X.Y.Z. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[X.Y.Z]`, and adds a fresh empty `[Unreleased]` section.
+
+   ## Motivation
+   Cuts the X.Y.Z release. Squash-merge this PR, then `/release X.Y.Z` again to tag and publish.
+
+   ## Changes
+   - Bump `pyproject.toml` version to X.Y.Z
+   - Bump `napt/__init__.py` `__version__` to X.Y.Z
+   - Promote `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` in `docs/changelog.md`
+   - Add comparison link `[X.Y.Z]: ...compare/PREV...X.Y.Z`
+
+   ## Testing
+   - [x] Unit tests pass
+   - [x] Integration tests pass (run via `pytest tests/`)
+   - [x] Manual testing performed (n/a — release prep only, no code changes)
+
+   ## Checklist
+   - [x] Code follows project conventions
+   - [x] Documentation updated (changelog promoted)
+   - [x] Tests pass
+   - [x] No linting errors
+   EOF
+   )"
+   ```
+
+   Substitute `X.Y.Z` with the real version and `YYYY-MM-DD` with today's date in the heredoc before running. Pull the bullet content for the **Changes** section from the actual `[X.Y.Z]` changelog block — replace the boilerplate above with one line per real bullet if there are notable user-facing changes worth surfacing in the PR body.
+
+9. **Report PR URL.** Tell the user to squash-merge, then re-run `/release X.Y.Z` for Phase 2.
+
+## Phase 2: Tag and publish
+
+1. **Pull latest main:** `git pull origin main`
+
+2. **Verify version files.** Read `pyproject.toml` and `napt/__init__.py` to confirm both show X.Y.Z. If not, stop and report.
+
+3. **Tag and push the tag:**
+   ```
+   git tag -a X.Y.Z -m "Release X.Y.Z"
+   git push origin X.Y.Z
+   ```
+
+4. **Build release notes** following the template below. Read the `[X.Y.Z]` section of `docs/changelog.md` for source content.
+
+5. **Create the GitHub release:**
+   ```
+   gh release create X.Y.Z --title "NAPT X.Y.Z" --body "$(cat <<'EOF'
+   <release notes here>
+   EOF
+   )"
+   ```
+
+6. **Report the release URL.**
+
+## Release Notes Template
+
+**Title:** `NAPT X.Y.Z`
+
+**Required sections (in order):**
+1. **Hero statement** — one sentence describing the release theme
+2. **⚠️ Breaking Changes** — with migration notes (omit if none)
+3. **✨ What's New** — features from changelog, grouped by category
+4. **🐛 Bug Fixes** — important fixes (omit if none)
+5. **🔗 Links** — quick start, full changelog, documentation
+
+**Optional sections:**
+- **🚀 Quick Start** — code examples for major new capabilities
+- **📦 What You Can Do Now** — workflow checklist (for major releases)
+
+**Emoji categories for features:**
+- 🔨 Build & Packaging
+- 🔍 Discovery
+- 📋 Recipes / Configuration
+
+**Writing style:**
+- Active voice, present tense
+- Concise — summarize the changelog, don't copy verbatim
+- Include code examples for major features
+- Highlight breaking changes clearly with migration instructions
+
+**Don't include:**
+- Internal refactorings (unless user-facing)
+- Trivial fixes (unless security/critical)
+- Work-in-progress features
+- Overly technical implementation details
+
+**Links to include (always):**
+- [Quick Start Guide](https://rogercibrian.github.io/notapkgtool/quick-start/)
+- [Full Changelog](https://rogercibrian.github.io/notapkgtool/changelog/)
+- [Documentation](https://rogercibrian.github.io/notapkgtool/)
+- [Sample Recipes](https://github.com/RogerCibrian/notapkgtool/tree/main/recipes)

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: roadmap
+description: Add or update an entry in docs/roadmap.md. Enforces the standard structure (Status / Complexity / Value / Description / Benefits / Prerequisites / Dependencies / Related) and category placement.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Read Edit Write Glob Grep
+argument-hint: "feature name and brief description"
+---
+
+You are adding or updating a roadmap entry in `docs/roadmap.md`. Follow the structure exactly.
+
+## Step 1: Decide the action
+
+- **Add new entry:** the user described a deferred feature ("add to roadmap", "let's do this later")
+- **Update existing entry:** the user is changing status, complexity, or scope of something already in the roadmap
+
+If unclear, read `docs/roadmap.md` first and ask.
+
+## Step 2: Determine the category
+
+Group entries by:
+- **User-Facing Features** — things end users will notice
+- **Code Quality & Validation** — internal correctness improvements
+- **Technical Enhancements** — perf, infra, refactoring with technical payoff
+
+If the feature doesn't clearly belong to any category, ask before assuming.
+
+## Step 3: Write the entry
+
+Use this exact format:
+
+```markdown
+#### Feature Name
+
+**Status**: 💡 Idea
+**Complexity**: Low (few hours to 1 day)
+**Value**: High
+
+**Description**: One-paragraph description of what the feature does and
+why it matters. Wrap at 80 chars.
+
+**Benefits**:
+
+- Benefit 1
+- Benefit 2
+
+**Prerequisites**: (optional — external things that must exist before work starts)
+
+- Item 1
+
+**Dependencies**: (optional — NAPT features or technical blockers)
+
+- Item 1
+
+**Related**: Link or inline note (no bullet list)
+```
+
+## Field rules
+
+- Use `####` (H4) headings — **no status emoji in the header**
+- `**Status**`, `**Complexity**`, `**Value**` have no blank lines between them; blank line after the group
+- Complexity always includes a time estimate for active/idea entries:
+  - `Low (few hours to 1 day)`
+  - `Medium (1-3 days)`
+  - `High (3-5 days)`
+  - `Very High (5-10 days)`
+  - Omit the estimate for completed entries (e.g., just `High`)
+- `**Benefits**:` always has a blank line before the bullet list
+- `**Prerequisites**:` — things that must exist externally before starting (e.g., Azure CLI, stable schema)
+- `**Dependencies**:` — technical blockers or other NAPT features that must be built first
+- `**Related**:` — inline note or link, no bullet list
+- For completed entries, use `**Changes**:` (what was done) or `**Notes**:` (implementation details) instead of Benefits
+
+## Status progression
+
+💡 Idea → 🔬 Investigating → 📋 Ready → 🚧 In Progress → ✅ Completed
+
+## Don't add
+
+- Bug reports (use GitHub issues)
+- Small enhancements that could just be done now
+- Vague ideas without a clear value statement
+
+## Step 4: Insert in the right place
+
+- New entries: place at the bottom of the appropriate category section
+- Status changes: edit in place
+- Completed entries: leave in their category but update Status, swap Benefits → Changes/Notes, drop the Complexity time estimate
+
+## Step 5: Confirm
+
+Tell the user: which category, what status, and the exact heading you used. Don't over-explain — a one-line summary is enough.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: ship
+description: Wrap up current work - lint, test, branch (if needed), update docs/changelog, commit, and create PR
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Glob Grep
+argument-hint: "commit type: feat|fix|refactor|docs|test|chore"
+---
+
+You are shipping the current work as a PR. Follow every step in order.
+
+## Step 1: Assess current state
+
+Run these in parallel:
+- `git branch --show-current` to check if on a feature branch or main
+- `git status` to see what's changed (never use -uall)
+- `git diff --stat` to understand scope of changes
+
+Tell the user what you found: branch name, number of files changed, and a
+one-line summary of the changes.
+
+## Step 2: Lint and format
+
+Run these sequentially using the platform's Python path (`.venv/Scripts/python.exe`
+on Windows, `.venv/bin/python` on macOS/Linux):
+```
+python -m ruff check --fix napt/ tests/
+python -m black napt/ tests/
+python -m ruff check napt/ tests/
+```
+
+If ruff or black made changes, tell the user what was fixed.
+If any lint errors remain that --fix couldn't resolve, stop and report them.
+
+## Step 3: Run tests
+
+```
+python -m pytest tests/ -q
+```
+
+Run the full test suite including integration tests. If tests fail, stop and
+report the failures. Do not continue.
+
+## Step 4: Create branch (if needed)
+
+If already on a feature branch (not `main`), skip this step.
+
+If on `main`:
+1. Determine the commit type from the changes (feat, fix, refactor, docs,
+   test, chore). If the user passed an argument, use that as the type.
+2. Pick a descriptive branch name following docs/branching.md conventions:
+   - Prefix: `feature/`, `bugfix/`, `docs/`, `refactor/`, `test/`, `chore/`
+   - Lowercase with hyphens, 3-6 words, descriptive not generic
+3. Create the branch: `git checkout -b <type>/<name>`
+4. Tell the user the branch name you chose.
+
+## Step 5: Update docs and changelog
+
+Check whether any changes affect user-facing behavior by reviewing the diff.
+
+If user-facing changes exist:
+1. Read `docs/changelog.md`
+2. Add entries under `[Unreleased]` following Keep a Changelog 1.1.0 format
+   (Added/Changed/Fixed/Removed). Focus on user impact, not implementation.
+3. Check if `docs/user-guide.md`, `docs/common-tasks.md`, or
+   `docs/recipe-reference.md` need updates based on the CLAUDE.md rules.
+   Update them if needed.
+
+If changes are purely internal (refactor, test, chore with no user impact),
+skip changelog and doc updates. Tell the user you skipped this and why.
+
+## Step 6: Commit
+
+1. Stage all relevant changed files by name (not `git add -A`). Never stage
+   .env, credentials, or secrets files.
+2. Write a commit message in conventional commit format per CLAUDE.md:
+   - `type: Subject` (imperative, capitalized, under 50 chars, no period)
+   - Use a HEREDOC for the message
+3. Multiple commits are fine if it makes sense to separate them logically
+   (e.g., a refactor commit + a feature commit, or code changes separate
+   from doc updates). Use your judgment.
+4. Commit.
+
+## Step 7: Push and create PR
+
+1. Push the branch: `git push -u origin <branch-name>`
+2. Create the PR using `gh pr create` with:
+   - Title in conventional commit format (same as commit subject)
+   - Body following the PR template structure (Description, Motivation,
+     Changes, Testing, Checklist). Use a HEREDOC for the body.
+   - PR descriptions should describe what changed and why, not include
+     setup instructions or how-to guides.
+3. Report the PR URL to the user.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -3,7 +3,7 @@ name: ship
 description: Wrap up current work - lint, test, branch (if needed), update docs/changelog, commit, and create PR
 disable-model-invocation: true
 user-invocable: true
-allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Glob Grep
+allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Glob Grep Agent
 argument-hint: "commit type: feat|fix|refactor|docs|test|chore"
 ---
 
@@ -21,12 +21,11 @@ one-line summary of the changes.
 
 ## Step 2: Lint and format
 
-Run these sequentially using the platform's Python path (`.venv/Scripts/python.exe`
-on Windows, `.venv/bin/python` on macOS/Linux):
+Run these sequentially:
 ```
-python -m ruff check --fix napt/ tests/
-python -m black napt/ tests/
-python -m ruff check napt/ tests/
+.venv/Scripts/python.exe -m ruff check --fix napt/ tests/
+.venv/Scripts/python.exe -m black napt/ tests/
+.venv/Scripts/python.exe -m ruff check napt/ tests/
 ```
 
 If ruff or black made changes, tell the user what was fixed.
@@ -35,7 +34,7 @@ If any lint errors remain that --fix couldn't resolve, stop and report them.
 ## Step 3: Run tests
 
 ```
-python -m pytest tests/ -q
+.venv/Scripts/python.exe -m pytest tests/ -q
 ```
 
 Run the full test suite including integration tests. If tests fail, stop and
@@ -69,7 +68,39 @@ If user-facing changes exist:
 If changes are purely internal (refactor, test, chore with no user impact),
 skip changelog and doc updates. Tell the user you skipped this and why.
 
-## Step 6: Commit
+## Step 6: Run napt-reviewer
+
+Invoke the `napt-reviewer` subagent via the Agent tool to review the full
+branch delta against CLAUDE.md conventions, docs/changelog requirements, and
+project principles (including forward-looking consequences).
+
+- `subagent_type`: `napt-reviewer`
+- `description`: "Review branch against CLAUDE.md"
+- `prompt`: "Review the current branch against CLAUDE.md conventions. This
+  is a pre-commit review — uncommitted changes in the working tree are part
+  of what will ship. Use `git diff main` to capture the full delta including
+  uncommitted changes. Report findings with severity and a final verdict."
+
+**Echo the reviewer's full output verbatim** as your own text output before
+doing anything else. The subagent's output renders as a collapsed box in the
+terminal by default, so the user can't see findings without expanding it.
+Repeating the output as main-thread text makes it visible inline. Preserve
+the reviewer's severity grouping and final verdict line.
+
+Then, based on the findings:
+
+- **If the review is entirely clean** (no `[BLOCKING]`, no `[SUGGESTION]`,
+  no `[NIT]`, and verdict is `ship`), continue to Step 7 without prompting.
+- **If the reviewer returns any finding at any severity** — including
+  `[NIT]` — STOP and ask the user how to proceed. Do not auto-fix, do not
+  auto-commit, do not continue to Step 7. Ask the user per-finding or
+  collectively: "How would you like to proceed — address any of these before
+  committing, skip them, or override?" Wait for their direction.
+
+Never attempt to fix findings on the user's behalf without explicit
+instruction. The reviewer surfaces; the user decides — including on nits.
+
+## Step 7: Commit
 
 1. Stage all relevant changed files by name (not `git add -A`). Never stage
    .env, credentials, or secrets files.
@@ -81,7 +112,7 @@ skip changelog and doc updates. Tell the user you skipped this and why.
    from doc updates). Use your judgment.
 4. Commit.
 
-## Step 7: Push and create PR
+## Step 8: Push and create PR
 
 1. Push the branch: `git push -u origin <branch-name>`
 2. Create the PR using `gh pr create` with:

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NAPT - Not a Pkg Tool
+"""Python-based CLI tool for Windows application packaging and Intune deployment.
 
-A Python-based CLI tool for automating Windows application packaging and
-deployment to Microsoft Intune using PSAppDeployToolkit (PSADT).
+Uses PSAppDeployToolkit (PSADT) to automate packaging and deployment to
+Microsoft Intune.
 
 NAPT provides:
 

--- a/napt/config/loader.py
+++ b/napt/config/loader.py
@@ -113,6 +113,7 @@ from napt.exceptions import ConfigError
 @dataclass(frozen=True)
 class LoadContext:
     """Metadata describing how the config was resolved.
+
     Useful for debugging and logging.
     """
 

--- a/napt/discovery/api_github.py
+++ b/napt/discovery/api_github.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""GitHub API discovery strategy for NAPT.
+r"""GitHub API discovery strategy for NAPT.
 
 This is a VERSION-FIRST strategy that queries the GitHub API to get version
 and download URL WITHOUT downloading the installer. This enables fast version
@@ -160,7 +160,7 @@ _DEFAULT_PRERELEASE = False
 
 
 class ApiGithubStrategy:
-    """Discovery strategy for GitHub releases.
+    r"""Discovery strategy for GitHub releases.
 
     Configuration example:
         source:
@@ -176,12 +176,12 @@ class ApiGithubStrategy:
         self,
         app_config: dict[str, Any],
     ) -> RemoteVersion:
-        """Fetch latest release from GitHub API without downloading
-        (version-first path).
+        r"""Fetches latest release from GitHub API without downloading.
 
-        This method queries the GitHub API for the latest release and extracts
-        the version from the tag name and the download URL from matching assets.
-        If the version matches cached state, the download can be skipped entirely.
+        Version-first path: queries the GitHub API for the latest release and
+        extracts the version from the tag name and the download URL from
+        matching assets. If the version matches cached state, the download
+        can be skipped entirely.
 
         Args:
             app_config: App configuration containing discovery.repo and

--- a/napt/discovery/api_json.py
+++ b/napt/discovery/api_json.py
@@ -203,12 +203,11 @@ class ApiJsonStrategy:
         self,
         app_config: dict[str, Any],
     ) -> RemoteVersion:
-        """Query JSON API for version and download URL without downloading
-        (version-first path).
+        """Queries JSON API for version and download URL without downloading.
 
-        This method calls a JSON API, extracts version and download URL using
-        JSONPath expressions. If the version matches cached state, the download
-        can be skipped entirely.
+        Version-first path: calls a JSON API, extracts version and download URL
+        using JSONPath expressions. If the version matches cached state, the
+        download can be skipped entirely.
 
         Args:
             app_config: App configuration containing discovery.api_url,

--- a/napt/discovery/web_scrape.py
+++ b/napt/discovery/web_scrape.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Web scraping discovery strategy for NAPT.
+r"""Web scraping discovery strategy for NAPT.
 
 This is a VERSION-FIRST strategy that scrapes vendor download pages to find
 download links and extract version information from those links. This enables
@@ -198,12 +198,12 @@ class WebScrapeStrategy:
         self,
         app_config: dict[str, Any],
     ) -> RemoteVersion:
-        """Scrape download page for version and URL without downloading
-        (version-first path).
+        r"""Scrapes download page for version and URL without downloading.
 
-        This method scrapes an HTML page, finds a download link using CSS selector
-        or regex, extracts the version from that link, and returns version info.
-        If the version matches cached state, the download can be skipped entirely.
+        Version-first path: scrapes an HTML page, finds a download link using a
+        CSS selector or regex, extracts the version from that link, and returns
+        version info. If the version matches cached state, the download can be
+        skipped entirely.
 
         Args:
             app_config: App configuration containing discovery.page_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,15 @@ line-length = 88
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "B", "UP"]
+select = ["E", "F", "I", "B", "UP", "D"]
 extend-ignore = ["E203", "E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"tests/**" = ["D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.isort]
 known-first-party = ["napt"]


### PR DESCRIPTION
## Description
Adds the Claude Code project workflow for NAPT: hooks, user-invocable skills, a project-level reviewer subagent, a slimmed `CLAUDE.md`, an initial permissions allowlist, and ruff D-rule docstring linting under Google convention. Establishes the preview/pause pattern where the subagent surfaces findings and the human decides how to act on them.

## Motivation
Before this PR there was no project-level Claude Code configuration beyond a single CLAUDE.md file. Mechanical enforcement was inconsistent (ruff ran on demand, no auto-format on edit, no license-header injection), workflow-specific content bloated CLAUDE.md, and there was no automated check for judgment-heavy rules (docstring semantics, logging level choice, exception type choice, `results.py` scope, ASCII console output, documentation compliance, forward-looking consequences). This PR addresses all of that in one place.

## Changes

**Hooks (`.claude/hooks/`):**
- `lint_edited.py` — PostToolUse on Edit/Write/MultiEdit; runs `ruff --fix` and `black` on edits under `napt/` or `tests/`. Silent on success, never blocks.
- `check_license_header.py` — PreToolUse on Write; auto-prepends the Apache 2.0 header to `napt/**/*.py` when missing (shebang-aware). Uses `hookSpecificOutput.updatedInput` so the Write proceeds with the normalized content — no retry loop.

**Skills (`.claude/skills/`):**
- `/ship` — lint, test, branch, update docs/changelog, run `napt-reviewer`, commit, push, open PR. Step 6 echoes reviewer output inline (Claude Code's default renders subagent output collapsed) and pauses for user input on any finding at any severity.
- `/release X.Y.Z` — two-phase release workflow (PR → tag/publish). Phase 1 bumps `pyproject.toml` and `napt/__init__.py`, promotes `[Unreleased]`, opens the release PR. Phase 2 tags and publishes after the squash-merge.
- `/add-recipe-field` — walkthrough for recipe YAML schema changes (validation, documentation, categorization, per-category checklist).
- `/roadmap` — enforces `docs/roadmap.md` entry structure and category placement.

**Subagent (`.claude/agents/`):**
- `napt-reviewer` — reads CLAUDE.md and `pyproject.toml` at runtime as single sources of truth. Reviews current branch vs `main` by default (or `pr=<N>` for a specific PR). Covers docstring semantics, logging levels, exception types, `results.py` scope, ASCII rule, project principles, documentation compliance (changelog + docs), and forward-looking consequences. Reports findings with severity tags; does not modify code.

**`CLAUDE.md`:**
- Shell updated from PowerShell 5.1 to 7 (drops the "never use `&&`" rule).
- Recipe-schema, release, and roadmap sections removed (moved into their respective skills).
- Documents both hooks and the ruff D-rule config.
- Net: -192 lines (~41% smaller).

**Config:**
- `pyproject.toml`: adds `D` to ruff's `select` with `[tool.ruff.lint.pydocstyle] convention = "google"` and `"tests/**" = ["D"]` per-file-ignore. Fixes the 10 resulting D-rule violations in `napt/` (D205, D301, D415) as one-off docstring cleanup.
- `.claude/settings.json`: `permissions.allow` entries for the venv Python invocations used by `pytest`, `ruff check`, and `black` (`:*` suffix form); wires both hooks.

## Testing
- [x] Unit tests added/updated — no test changes needed; existing suite exercises the touched `napt/` modules
- [x] Integration tests added/updated — n/a
- [x] Manual testing performed — `napt-reviewer` was smoke-tested twice (first run exposed three prompt gaps including weak handling of ruff D301 semantics; second run after prompt tightening returned clean). Full `/ship` flow was exercised end-to-end on this branch.

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated — CLAUDE.md restructured to match new skill/hook layout; no user-facing docs needed (contributor-tooling scope)
- [x] Tests pass — 443 tests pass (full suite including integration)
- [x] No linting errors — `ruff check napt/ tests/` clean under the new config