### PR TITLE
refactor: Unify discovery strategy contract

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,13 @@
 
 **NAPT does not:** Git operations, PR creation, CI/CD workflow logic. Don't add `--create-pr` flags or git commands.
 
+**Audience — CLI tool, not a library:** NAPT is a CLI consumed via `napt <command>`. Write docstrings, examples, and architectural decisions for two audiences only:
+
+1. **CLI users** — interact via `napt <command>`; never import NAPT in their own code.
+2. **Contributors** — work inside this codebase.
+
+Don't write framing like "third-party extension API," "implementing custom strategies in your project," or "as a library user." Code is organized for internal clarity and CLI ergonomics, not for external Python consumers. Public Python entry points (e.g. `discover_recipe`, `validate_recipe`) exist for testing and scripting but are not a stability contract — don't add backwards-compat shims, plugin systems, or extension hooks aimed at downstream Python users.
+
 **No backward compatibility (pre-release):** Implement cleanest solutions directly. Remove deprecated code immediately. No migration paths or fallback logic. After v1.0.0, standard semver applies.
 
 ---
@@ -93,6 +100,10 @@ Don't repeat the class name (DiscoverResult) - mkdocstrings extracts it from the
 **Module docstrings:** Required for all modules. First line is summary, then blank line, then details.
 
 **Test docstrings:** Use `"""Tests that <condition>."""` format. Keep brief.
+
+**Cross-references:** Use Markdown reference links — `[Display Name][full.dotted.path]` — never Sphinx-style (`:class:`, `:func:`, `:meth:`, `:mod:`). Sphinx syntax renders as literal text in mkdocstrings. The short form `[Name][]` only works when `Name` is itself the full identifier; for project symbols always use the full dotted path. For stdlib types, don't link — wrap in double backticks (e.g. `` ``typing.Protocol`` ``).
+
+**No meta-commentary in docstrings or code.** Describe the subject, not the writing. Skip defensive denials ("this is internal, not a public API"), syntax explanations ("the reference above uses the short form because..."), and any sentence that explains how you wrote rather than what the thing is.
 
 **Validate rendering:**
 ```powershell

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -82,7 +82,7 @@ Result (dataclass)
 
 ## Key Concepts
 
-- **Discovery Strategies:** Protocol-based, stateless, registered in global registry. Two paths: version-first (api_github, api_json, web_scrape) and file-first (url_download with ETag)
+- **Discovery Strategies:** Protocol-based, stateless, registered in global registry (api_github, api_json, web_scrape). All return a `RemoteVersion` from configuration alone. The orchestrator runs the result through `resolve_with_cache` to skip the download when the version is unchanged. `url_download` is a separate flow (not a registered strategy) because it must download the file to determine the version.
 - **Configuration:** 3-layer system (org → vendor → recipe) with deep merging
 - **State Management:** Tracks versions in `state/versions.json` for caching
 - **Exceptions:** All NAPT domain errors use custom exceptions inheriting from `NAPTError` (ConfigError, NetworkError, PackagingError) - allows catching all NAPT errors or specific types

--- a/napt/discovery/__init__.py
+++ b/napt/discovery/__init__.py
@@ -12,73 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Discovery strategies for NAPT.
+"""Discovery package: registry, strategies, and orchestration.
 
-This package provides a pluggable strategy pattern for discovering application
-versions and downloading installers from various sources. Strategies are divided
-into two types: version-first (can determine version without downloading) and
-file-first (must download to extract version).
+Two flows feed into
+[discover_recipe][napt.discovery.manager.discover_recipe]:
 
-Strategy Pattern:
-    Discovery strategies implement one of two approaches:
+- **Registered strategies** (api_github, api_json, web_scrape) implement
+    [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy] — they
+    discover a version and its download URL without touching the file.
+    The orchestrator runs the result through
+    [resolve_with_cache][napt.discovery.base.resolve_with_cache] to
+    decide whether to skip the download.
+- **url_download** is a separate flow at
+    [run_url_download][napt.discovery.url_download.run_url_download]. It
+    downloads the file with HTTP conditional requests and extracts the
+    version from the file's metadata. It is not a registered strategy
+    because it cannot determine the version without the file.
 
-VERSION-FIRST (api_github, api_json, web_scrape):
-  - Implement get_version_info() -> RemoteVersion
-  - Can determine version and download URL without downloading installer
-  - Core orchestration checks version first, then decides whether to download
-  - Enables zero-bandwidth update checks when version unchanged
+The discovery orchestrator dispatches to one of the two flows based
+on the recipe's ``discovery.strategy`` value.
 
-FILE-FIRST (url_download):
-  - Implement discover_version() -> tuple[str, str, Path, str, dict]
-  - Must download installer to extract version from file metadata
-  - Uses HTTP ETag conditional requests for efficiency
-
-The strategy registry allows dynamic lookup based on the strategy name
-in the recipe configuration.
-
-Available Strategies:
-    url_download : UrlDownloadStrategy (FILE-FIRST)
-        Download from a fixed URL and extract version from the file itself.
-        Supports MSI ProductVersion extraction. Uses ETag caching.
-    api_github : ApiGithubStrategy (VERSION-FIRST)
-        Fetch from GitHub releases API and extract version from tags.
-        Fast API-based version checks (~100ms).
-    api_json : ApiJsonStrategy (VERSION-FIRST)
-        Query JSON API endpoints for version and download URL.
-        Fast API-based version checks (~100ms).
-    web_scrape : WebScrapeStrategy (VERSION-FIRST)
-        Scrape vendor download pages to find links and extract versions.
-        Works for vendors without APIs or static URLs.
-
-Example:
-    Register and use a custom strategy:
-
-        from napt.discovery import get_strategy
-        from pathlib import Path
-
-        # Get a strategy by name (auto-registered on import)
-        strategy = get_strategy("url_download")
-
-        # Use it to discover a version
-        app_config = {
-            "source": {
-                "strategy": "url_download",
-                "url": "https://example.com/app.msi",
-            }
-        }
-
-        version, source, file_path, sha256, headers = strategy.discover_version(
-            app_config, Path("./downloads")
-        )
-        print(f"Version: {version}")
+Built-in strategies:
+    - [api_github][napt.discovery.api_github.ApiGithubStrategy]:
+        queries the GitHub releases API for the latest tag.
+    - [api_json][napt.discovery.api_json.ApiJsonStrategy]:
+        extracts version and download URL from a JSON endpoint.
+    - [web_scrape][napt.discovery.web_scrape.WebScrapeStrategy]:
+        parses a vendor download page for both fields.
 
 """
 
-# Import strategy modules to trigger self-registration
 from . import (
     api_github,  # noqa: F401
     api_json,  # noqa: F401
-    url_download,  # noqa: F401
     web_scrape,  # noqa: F401
 )
 from .base import DiscoveryStrategy, get_strategy

--- a/napt/discovery/api_github.py
+++ b/napt/discovery/api_github.py
@@ -12,132 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""GitHub API discovery strategy for NAPT.
+r"""GitHub releases discovery strategy.
 
-This is a VERSION-FIRST strategy that queries the GitHub API to get version
-and download URL WITHOUT downloading the installer. This enables fast version
-checks and efficient caching.
+Queries the GitHub releases API for the latest tag and the download URL
+of a matching asset. The version comes from the release tag (parsed
+with a regex); the download URL comes from the first asset whose
+filename matches ``asset_pattern``.
 
-Key Advantages:
-
-- Fast version discovery (GitHub API call ~100ms)
-- Can skip downloads entirely when version unchanged
-- Direct access to latest releases via stable GitHub API
-- Version extraction from Git tags (semantic versioning friendly)
-- Asset pattern matching for multi-platform releases
-- Optional authentication for higher rate limits
-- No web scraping required
-- Ideal for CI/CD with scheduled checks
-
-Supported Version Extraction:
-
-- Tag-based: Extract version from release tag names
-    - Supports named capture groups: (?P<version>...)
-    - Default pattern strips "v" prefix: v1.2.3 -> 1.2.3
-    - Falls back to full tag if no pattern match
-
-Use Cases:
-
-- Open-source projects (Git, VS Code, Node.js, etc.)
-- Projects with GitHub releases (Firefox, Chrome alternatives)
-- Vendors who publish installers as release assets
-- Projects with semantic versioned tags
-- CI/CD pipelines with frequent version checks
-
-Recipe Configuration:
+Recipe Example:
     ```yaml
-    source:
-        strategy: api_github
-        repo: "git-for-windows/git"                    # Required: owner/repo
-        asset_pattern: "Git-.*-64-bit\\.exe$"          # Required: regex for asset
-        version_pattern: "v?([0-9.]+)"                 # Optional: version extraction
-        prerelease: false                              # Optional: include prereleases
-        token: "${GITHUB_TOKEN}"                       # Optional: auth token
+    discovery:
+      strategy: api_github
+      repo: "git-for-windows/git"            # required, "owner/name"
+      asset_pattern: "Git-.*-64-bit\\.exe$"  # required, regex on asset filename
+      version_pattern: "v?([0-9.]+)"         # optional, default strips "v"
+      prerelease: false                      # optional, default false
+      token: "${GITHUB_TOKEN}"               # optional, supports env expansion
     ```
 
 Configuration Fields:
-
-- **repo** (str, required): GitHub repository in "owner/name" format
-    (e.g., "git-for-windows/git")
-- **asset_pattern** (str, required): Regular expression to match asset
-    filename. If multiple assets match, the first match is used. Example:
-    ".*-x64\\.msi$" matches assets ending with "-x64.msi"
-- **version_pattern** (str, optional): Regular expression to extract version
-    from the release tag name. Use a named capture group (?P<version>...) or
-    the entire match. Default: "v?([0-9.]+)" strips optional "v" prefix.
-    Example: "release-([0-9.]+)" for tags like "release-1.2.3".
-    - **prerelease** (bool, optional): If True, include pre-release versions. If False
-      (default), only stable releases are considered. Uses GitHub's prerelease flag.
-    - **token** (str, optional): GitHub personal access token for authentication.
-      Increases rate limit from 60 to 5000 requests per hour. Can use environment
-      variable substitution: "${GITHUB_TOKEN}". No special permissions needed for
-      public repositories.
-
-Error Handling:
-
-- ValueError: Missing or invalid configuration fields
-- RuntimeError: API failures, no releases, no matching assets
-- Errors are chained with 'from err' for better debugging
-
-Rate Limits:
-
-- Unauthenticated: 60 requests/hour per IP
-- Authenticated: 5000 requests/hour per token
-- Tip: Use a token for production use or frequent checks
-
-Example:
-    In a recipe YAML:
-        ```yaml
-        apps:
-          - name: "Git for Windows"
-            id: "git"
-            source:
-              strategy: api_github
-              repo: "git-for-windows/git"
-              asset_pattern: "Git-.*-64-bit\\.exe$"
-        ```
-
-    From Python (version-first approach):
-        ```python
-        from napt.discovery.api_github import ApiGithubStrategy
-        from napt.download import download_file
-
-        strategy = ApiGithubStrategy()
-        app_config = {
-            "source": {
-                "repo": "git-for-windows/git",
-                "asset_pattern": ".*-64-bit\\.exe$",
-            }
-        }
-
-        # Get version WITHOUT downloading
-        version_info = strategy.get_version_info(app_config)
-        print(f"Latest version: {version_info.version}")
-
-        # Download only if needed
-        if need_to_download:
-            result = download_file(
-                version_info.download_url, Path("./downloads/my-app")
-            )
-            print(f"Downloaded to {result.file_path}")
-        ```
-
-    From Python (using core orchestration):
-        ```python
-        from pathlib import Path
-        from napt.discovery import discover_recipe
-
-        # Automatically uses version-first optimization
-        result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
-        print(f"Version {result.version} at {result.file_path}")
-        ```
+    - **repo** (required): GitHub repo as ``"owner/name"``.
+    - **asset_pattern** (required): Regex matched against asset filename.
+        First match wins. Case-sensitive by default; prefix with ``(?i)``
+        for case-insensitive matching.
+    - **version_pattern** (optional): Regex for extracting the version
+        from the release tag. Uses a named group ``(?P<version>...)`` or
+        capture group 1 if present, otherwise the full match. Default:
+        ``v?([0-9.]+)``.
+    - **prerelease** (optional, default false): When true, includes
+        pre-release versions; otherwise the latest release must be stable.
+    - **token** (optional): GitHub personal access token. Raises the API
+        rate limit from 60 to 5000 requests/hour. Supports ``${ENV_VAR}``
+        expansion. Public repos do not require any special permissions.
 
 Note:
-    Version discovery via API only (no download required).
-    Core orchestration automatically skips download if version unchanged.
-    The GitHub API is stable and well-documented. Releases are fetched in order
-    (latest first). Asset matching is case-sensitive by default (use (?i) for
-    case-insensitive). Consider url_download if you need a direct download URL instead.
+    GitHub returns the most recent release first. If no asset matches,
+    or the latest release is a pre-release while ``prerelease: false``,
+    discovery raises an error rather than walking back through history.
 
 """
 
@@ -160,55 +71,31 @@ _DEFAULT_PRERELEASE = False
 
 
 class ApiGithubStrategy:
-    r"""Discovery strategy for GitHub releases.
+    """Discovery strategy for GitHub releases."""
 
-    Configuration example:
-        source:
-          strategy: api_github
-          repo: "owner/repository"
-          asset_pattern: ".*\\.msi$"
-          version_pattern: "v?([0-9.]+)"
-          prerelease: false
-          token: "${GITHUB_TOKEN}"
-    """
+    def discover(self, app_config: dict[str, Any]) -> RemoteVersion:
+        r"""Discovers the latest GitHub release version and asset download URL.
 
-    def get_version_info(
-        self,
-        app_config: dict[str, Any],
-    ) -> RemoteVersion:
-        r"""Fetches latest release from GitHub API without downloading.
-
-        Version-first path: queries the GitHub API for the latest release and
-        extracts the version from the tag name and the download URL from
-        matching assets. If the version matches cached state, the download
-        can be skipped entirely.
+        Queries the GitHub releases API for the latest release of the
+        configured repository. Extracts the version from the release tag
+        (via ``version_pattern``) and the download URL from the first
+        asset matching ``asset_pattern``.
 
         Args:
-            app_config: App configuration containing discovery.repo and
-                optional fields.
+            app_config: Merged recipe configuration dict containing
+                ``discovery.repo`` and ``discovery.asset_pattern``,
+                plus optional ``version_pattern``, ``prerelease``, and
+                ``token`` fields.
 
         Returns:
-            Version info with version string, download URL, and
-                source name.
+            Latest version, the matched asset's download URL, and
+            ``"api_github"`` as the source identifier.
 
         Raises:
-            ValueError: If required config fields are missing, invalid, or if
-                no matching assets are found.
-            RuntimeError: If API call fails or release has no assets.
-
-        Example:
-            Get version from GitHub releases:
-                ```python
-                strategy = ApiGithubStrategy()
-                config = {
-                    "source": {
-                        "repo": "owner/repo",
-                        "asset_pattern": ".*\\.msi$"
-                    }
-                }
-                version_info = strategy.get_version_info(config)
-                # version_info.version returns: '1.0.0'
-                ```
+            ConfigError: On missing or malformed required configuration,
+                or when patterns do not match the release.
+            NetworkError: On API failure, missing assets, or rejected
+                pre-releases.
 
         """
         from napt.logging import get_global_logger

--- a/napt/discovery/api_json.py
+++ b/napt/discovery/api_json.py
@@ -12,157 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""JSON API discovery strategy for NAPT.
+"""JSON API discovery strategy.
 
-This is a VERSION-FIRST strategy that queries JSON API endpoints to get version
-and download URL WITHOUT downloading the installer. This enables fast version
-checks and efficient caching.
+Queries a JSON API endpoint for the latest version and download URL.
+Both fields are extracted from the response using JSONPath expressions.
 
-Key Advantages:
-
-- Fast version discovery (API call ~100ms)
-- Can skip downloads entirely when version unchanged
-- Direct API access for version and download URL
-- Support for complex JSON structures with JSONPath
-- Custom headers for authentication
-- Support for GET and POST requests
-- No file parsing required
-- Ideal for CI/CD with scheduled checks
-
-Supported Features:
-
-- JSONPath navigation for nested structures
-- Array indexing and filtering
-- Custom HTTP headers (Authorization, etc.)
-- POST requests with JSON body
-- Environment variable expansion in values
-
-Use Cases:
-
-- Vendors with JSON APIs (Microsoft, Mozilla, etc.)
-- Cloud services with version endpoints
-- CDNs that provide metadata APIs
-- Applications with update check APIs
-- APIs requiring authentication or custom headers
-- CI/CD pipelines with frequent version checks
-
-Recipe Configuration:
+Recipe Example:
     ```yaml
-    source:
-        strategy: api_json
-        api_url: "https://vendor.com/api/latest"
-        version_path: "version"                      # JSONPath to version
-        download_url_path: "download_url"            # JSONPath to URL
-        method: "GET"                                # Optional: GET or POST
-        headers:                                     # Optional: custom headers
+    discovery:
+      strategy: api_json
+      api_url: "https://vendor.example.com/api/latest"  # required
+      version_path: "version"                           # required, JSONPath
+      download_url_path: "download_url"                 # required, JSONPath
+      method: "GET"                                     # optional, GET or POST
+      headers:                                          # optional
         Authorization: "Bearer ${API_TOKEN}"
         Accept: "application/json"
-        body:                                        # Optional: POST body
+      body:                                             # optional, POST only
         platform: "windows"
         arch: "x64"
-        timeout: 30                                  # Optional: timeout in seconds
+      timeout: 30                                       # optional, seconds
+    ```
+
+    Nested response, with auth header:
+    ```yaml
+    discovery:
+      strategy: api_json
+      api_url: "https://vendor.example.com/api/releases"
+      version_path: "stable.version"
+      download_url_path: "stable.platforms.windows.x64"
+      headers:
+        Authorization: "Bearer ${API_TOKEN}"
     ```
 
 Configuration Fields:
-
-- **api_url** (str, required): API endpoint URL that returns JSON with version
-    and download information
-- **version_path** (str, required): JSONPath expression to extract version from
-    the API response. Examples: "version", "release.version", "data.version"
-- **download_url_path** (str, required): JSONPath expression to extract
-    download URL from the API response. Examples: "download_url", "assets.url",
-    "platforms.windows.x64"
-- **method** (str, optional): HTTP method to use. Either "GET" or "POST".
-    Default is "GET"
-- **headers** (dict, optional): Custom HTTP headers to send with the request.
-    Useful for authentication or setting Accept headers. Values support
-    environment variable expansion. Example: {"Authorization": "Bearer ${API_TOKEN}"}
-- **body** (dict, optional): Request body for POST requests. Sent as JSON.
-    Only used when method="POST". Example: {"platform": "windows", "arch": "x64"}
-    - **timeout** (int, optional): Request timeout in seconds. Default is 30.
-
-JSONPath Syntax:
-
-- Simple paths: "version", "release.version"
-- Array indexing: "data.version", "releases.version"
-- Nested paths: "data.latest.download.url", "response.assets.browser_download_url"
-
-Error Handling:
-
-- ValueError: Missing or invalid configuration, invalid JSONPath, path not found
-- RuntimeError: API failures, invalid JSON response
-- Errors are chained with 'from err' for better debugging
-
-Example:
-    In a recipe YAML (simple API):
-        ```yaml
-        apps:
-          - name: "My App"
-            id: "my-app"
-            source:
-              strategy: api_json
-              api_url: "https://api.vendor.com/latest"
-              version_path: "version"
-              download_url_path: "download_url"
-        ```
-
-    In a recipe YAML (nested structure):
-        ```yaml
-        apps:
-          - name: "My App"
-            id: "my-app"
-            source:
-              strategy: api_json
-              api_url: "https://api.vendor.com/releases"
-              version_path: "stable.version"
-              download_url_path: "stable.platforms.windows.x64"
-              headers:
-                Authorization: "Bearer ${API_TOKEN}"
-        ```
-
-    From Python (version-first approach):
-        ```python
-        from napt.discovery.api_json import ApiJsonStrategy
-        from napt.download import download_file
-
-        strategy = ApiJsonStrategy()
-        app_config = {
-            "source": {
-                "api_url": "https://api.vendor.com/latest",
-                "version_path": "version",
-                "download_url_path": "download_url",
-            }
-        }
-
-        # Get version WITHOUT downloading
-        version_info = strategy.get_version_info(app_config)
-        print(f"Latest version: {version_info.version}")
-
-        # Download only if needed
-        if need_to_download:
-            result = download_file(
-                version_info.download_url, Path("./downloads/my-app")
-            )
-            print(f"Downloaded to {result.file_path}")
-        ```
-
-    From Python (using core orchestration):
-        ```python
-        from pathlib import Path
-        from napt.discovery import discover_recipe
-
-        # Automatically uses version-first optimization
-        result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
-        print(f"Version {result.version} at {result.file_path}")
-        ```
+    - **api_url** (required): JSON endpoint URL.
+    - **version_path** (required): JSONPath expression locating the
+        version string in the response (e.g. ``"version"``,
+        ``"release.version"``).
+    - **download_url_path** (required): JSONPath expression locating
+        the installer download URL in the response.
+    - **method** (optional, default ``"GET"``): ``"GET"`` or ``"POST"``.
+    - **headers** (optional): HTTP headers to send. Values support
+        ``${ENV_VAR}`` expansion.
+    - **body** (optional): Dict sent as a JSON body. Only used when
+        ``method: POST``.
+    - **timeout** (optional, default 30): Request timeout in seconds.
 
 Note:
-    - Version discovery via API only (no download required)
-    - Core orchestration automatically skips download if version unchanged
-    - JSONPath uses jsonpath-ng library for robust parsing
-    - Environment variable expansion works in headers and other string values
-    - POST body is sent as JSON (Content-Type: application/json)
-    - Timeout defaults to 30 seconds to prevent hanging on slow APIs
+    JSONPath uses the ``jsonpath-ng`` library. Environment-variable
+    expansion (``${VAR}``) is applied to string values in ``headers``.
+    POST bodies are always sent as ``application/json``.
 
 """
 
@@ -186,56 +86,30 @@ _DEFAULT_TIMEOUT = 30
 
 
 class ApiJsonStrategy:
-    """Discovery strategy for JSON API endpoints.
+    """Discovery strategy for JSON API endpoints."""
 
-    Configuration example:
-        source:
-          strategy: api_json
-          api_url: "https://api.vendor.com/latest"
-          version_path: "version"
-          download_url_path: "download_url"
-          method: "GET"
-          headers:
-            Authorization: "Bearer ${API_TOKEN}"
-    """
+    def discover(self, app_config: dict[str, Any]) -> RemoteVersion:
+        """Discovers version and download URL from a JSON API endpoint.
 
-    def get_version_info(
-        self,
-        app_config: dict[str, Any],
-    ) -> RemoteVersion:
-        """Queries JSON API for version and download URL without downloading.
-
-        Version-first path: calls a JSON API, extracts version and download URL
-        using JSONPath expressions. If the version matches cached state, the
-        download can be skipped entirely.
+        Calls the configured ``api_url`` and extracts the version and
+        download URL using JSONPath expressions. The HTTP method,
+        headers, and body are configurable so the same strategy works
+        for GET and POST endpoints.
 
         Args:
-            app_config: App configuration containing discovery.api_url,
-                discovery.version_path, and discovery.download_url_path.
+            app_config: Merged recipe configuration dict containing
+                ``discovery.api_url``, ``discovery.version_path``, and
+                ``discovery.download_url_path``, plus optional
+                ``method``, ``headers``, and ``body`` fields.
 
         Returns:
-            Version info with version string, download URL, and
-                source name.
+            Discovered version, download URL, and ``"api_json"`` as
+            the source identifier.
 
         Raises:
-            ValueError: If required config fields are missing, invalid, or if
-                JSONPath expressions don't match anything in the response.
-            RuntimeError: If API call fails (chained with 'from err').
-
-        Example:
-            Get version info from JSON API:
-                ```python
-                strategy = ApiJsonStrategy()
-                config = {
-                    "discovery": {
-                        "api_url": "https://api.vendor.com/latest",
-                        "version_path": "version",
-                        "download_url_path": "download_url"
-                    }
-                }
-                version_info = strategy.get_version_info(config)
-                # version_info.version returns: '1.0.0'
-                ```
+            ConfigError: On missing required configuration or when
+                the JSONPath expressions do not match the response.
+            NetworkError: On API request failure.
 
         """
         from napt.logging import get_global_logger

--- a/napt/discovery/base.py
+++ b/napt/discovery/base.py
@@ -12,57 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Discovery strategy base protocol and registry for NAPT.
+"""Discovery strategy protocol, registry, and shared helpers.
 
-This module defines the foundational components for the discovery system:
+A *discovery strategy* answers a single question: "what is the latest
+version of this app, and where can it be downloaded from?" Strategies
+return that answer as a [RemoteVersion][napt.discovery.base.RemoteVersion]
+dataclass. They do not download files or touch the cache themselves;
+the orchestrator does.
 
-- DiscoveryStrategy protocol: Interface that all strategies must implement
-- Strategy registry: Global dict mapping strategy names to implementations
-- Registration and lookup functions: register_strategy() and get_strategy()
+Built-in strategies:
+    - api_github: queries the GitHub releases API for the latest tag.
+    - api_json: extracts version and download URL from a JSON endpoint.
+    - web_scrape: parses a vendor download page for both fields.
 
-The discovery system uses a strategy pattern to support multiple ways
-of obtaining application installers and their versions:
-
-- url_download: Direct download from a static URL (FILE-FIRST)
-- web_scrape: Scrape vendor download pages to find links and extract versions
-    (VERSION-FIRST)
-- api_github: Fetch from GitHub releases API (VERSION-FIRST)
-- api_json: Query JSON API endpoints for version and download URL (VERSION-FIRST)
+The fourth flow (``url_download``) is *not* a registered strategy. It
+downloads a fixed URL and extracts the version from the file itself,
+which is a different shape than the strategies in this module. The
+discovery orchestrator dispatches to that flow directly when a recipe
+uses ``strategy: url_download``.
 
 Design Philosophy:
-    - Strategies are Protocol classes (structural subtyping, not inheritance)
-    - Registration happens at module import time (strategies self-register)
-    - Registry is a simple dict (no complex dependency injection needed)
-    - Each strategy is stateless and can be instantiated on-demand
-
-Protocol Benefits:
-
-Using typing.Protocol instead of ABC allows:
-
-- Duck typing: Classes don't need explicit inheritance
-- Better IDE support: Type checkers verify interface compliance
-- Flexibility: Third-party code can add strategies without touching base
+    - Strategies are ``typing.Protocol`` types. Implementations are
+        matched structurally; no inheritance is required.
+    - Strategies are pure functions of configuration. They have no state,
+        no I/O of files, and no awareness of the cache.
+    - Registration is a side effect of importing each strategy module.
+    - The [resolve_with_cache][napt.discovery.base.resolve_with_cache]
+        helper turns a [RemoteVersion][napt.discovery.base.RemoteVersion]
+        into a [StrategyResult][napt.discovery.base.StrategyResult] by
+        checking the cache and downloading if needed. Strategies don't
+        call it themselves; the orchestrator does.
 
 Example:
-    Implementing a custom strategy:
+    Adding a new strategy to the codebase:
         ```python
-        from napt.discovery.base import register_strategy, DiscoveryStrategy
-        from pathlib import Path
-        from typing import Any
-        class MyCustomStrategy:
-            def discover_version(
-                self, app_config: dict[str, Any], output_dir: Path
-            ) -> tuple[str, str, Path, str, dict]:
-                # Implement your discovery logic here
-                ...
+        from napt.discovery.base import (
+            RemoteVersion, register_strategy,
+        )
 
-        # Register it (typically at module import)
-        register_strategy("my_custom", MyCustomStrategy)
+        class GitlabReleasesStrategy:
+            def discover(self, app_config):
+                # Query GitLab API and parse the response...
+                return RemoteVersion(
+                    version="1.2.3",
+                    download_url="https://gitlab.example.com/.../installer.msi",
+                    source="gitlab_releases",
+                )
 
-        # Now it can be used in recipes:
-        # discovery:
-        #   strategy: my_custom
-        #   ...
+            def validate_config(self, app_config):
+                errors = []
+                if "project" not in app_config.get("discovery", {}):
+                    errors.append("Missing required field: discovery.project")
+                return errors
+
+        register_strategy("gitlab_releases", GitlabReleasesStrategy)
         ```
 
 """
@@ -73,22 +76,27 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
+from napt.download import download_file
 from napt.exceptions import ConfigError
+from napt.logging import get_global_logger
+from napt.versioning import is_newer
 
 
 @dataclass(frozen=True)
 class RemoteVersion:
-    """Represents a version and download URL obtained from a remote source.
+    """Version and download URL discovered from a remote source.
 
-    Used by version-first strategies (web_scrape, api_github, api_json) that
-    can determine both the version and where to download the installer *without*
-    fetching the file first. This allows the core pipeline to skip the download
-    entirely when the version is unchanged.
+    Returned by every [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy]
+    implementation. The orchestrator passes this to
+    [resolve_with_cache][napt.discovery.base.resolve_with_cache] to decide
+    whether the file needs to be re-downloaded.
 
     Attributes:
-        version: Raw version string (e.g., "140.0.7339.128").
-        download_url: URL to download the installer.
-        source: Strategy name for logging (e.g., "web_scrape", "api_github").
+        version: Raw version string extracted from the remote source
+            (for example, ``"140.0.7339.128"``).
+        download_url: URL the installer can be fetched from.
+        source: Name of the strategy that produced this result, used
+            for logging and result reporting (for example, ``"api_github"``).
     """
 
     version: str
@@ -96,69 +104,81 @@ class RemoteVersion:
     source: str
 
 
+@dataclass(frozen=True)
+class StrategyResult:
+    """Resolved discovery result, ready to be saved to state.
+
+    Returned by both the version-first flow (via
+    [resolve_with_cache][napt.discovery.base.resolve_with_cache]) and the
+    url_download flow. Captures everything the orchestrator needs to
+    update the state cache and build a public
+    [DiscoverResult][napt.results.DiscoverResult].
+
+    Attributes:
+        version: Version string for the resolved file.
+        version_source: Strategy name that produced this version
+            (for example, ``"api_github"`` or ``"url_download"``).
+        file_path: Path to the resolved installer on disk. This is either
+            a freshly downloaded file or a previously cached file when the
+            cache was reused.
+        sha256: SHA-256 hex digest of the resolved file.
+        headers: HTTP response headers from the download. Empty when the
+            cache was reused without a network call. Used to persist
+            ``ETag`` / ``Last-Modified`` for the next conditional request.
+        download_url: URL the file came from. Stored in state so that
+            future runs know where to re-fetch from if needed.
+        cached: True when the file was reused from cache; False when it
+            was downloaded.
+    """
+
+    version: str
+    version_source: str
+    file_path: Path
+    sha256: str
+    headers: dict[str, str]
+    download_url: str
+    cached: bool
+
+
 class DiscoveryStrategy(Protocol):
     """Protocol for version discovery strategies.
 
-    Each strategy must implement discover_version() which downloads
-    and extracts version information based on the app config.
+    A strategy queries a remote source (API, web page, etc.) and returns
+    the latest version plus its download URL. Strategies do not download
+    files, touch the cache, or write to disk. Those concerns belong to
+    the orchestrator.
 
-    Strategies may optionally implement validate_config() to provide
-    strategy-specific configuration validation without network calls.
+    Implementations need only a ``discover`` and a ``validate_config``
+    method with the signatures below.
     """
 
-    def discover_version(
-        self, app_config: dict[str, Any], output_dir: Path
-    ) -> tuple[str, str, Path, str, dict]:
-        """Discover and download an application version.
+    def discover(self, app_config: dict[str, Any]) -> RemoteVersion:
+        """Discovers the latest version and its download URL.
 
         Args:
-            app_config: The merged recipe configuration dict.
-            output_dir: Directory to download the installer to.
+            app_config: Merged recipe configuration dict.
 
         Returns:
-            A tuple (version, version_source, file_path, sha256, headers), where
-                version is the extracted version string, version_source identifies
-                how the version was obtained (e.g., "url_download"), file_path is
-                the path to the downloaded file, sha256 is the SHA-256 hash,
-                and headers contains HTTP response headers for caching.
+            Latest version, the URL it can be downloaded from, and the
+            strategy's own name as the source identifier.
 
         Raises:
-            ValueError: On discovery or download failures.
-            RuntimeError: On discovery or download failures.
+            ConfigError: On missing or invalid required configuration.
+            NetworkError: On HTTP failures or version-extraction errors.
 
         """
         ...
 
     def validate_config(self, app_config: dict[str, Any]) -> list[str]:
-        """Validate strategy-specific configuration (optional).
+        """Validates strategy-specific configuration fields without network calls.
 
-        This method validates the app configuration for strategy-specific
-        requirements without making network calls or downloading files.
-        Useful for quick feedback during recipe development.
+        Implementations should check field presence, types, and format only.
 
         Args:
-            app_config: The merged recipe configuration dict.
+            app_config: Merged recipe configuration dict.
 
         Returns:
-            List of error messages. Empty list if configuration is valid.
-            Each error should be a human-readable description of the issue.
-
-        Example:
-            Check required fields:
-                ```python
-                def validate_config(self, app_config):
-                    errors = []
-                    source = app_config.get("discovery", {})
-                    if "url" not in source:
-                        errors.append("Missing required field: discovery.url")
-                    return errors
-                ```
-
-        Note:
-            This method is optional; strategies without it will skip validation.
-            Should NOT make network calls or download files. Should check field
-            presence, types, and format only. Used by 'napt validate' command
-            for fast recipe checking.
+            Human-readable error messages. Empty when configuration is valid.
 
         """
         ...
@@ -168,81 +188,46 @@ _STRATEGY_REGISTRY: dict[str, type[DiscoveryStrategy]] = {}
 
 
 def register_strategy(name: str, strategy_class: type[DiscoveryStrategy]) -> None:
-    """Register a discovery strategy by name in the global registry.
+    """Registers a discovery strategy by name in the global registry.
 
-    This function should be called when a strategy module is imported,
-    typically at module level. Registering the same name twice will
-    overwrite the previous registration (allows monkey-patching for tests).
+    Strategies call this at module import time so they're available when
+    the orchestrator looks them up. Registering the same name twice
+    overwrites the previous entry (intentional, to allow test
+    monkey-patching).
 
     Args:
-        name: Strategy name (e.g., "url_download"). This is the value
-            used in recipe YAML files under discovery.strategy. Names should be
-            lowercase with underscores for readability.
-        strategy_class: The strategy class to
-            register. Must implement the DiscoveryStrategy protocol (have a
-            discover_version method with the correct signature).
-
-    Example:
-        Register at module import time:
-            ```python
-            # In discovery/my_strategy.py
-            from .base import register_strategy
-
-            class MyStrategy:
-                def discover_version(self, app_config, output_dir):
-                    ...
-
-            register_strategy("my_strategy", MyStrategy)
-            ```
+        name: Strategy name. This is the value used in recipe YAML files
+            under ``discovery.strategy``. Use lowercase with underscores.
+        strategy_class: Class implementing
+            [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy].
+            Type checkers verify protocol compliance statically.
 
     Note:
-        No validation is performed at registration time. Type checkers will
-        verify protocol compliance at static analysis time. Runtime errors
-        occur at strategy instantiation or invocation.
+        ``url_download`` is intentionally not registered here. It runs
+        through a separate code path in the orchestrator because it
+        downloads the file before it can determine the version, which
+        does not fit the version-first contract.
 
     """
     _STRATEGY_REGISTRY[name] = strategy_class
 
 
 def get_strategy(name: str) -> DiscoveryStrategy:
-    """Get a discovery strategy instance by name from the global registry.
+    """Returns a discovery strategy instance by name from the registry.
 
-    The strategy is instantiated on-demand (strategies are stateless, so
-    a new instance is created for each call). The strategy module must
-    have been imported first for registration to occur.
+    Strategies are instantiated on-demand because they are stateless. The
+    strategy's module must already be imported for registration to have
+    happened.
 
     Args:
-        name: Strategy name (e.g., "url_download"). Must exactly match
-            a name registered via register_strategy(). Case-sensitive.
+        name: Registered strategy name. Case-sensitive.
 
     Returns:
-        A new instance of the requested strategy, ready
-            to use.
+        New instance of the requested strategy.
 
     Raises:
-        ConfigError: If the strategy name is not registered. The error message
-            includes a list of available strategies for troubleshooting.
-
-    Example:
-        Get and use a strategy:
-            ```python
-            from napt.discovery import get_strategy
-            strategy = get_strategy("url_download")
-            # Use strategy.discover_version(...)
-            ```
-
-        Handle unknown strategy:
-            ```python
-            try:
-                strategy = get_strategy("nonexistent")
-            except ConfigError as e:
-                print(f"Strategy not found: {e}")
-            ```
-
-    Note:
-        Strategies must be registered before they can be retrieved. The
-        url_download strategy is auto-registered when imported. New strategies
-        can be added by creating a module and registering.
+        ConfigError: If the name is not registered. The message lists
+            the available strategies for troubleshooting.
 
     """
     if name not in _STRATEGY_REGISTRY:
@@ -251,3 +236,80 @@ def get_strategy(name: str) -> DiscoveryStrategy:
             f"Unknown discovery strategy: {name!r}. Available: {available or '(none)'}"
         )
     return _STRATEGY_REGISTRY[name]()
+
+
+def resolve_with_cache(
+    info: RemoteVersion,
+    app_config: dict[str, Any],
+    output_dir: Path,
+    cache: dict[str, Any] | None,
+) -> StrategyResult:
+    """Resolves a [RemoteVersion][napt.discovery.base.RemoteVersion] to a [StrategyResult][napt.discovery.base.StrategyResult].
+
+    Implements the version-first fast path: when the discovered version
+    matches the cached version and the cached file still exists on disk,
+    the download is skipped entirely. Otherwise the file is downloaded
+    fresh from ``info.download_url``.
+
+    Args:
+        info: Version and download URL produced by a strategy's
+            [discover][napt.discovery.base.DiscoveryStrategy.discover] call.
+        app_config: Merged recipe configuration. Used to read ``id``
+            for the per-app download subdirectory.
+        output_dir: Base directory to download into. Files land in
+            ``output_dir / app_id``.
+        cache: Cached state for this recipe (``known_version``,
+            ``file_path``, ``sha256``), or ``None`` when no prior state
+            exists or stateless mode is on.
+
+    Returns:
+        Resolved version, file path, and download metadata. The
+        ``cached`` field indicates whether the download was skipped.
+
+    Raises:
+        NetworkError: On download failures.
+
+    """
+    logger = get_global_logger()
+    app_id = app_config["id"]
+
+    if cache and not is_newer(info.version, cache.get("known_version")):
+        cached_path_str = cache.get("file_path")
+        cached_sha = cache.get("sha256")
+        if cached_path_str and cached_sha:
+            cached_path = Path(cached_path_str)
+            if cached_path.exists():
+                logger.info(
+                    "CACHE",
+                    f"Version {info.version} unchanged, using cached file",
+                )
+                return StrategyResult(
+                    version=info.version,
+                    version_source=info.source,
+                    file_path=cached_path,
+                    sha256=cached_sha,
+                    headers={},
+                    download_url=info.download_url,
+                    cached=True,
+                )
+            logger.warning(
+                "CACHE",
+                f"Cached file {cached_path} not found, re-downloading",
+            )
+
+    if cache and cache.get("known_version"):
+        logger.info(
+            "DISCOVERY",
+            f"Version changed: {cache.get('known_version')} -> {info.version}",
+        )
+
+    dl = download_file(info.download_url, output_dir / app_id)
+    return StrategyResult(
+        version=info.version,
+        version_source=info.source,
+        file_path=dl.file_path,
+        sha256=dl.sha256,
+        headers=dl.headers,
+        download_url=info.download_url,
+        cached=False,
+    )

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -12,69 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Discovery pipeline orchestration for NAPT.
+"""Discovery pipeline orchestration.
 
-This module provides high-level orchestration for the discovery workflow,
-coordinating config loading, strategy selection, version checking, downloading,
-and state management.
+This module owns the top-level [discover_recipe][napt.discovery.manager.discover_recipe]
+entry point used by ``napt discover``. It loads the merged configuration,
+picks a flow based on the recipe's ``discovery.strategy`` value, persists
+state for the next run, and returns the public
+[DiscoverResult][napt.results.DiscoverResult].
 
-Two-Path Architecture:
+Two Flows:
+    Two flows feed into the same orchestration:
 
-The orchestration automatically selects the optimal path based on what each
-discovery strategy can do:
+    - **Version-first** (api_github, api_json, web_scrape and any other
+        registered [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy]):
+        the strategy returns a
+        [RemoteVersion][napt.discovery.base.RemoteVersion], and
+        [resolve_with_cache][napt.discovery.base.resolve_with_cache]
+        decides whether to skip the download (version unchanged + file
+        present) or fetch fresh.
+    - **url_download** (handled by
+        [run_url_download][napt.discovery.url_download.run_url_download]):
+        downloads the file with HTTP conditional headers (``ETag`` /
+        ``Last-Modified``) and extracts the version from the file's
+        metadata. Not a registered strategy because it cannot determine
+        the version without the file.
 
-- **Version-First Path** (web_scrape, api_github, api_json): These strategies
-    can check the version without downloading the file. NAPT compares the
-    discovered version to the cached version. If they match and the file
-    already exists, the download is skipped entirely. This makes update checks
-    very fast (~100-300ms) since no large installer files are downloaded.
-
-- **File-First Path** (url_download): This strategy requires downloading the
-    file to extract the version. NAPT uses HTTP ETag headers to check if the
-    file has changed. If the server responds with HTTP 304 (Not Modified),
-    the existing cached file is reused, avoiding unnecessary re-downloads.
-
-Design Principles:
-
-- Each function has a single, clear responsibility
-- Functions return structured data (dataclasses) for easy testing and extension
-- Error handling uses exceptions; CLI layer formats for user display
-- Discovery strategies are dynamically loaded via registry pattern
-- Configuration is immutable once loaded
-
-Example:
-    Basic version discovery:
-        ```python
-        from pathlib import Path
-        from napt.discovery import discover_recipe
-
-        result = discover_recipe(
-            recipe_path=Path("recipes/Google/chrome.yaml"),
-            output_dir=Path("./downloads"),
-        )
-
-        print(f"App: {result.app_name}")
-        print(f"Version: {result.version}")
-        print(f"SHA-256: {result.sha256}")
-
-        # Version-first strategies: may have skipped download if unchanged!
-        ```
+Both flows return a [StrategyResult][napt.discovery.base.StrategyResult],
+which this module unwraps into state-cache fields and the public result.
 
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from napt import __version__
 from napt.config.loader import load_effective_config
-from napt.discovery.base import get_strategy
-from napt.download import download_file
+from napt.discovery.base import (
+    StrategyResult,
+    get_strategy,
+    resolve_with_cache,
+)
+from napt.discovery.url_download import run_url_download
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import DiscoverResult
 from napt.state import load_state, save_state
-from napt.versioning import is_newer
 
 
 def discover_recipe(
@@ -83,270 +68,156 @@ def discover_recipe(
     state_file: Path | None = Path("state/versions.json"),
     stateless: bool = False,
 ) -> DiscoverResult:
-    """Discover the latest version by loading config and downloading installer.
+    """Discovers the latest version of an app and resolves its installer.
 
-    This is the main entry point for the 'napt discover' command. It orchestrates
-    the entire discovery workflow using a two-path architecture optimized for
-    version-first strategies.
-
-    The function uses duck typing to detect strategy capabilities:
-
-    VERSION-FIRST PATH (if strategy has get_version_info method):
-
-    1. Load effective configuration (org + vendor + recipe merged)
-    2. Call strategy.get_version_info() to discover version (no download)
-    3. Compare discovered version to cached known_version
-    4. If match and file exists -> skip download entirely (fast path!)
-    5. If changed or missing -> download installer via download_file()
-    6. Update state and return results
-
-    FILE-FIRST PATH (if strategy has only discover_version method):
-
-    1. Load effective configuration (org + vendor + recipe merged)
-    2. Call strategy.discover_version() with cached ETag
-    3. Strategy handles conditional request (HTTP 304 vs 200)
-    4. Extract version from downloaded file
-    5. Update state and return results
+    Loads the recipe configuration, dispatches to the appropriate
+    discovery flow (version-first registered strategy or ``url_download``),
+    persists the result to the state cache, and returns the public
+    discovery result.
 
     Args:
         recipe_path: Path to the recipe YAML file. Must exist and be
-            readable. The path is resolved to absolute form.
-        output_dir: Directory to download the installer to. Created if
-            it doesn't exist. The downloaded file will be named based on
-            Content-Disposition header or URL path.
-        state_file: Path to state file for version tracking
-            and ETag caching. Default is "state/versions.json". Set to None
-            to disable.
-        stateless: If True, disable state tracking (no caching,
-            always download). Default is False.
+            readable.
+        output_dir: Directory to download the installer into. When
+            omitted, falls back to ``directories.discover`` from the
+            merged configuration. Created if it does not exist.
+        state_file: Path to the state file used for caching. Defaults
+            to ``state/versions.json``. Set to ``None`` to disable
+            persistence (run still uses an in-memory cache).
+        stateless: When True, skips loading and saving state entirely.
+            Forces every run to behave as if no prior cache existed.
 
     Returns:
-        Discovery results and metadata including version, file path, and SHA-256 hash.
+        Public discovery result containing the resolved version,
+        file path, and SHA-256 hash.
 
     Raises:
-        ConfigError: On missing or invalid configuration fields (missing name or id,
-            missing 'discovery.strategy' field, unknown discovery strategy name),
-            YAML parse errors (from config loader), or if recipe file doesn't exist.
-        NetworkError: On download failures or version extraction errors.
-
-    Example:
-        Basic version discovery:
-            ```python
-            from pathlib import Path
-            result = discover_recipe(
-                Path("recipes/Google/chrome.yaml"),
-                Path("./downloads")
-            )
-            print(result.version)  # 141.0.7390.123
-            ```
-
-        Handling errors:
-            ```python
-            try:
-                result = discover_recipe(Path("invalid.yaml"), Path("."))
-            except ConfigError as e:
-                print(f"Config error: {e}")
-            except NetworkError as e:
-                print(f"Network error: {e}")
-            ```
-
-    Note:
-        The discovery strategy must be registered before calling this function.
-        Version-first strategies (web_scrape, api_github, api_json) can skip
-        downloads entirely when version unchanged (fast path optimization).
-        File-first strategy (url_download) uses ETag conditional requests.
-        Downloaded files are written atomically (.part then renamed). Progress
-        output goes to stdout via the download module. Strategy type detected
-        via duck typing (hasattr for get_version_info).
+        ConfigError: On missing or invalid configuration, including
+            an unknown ``discovery.strategy`` value.
+        NetworkError: On download or version-extraction failures from
+            either flow.
 
     """
     logger = get_global_logger()
 
-    # Load state file unless running in stateless mode
-    state = None
-    if not stateless and state_file:
-        try:
-            state = load_state(state_file)
-            logger.verbose("STATE", f"Loaded state from {state_file}")
-        except FileNotFoundError:
-            logger.verbose("STATE", f"State file not found, will create: {state_file}")
-            state = {
-                "metadata": {"napt_version": __version__, "schema_version": "2"},
-                "apps": {},
-            }
-        except Exception as err:
-            logger.warning("STATE", f"Failed to load state: {err}")
-            logger.verbose("STATE", "Continuing without state tracking")
-            state = None
+    state = _load_state(state_file, stateless, logger)
 
-    # 1. Load and merge configuration
     logger.step(1, 4, "Loading configuration...")
     config = load_effective_config(recipe_path)
-
-    # Resolve output_dir from config default when not provided by caller.
     if output_dir is None:
         output_dir = Path(config["directories"]["discover"])
 
-    # 2. Extract app identity
-    logger.step(2, 4, "Discovering version...")
     app_name = config["name"]
     app_id = config["id"]
 
-    # 3. Get the discovery strategy name
     discovery = config.get("discovery", {})
     strategy_name = discovery.get("strategy")
     if not strategy_name:
         raise ConfigError(f"No 'discovery.strategy' defined for app: {app_name}")
 
-    # 4. Get the strategy implementation
-    strategy = get_strategy(strategy_name)
+    cache = _get_cache_for_app(state, app_id, logger)
 
-    # Get cache for this recipe from state
-    cache = None
-    if state and app_id:
-        cache = state.get("apps", {}).get(app_id)
-        if cache:
-            logger.verbose("STATE", f"Using cache for {app_id}")
-            if cache.get("known_version"):
-                logger.verbose(
-                    "STATE", f"  Cached version: {cache.get('known_version')}"
-                )
-            if cache.get("etag"):
-                logger.verbose("STATE", f"  Cached ETag: {cache.get('etag')}")
-
-    # 5. Run discovery: version-first or file-first path
-    logger.step(3, 4, "Discovering version...")
-
-    # Check if strategy supports version-first (has get_version_info method)
-    download_url = None  # Track actual download URL for state file
-    if hasattr(strategy, "get_version_info"):
-        # VERSION-FIRST PATH (web_scrape, api_github, api_json)
-        # Get version without downloading
-        version_info = strategy.get_version_info(config)
-        download_url = version_info.download_url  # Save for state file
-
-        logger.info("DISCOVERY", f"Version discovered: {version_info.version}")
-
-        # Check if we can use cached file (version match + file exists)
-        if not is_newer(
-            version_info.version, cache.get("known_version") if cache else None
-        ):
-            cached_file_path = (
-                Path(cache["file_path"]) if cache and cache.get("file_path") else None
-            )
-
-            if cached_file_path is not None and cached_file_path.exists():
-                # Fast path: version unchanged, file exists, skip download!
-                logger.info(
-                    "CACHE",
-                    f"Version {version_info.version} unchanged, using cached file",
-                )
-                logger.step(4, 4, "Using cached file...")
-                file_path = cached_file_path
-                sha256 = cache.get("sha256")
-                version = version_info.version
-                version_source = version_info.source
-                headers = {}  # No download occurred, no headers
-            else:
-                # File missing or no cached path — re-download
-                if cached_file_path is not None:
-                    logger.warning(
-                        "CACHE",
-                        f"Cached file {cached_file_path} not found, re-downloading",
-                    )
-                logger.step(4, 4, "Downloading installer...")
-                dl = download_file(
-                    version_info.download_url,
-                    output_dir / app_id,
-                )
-                file_path, sha256, headers = dl.file_path, dl.sha256, dl.headers
-                version = version_info.version
-                version_source = version_info.source
-        else:
-            # Version changed or no cache, download new version
-            if cache:
-                logger.info(
-                    "DISCOVERY",
-                    (
-                        f"Version changed: {cache.get('known_version')} -> "
-                        f"{version_info.version}"
-                    ),
-                )
-            logger.step(4, 4, "Downloading installer...")
-            dl = download_file(
-                version_info.download_url,
-                output_dir / app_id,
-            )
-            file_path, sha256, headers = dl.file_path, dl.sha256, dl.headers
-            version = version_info.version
-            version_source = version_info.source
+    logger.step(2, 4, "Discovering version...")
+    if strategy_name == "url_download":
+        logger.step(3, 4, "Fetching installer...")
+        result = run_url_download(config, output_dir, cache=cache)
     else:
-        # FILE-FIRST PATH (url_download only)
-        # Must download to extract version (or use cached file via ETag)
-        logger.step(4, 4, "Fetching installer...")
-        version, version_source, file_path, sha256, headers = strategy.discover_version(
-            config, output_dir, cache=cache
-        )
-        download_url = str(config.get("discovery", {}).get("url", ""))
+        strategy = get_strategy(strategy_name)
+        info = strategy.discover(config)
+        logger.info("DISCOVERY", f"Version discovered: {info.version}")
+        logger.step(3, 4, "Resolving installer...")
+        result = resolve_with_cache(info, config, output_dir, cache)
 
-    # Update state with discovered information
-    if state and app_id and state_file:
-        from datetime import UTC, datetime
+    logger.step(4, 4, "Updating state...")
+    if state is not None and app_id and state_file:
+        _save_app_state(state, state_file, app_id, strategy_name, result, logger)
 
-        if "apps" not in state:
-            state["apps"] = {}
-
-        # Extract ETag and Last-Modified from headers for next run
-        etag = headers.get("ETag")
-        last_modified = headers.get("Last-Modified")
-
-        if etag:
-            logger.verbose("STATE", f"Saving ETag for next run: {etag}")
-        if last_modified:
-            logger.verbose(
-                "STATE", f"Saving Last-Modified for next run: {last_modified}"
-            )
-
-        # Build cache entry with new schema v2
-        cache_entry = {
-            "url": download_url
-            or "",  # Actual download URL (from version_info or discovery.url)
-            "etag": etag if etag else None,  # Only useful for url_download
-            "last_modified": (
-                last_modified if last_modified else None
-            ),  # Only useful for url_download
-            "sha256": sha256,
-            "file_path": str(file_path),  # Actual filename (may differ from URL)
-        }
-
-        # Optional fields
-        if version:
-            cache_entry["known_version"] = version
-        if strategy_name:
-            cache_entry["strategy"] = strategy_name
-
-        state["apps"][app_id] = cache_entry
-
-        state["metadata"] = {
-            "napt_version": __version__,
-            "last_updated": datetime.now(UTC).isoformat(),
-            "schema_version": "2",
-        }
-
-        try:
-            save_state(state, state_file)
-            logger.verbose("STATE", f"Updated state file: {state_file}")
-        except Exception as err:
-            logger.warning("STATE", f"Failed to save state: {err}")
-
-    # 6. Return results
     return DiscoverResult(
         app_name=app_name,
         app_id=app_id,
         strategy=strategy_name,
-        version=version,
-        version_source=version_source,
-        file_path=file_path,
-        sha256=sha256,
+        version=result.version,
+        version_source=result.version_source,
+        file_path=result.file_path,
+        sha256=result.sha256,
         status="success",
     )
+
+
+def _load_state(
+    state_file: Path | None, stateless: bool, logger: Any
+) -> dict[str, Any] | None:
+    """Loads the state file, or returns a fresh state dict if missing."""
+    if stateless or not state_file:
+        return None
+    try:
+        state = load_state(state_file)
+        logger.verbose("STATE", f"Loaded state from {state_file}")
+        return state
+    except FileNotFoundError:
+        logger.verbose("STATE", f"State file not found, will create: {state_file}")
+        return {
+            "metadata": {"napt_version": __version__, "schema_version": "2"},
+            "apps": {},
+        }
+    except Exception as err:
+        logger.warning("STATE", f"Failed to load state: {err}")
+        logger.verbose("STATE", "Continuing without state tracking")
+        return None
+
+
+def _get_cache_for_app(
+    state: dict[str, Any] | None, app_id: str, logger: Any
+) -> dict[str, Any] | None:
+    """Pulls the per-app cache entry from state, logging what we found."""
+    if not state or not app_id:
+        return None
+    cache = state.get("apps", {}).get(app_id)
+    if not cache:
+        return None
+    logger.verbose("STATE", f"Using cache for {app_id}")
+    if cache.get("known_version"):
+        logger.verbose("STATE", f"  Cached version: {cache.get('known_version')}")
+    if cache.get("etag"):
+        logger.verbose("STATE", f"  Cached ETag: {cache.get('etag')}")
+    return cache
+
+
+def _save_app_state(
+    state: dict[str, Any],
+    state_file: Path,
+    app_id: str,
+    strategy_name: str,
+    result: StrategyResult,
+    logger: Any,
+) -> None:
+    """Writes the resolved discovery result back to the state file."""
+    etag = result.headers.get("ETag")
+    last_modified = result.headers.get("Last-Modified")
+    if etag:
+        logger.verbose("STATE", f"Saving ETag for next run: {etag}")
+    if last_modified:
+        logger.verbose("STATE", f"Saving Last-Modified for next run: {last_modified}")
+
+    cache_entry: dict[str, Any] = {
+        "url": result.download_url,
+        "etag": etag,
+        "last_modified": last_modified,
+        "sha256": result.sha256,
+        "file_path": str(result.file_path),
+        "known_version": result.version,
+        "strategy": strategy_name,
+    }
+
+    state.setdefault("apps", {})[app_id] = cache_entry
+    state["metadata"] = {
+        "napt_version": __version__,
+        "last_updated": datetime.now(UTC).isoformat(),
+        "schema_version": "2",
+    }
+
+    try:
+        save_state(state, state_file)
+        logger.verbose("STATE", f"Updated state file: {state_file}")
+    except Exception as err:
+        logger.warning("STATE", f"Failed to save state: {err}")

--- a/napt/discovery/url_download.py
+++ b/napt/discovery/url_download.py
@@ -12,106 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""URL download discovery strategy for NAPT.
+"""url_download discovery flow.
 
-This is a FILE-FIRST strategy that downloads an installer from a fixed HTTP(S)
-URL and extracts version information from the downloaded file. Uses HTTP ETag
-conditional requests to avoid re-downloading unchanged files.
+This module is intentionally not a
+[DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy]. The
+strategies in [napt.discovery.base][] produce a
+[RemoteVersion][napt.discovery.base.RemoteVersion] from configuration
+alone (version-first). ``url_download`` cannot do that — it has no
+remote endpoint to query for the version, so it must download the
+installer and extract the version from the file's metadata. The
+discovery orchestrator special-cases ``strategy: url_download`` and
+dispatches to
+[run_url_download][napt.discovery.url_download.run_url_download] directly.
 
-Key Advantages:
+Cache Strategy:
+    Uses HTTP conditional requests. If a previous run stored an ``ETag``
+    or ``Last-Modified`` header in state, those are sent as
+    ``If-None-Match`` / ``If-Modified-Since`` on the next request. A
+    server response of HTTP 304 reuses the cached file without a
+    re-download. This is a different mechanism than the version-first
+    strategies, which compare version strings (no HTTP round-trip
+    required to detect "no change" beyond the initial discovery query).
 
-- Works with any fixed URL (version not required in URL)
-- Extracts accurate version directly from installer metadata
-- Uses ETag-based conditional requests for efficiency (~500ms vs full download)
-- Simple and reliable for vendors with stable download URLs
-- Fallback strategy when version not available via API/URL pattern
+Supported File Types:
+    - ``.msi`` — version is read from the MSI ProductVersion property.
+    - Other extensions raise [ConfigError][napt.exceptions.ConfigError].
+        For non-MSI installers, use a version-first strategy.
 
-Supported Version Extraction:
-
-- **MSI files** (`.msi` extension): Automatically detected, extracts
-  ProductVersion property from MSI files
-- **Other file types**: Not supported. Use a version-first strategy
-  (api_github, api_json, web_scrape) or ensure file is an MSI installer.
-- **(Future)** EXE files: Auto-detect and extract FileVersion from PE headers
-
-Use Cases:
-
-- Google Chrome: Fixed enterprise MSI URL, version embedded in MSI
-- Mozilla Firefox: Fixed enterprise MSI URL, version embedded in MSI
-- Vendors with stable download URLs and embedded version metadata
-- When version not available via API, URL pattern, or GitHub tags
-
-Recipe Configuration:
-
-    source:
+Recipe Example:
+    ```yaml
+    discovery:
       strategy: url_download
-      url: "https://vendor.com/installer.msi"          # Required: download URL
-
-Configuration Fields:
-
-- **url** (str, required): HTTP(S) URL to download the installer from. The URL
-    should be stable and point to the latest version.
-
-**Version Extraction:** Automatically detected by file extension. MSI files
-    (`.msi` extension) have versions extracted from ProductVersion property.
-    Other file types are not supported for version extraction - use a
-    version-first strategy (api_github, api_json, web_scrape) instead.
-
-Error Handling:
-
-- ConfigError: Missing or invalid configuration fields
-- NetworkError: Download failures, version extraction errors
-- Errors are chained with 'from err' for better debugging
-
-Example:
-    In a recipe YAML:
-        ```yaml
-        apps:
-          - name: "My App"
-            id: "my-app"
-            source:
-              strategy: url_download
-              url: "https://example.com/myapp-setup.msi"
-        ```
-
-    From Python:
-    ```python
-    from pathlib import Path
-    from napt.discovery.url_download import UrlDownloadStrategy
-
-    strategy = UrlDownloadStrategy()
-    app_config = {
-        "source": {
-            "url": "https://example.com/app.msi",
-        }
-    }
-
-    # With cache for ETag optimization
-    cache = {"etag": 'W/"abc123"', "sha256": "..."}
-    discovered, file_path, sha256, headers = strategy.discover_version(
-        app_config, Path("./downloads"), cache=cache
-    )
-    print(f"Version {discovered.version} at {file_path}")
+      url: "https://vendor.example.com/installer.msi"
     ```
-
-From Python (using core orchestration):
-    ```python
-    from pathlib import Path
-    from napt.discovery import discover_recipe
-
-    # Automatically uses ETag optimization
-    result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
-    print(f"Version {result.version} at {result.file_path}")
-    ```
-
-Note:
-    - Must download file to extract version (architectural constraint)
-    - ETag optimization reduces bandwidth but still requires network round-trip
-    - Core orchestration automatically provides cached ETag if available
-    - Server must support ETag or Last-Modified headers for optimization
-    - If server doesn't support conditional requests, full download occurs every time
-    - Consider version-first strategies (web_scrape, api_github, api_json) for
-      better performance when version available via web scraping or API
 
 """
 
@@ -124,192 +57,215 @@ from napt.download import download_file
 from napt.exceptions import ConfigError, NetworkError, NotModifiedError
 from napt.versioning.msi import extract_msi_metadata
 
-from .base import register_strategy
+from .base import StrategyResult
 
 
-class UrlDownloadStrategy:
-    """Discovery strategy for static HTTP(S) URLs.
+def run_url_download(
+    app_config: dict[str, Any],
+    output_dir: Path,
+    cache: dict[str, Any] | None = None,
+) -> StrategyResult:
+    """Downloads a fixed URL and extracts the version from the resulting file.
 
-    Configuration example:
-        source:
-          strategy: url_download
-          url: "https://example.com/installer.msi"
+    Issues a conditional HTTP request when ``cache`` carries an ``ETag``
+    or ``Last-Modified``. On HTTP 304 the cached file is reused; otherwise
+    the fresh download is used. Either way, the version is extracted from
+    the file (MSI ProductVersion today).
+
+    Args:
+        app_config: Merged recipe configuration dict containing
+            ``discovery.url`` and ``id``.
+        output_dir: Base directory to download into. The file lands
+            in ``output_dir / app_id``.
+        cache: Cached state for this recipe (``etag``, ``last_modified``,
+            ``file_path``, ``sha256``), or ``None`` when no prior state
+            exists or stateless mode is on.
+
+    Returns:
+        Resolved version, file path, and download metadata. The
+        ``cached`` field is True when HTTP 304 was used to reuse the
+        previously downloaded file.
+
+    Raises:
+        ConfigError: If ``discovery.url`` is missing, or if the
+            downloaded file is not an MSI (version extraction is
+            not supported for other file types).
+        NetworkError: On download or version-extraction failures.
+
     """
+    from napt.logging import get_global_logger
 
-    def discover_version(
-        self,
-        app_config: dict[str, Any],
-        output_dir: Path,
-        cache: dict[str, Any] | None = None,
-    ) -> tuple[str, str, Path, str, dict]:
-        """Download from static URL and extract version from the file.
+    logger = get_global_logger()
+    source = app_config.get("discovery", {})
+    url = source.get("url")
+    if not url:
+        raise ConfigError("url_download strategy requires 'discovery.url' in config")
 
-        Args:
-            app_config: App configuration containing discovery.url.
-            output_dir: Directory to save the downloaded file.
-            cache: Cached state with etag, last_modified,
-                file_path, and sha256 for conditional requests. If provided
-                and file is unchanged (HTTP 304), the cached file is returned.
+    app_id = app_config["id"]
 
-        Returns:
-            A tuple (version_info, file_path, sha256, headers), where
-                version_info contains the discovered version information,
-                file_path is the Path to the downloaded file, sha256 is the
-                SHA-256 hash, and headers contains HTTP response headers.
+    logger.verbose("DISCOVERY", "Strategy: url_download (file-first)")
+    logger.verbose("DISCOVERY", f"Source URL: {url}")
 
-        Raises:
-            ConfigError: If required config fields are missing or invalid.
-            NetworkError: If download or version extraction fails.
+    etag = cache.get("etag") if cache else None
+    last_modified = cache.get("last_modified") if cache else None
+    if etag:
+        logger.verbose("DISCOVERY", f"Using cached ETag: {etag}")
+    if last_modified:
+        logger.verbose("DISCOVERY", f"Using cached Last-Modified: {last_modified}")
 
-        """
-        from napt.logging import get_global_logger
+    try:
+        dl = download_file(
+            url,
+            output_dir / app_id,
+            etag=etag,
+            last_modified=last_modified,
+        )
+    except NotModifiedError:
+        return _resolve_not_modified(url, cache, output_dir, app_id, logger)
+    except (NetworkError, ConfigError):
+        raise
+    except Exception as err:
+        raise NetworkError(f"Failed to download {url}: {err}") from err
 
-        logger = get_global_logger()
-        source = app_config.get("discovery", {})
-        url = source.get("url")
-        if not url:
-            raise ConfigError(
-                "url_download strategy requires 'discovery.url' in config"
-            )
-
-        app_id = app_config["id"]
-
-        logger.verbose("DISCOVERY", "Strategy: url_download (file-first)")
-        logger.verbose("DISCOVERY", f"Source URL: {url}")
-
-        # Extract ETag/Last-Modified from cache if available
-        etag = cache.get("etag") if cache else None
-        last_modified = cache.get("last_modified") if cache else None
-
-        if etag:
-            logger.verbose("DISCOVERY", f"Using cached ETag: {etag}")
-        if last_modified:
-            logger.verbose("DISCOVERY", f"Using cached Last-Modified: {last_modified}")
-
-        # Download the file (with conditional request if cache available)
-        try:
-            dl = download_file(
-                url,
-                output_dir / app_id,
-                etag=etag,
-                last_modified=last_modified,
-            )
-            file_path, sha256, headers = dl.file_path, dl.sha256, dl.headers
-        except NotModifiedError:
-            # File unchanged (HTTP 304).
-            logger.info("CACHE", "File not modified (HTTP 304), using cached version")
-
-            cached_file_path = (
-                Path(cache["file_path"]) if cache and cache.get("file_path") else None
-            )
-
-            if (
-                cache
-                and cache.get("sha256")
-                and cached_file_path is not None
-                and cached_file_path.exists()
-            ):
-                # Extract version from cached file (auto-detect by extension)
-                if cached_file_path.suffix.lower() == ".msi":
-                    logger.verbose(
-                        "DISCOVERY", "Auto-detected MSI file, extracting version"
-                    )
-                    try:
-                        metadata = extract_msi_metadata(cached_file_path)
-                        version, version_source = (
-                            metadata.product_version,
-                            "url_download",
-                        )
-                    except Exception as err:
-                        raise NetworkError(
-                            f"Failed to extract MSI ProductVersion from cached "
-                            f"file {cached_file_path}: {err}"
-                        ) from err
-                else:
-                    raise ConfigError(
-                        f"Cannot extract version from file type: "
-                        f"{cached_file_path.suffix!r}. "
-                        f"url_download strategy currently supports MSI files only. "
-                        f"For other file types, use a version-first strategy "
-                        f"(api_github, api_json, web_scrape) or ensure the file "
-                        f"is an MSI installer."
-                    ) from None
-
-                # Preserve cached headers (no new headers on 304)
-                preserved_headers = {}
-                if cache.get("etag"):
-                    preserved_headers["ETag"] = cache["etag"]
-                if cache.get("last_modified"):
-                    preserved_headers["Last-Modified"] = cache["last_modified"]
-
-                return (
-                    version,
-                    version_source,
-                    cached_file_path,
-                    cache["sha256"],
-                    preserved_headers,
-                )
-            else:
-                # Cache incomplete or file missing — force unconditional re-download
-                logger.warning(
-                    "CACHE",
-                    "Cache incomplete or cached file not found, forcing re-download",
-                )
-                dl = download_file(url, output_dir / app_id)
-                file_path, sha256, headers = dl.file_path, dl.sha256, dl.headers
-        except Exception as err:
-            if isinstance(err, (NetworkError, ConfigError)):
-                raise
-            raise NetworkError(f"Failed to download {url}: {err}") from err
-
-        # File was downloaded (not cached), extract version from it (auto-detect by extension)
-        if file_path.suffix.lower() == ".msi":
-            logger.verbose("DISCOVERY", "Auto-detected MSI file, extracting version")
-            try:
-                metadata = extract_msi_metadata(file_path)
-                version, version_source = metadata.product_version, "url_download"
-            except Exception as err:
-                raise NetworkError(
-                    f"Failed to extract MSI ProductVersion from {file_path}: {err}"
-                ) from err
-        else:
-            raise ConfigError(
-                f"Cannot extract version from file type: {file_path.suffix!r}. "
-                f"url_download strategy currently supports MSI files only. "
-                f"For other file types, use a version-first strategy (api_github, "
-                f"api_json, web_scrape) or ensure the file is an MSI installer."
-            )
-
-        return version, version_source, file_path, sha256, headers
-
-    def validate_config(self, app_config: dict[str, Any]) -> list[str]:
-        """Validate url_download strategy configuration.
-
-        Checks for required fields and correct types without making network calls.
-
-        Args:
-            app_config: The app configuration from the recipe.
-
-        Returns:
-            List of error messages (empty if valid).
-
-        """
-        errors = []
-        source = app_config.get("discovery", {})
-
-        # Check required fields
-        if "url" not in source:
-            errors.append("Missing required field: discovery.url")
-        elif not isinstance(source["url"], str):
-            errors.append("discovery.url must be a string")
-        elif not source["url"].strip():
-            errors.append("discovery.url cannot be empty")
-
-        # Version extraction is now auto-detected by file extension
-        # No version configuration validation needed
-
-        return errors
+    version = _extract_version(dl.file_path)
+    return StrategyResult(
+        version=version,
+        version_source="url_download",
+        file_path=dl.file_path,
+        sha256=dl.sha256,
+        headers=dl.headers,
+        download_url=url,
+        cached=False,
+    )
 
 
-# Register this strategy when the module is imported
-register_strategy("url_download", UrlDownloadStrategy)
+def validate_url_download_config(app_config: dict[str, Any]) -> list[str]:
+    """Validates url_download configuration fields.
+
+    Called by [napt.validation.validate_config][] to compose the
+    url_download field rules into the overall recipe validation.
+
+    Args:
+        app_config: Merged recipe configuration dict.
+
+    Returns:
+        Human-readable error messages. Empty when configuration is valid.
+
+    """
+    errors: list[str] = []
+    source = app_config.get("discovery", {})
+
+    if "url" not in source:
+        errors.append("Missing required field: discovery.url")
+    elif not isinstance(source["url"], str):
+        errors.append("discovery.url must be a string")
+    elif not source["url"].strip():
+        errors.append("discovery.url cannot be empty")
+
+    return errors
+
+
+def _resolve_not_modified(
+    url: str,
+    cache: dict[str, Any] | None,
+    output_dir: Path,
+    app_id: str,
+    logger: Any,
+) -> StrategyResult:
+    """Handles HTTP 304 by reusing the cached file or forcing re-download.
+
+    When the server reports the file is unchanged, this attempts to reuse
+    the cached file path. If the cache is incomplete or the file is gone
+    from disk, it falls back to an unconditional re-download.
+
+    Args:
+        url: Original download URL (used for re-download fallback).
+        cache: Cached state for this recipe, if any.
+        output_dir: Base directory to download into for the fallback path.
+        app_id: Recipe app id, used for the per-app subdirectory.
+        logger: Global logger instance, passed in to avoid repeated lookups.
+
+    Returns:
+        Resolved version, file path, and download metadata. The
+        ``cached`` field is True when the previously cached file was
+        reused; False when the fallback re-download was used.
+
+    Raises:
+        NetworkError: On re-download or version-extraction failure.
+        ConfigError: If the cached file is not an MSI.
+
+    """
+    logger.info("CACHE", "File not modified (HTTP 304), using cached version")
+
+    cached_path_str = cache.get("file_path") if cache else None
+    cached_sha = cache.get("sha256") if cache else None
+    cached_path = Path(cached_path_str) if cached_path_str else None
+
+    if cache and cached_sha and cached_path is not None and cached_path.exists():
+        version = _extract_version(cached_path)
+        preserved_headers: dict[str, str] = {}
+        if cache.get("etag"):
+            preserved_headers["ETag"] = cache["etag"]
+        if cache.get("last_modified"):
+            preserved_headers["Last-Modified"] = cache["last_modified"]
+        return StrategyResult(
+            version=version,
+            version_source="url_download",
+            file_path=cached_path,
+            sha256=cached_sha,
+            headers=preserved_headers,
+            download_url=url,
+            cached=True,
+        )
+
+    logger.warning(
+        "CACHE",
+        "Cache incomplete or cached file not found, forcing re-download",
+    )
+    dl = download_file(url, output_dir / app_id)
+    version = _extract_version(dl.file_path)
+    return StrategyResult(
+        version=version,
+        version_source="url_download",
+        file_path=dl.file_path,
+        sha256=dl.sha256,
+        headers=dl.headers,
+        download_url=url,
+        cached=False,
+    )
+
+
+def _extract_version(file_path: Path) -> str:
+    """Extracts a version string from an installer file's metadata.
+
+    Currently supports MSI files via
+    [extract_msi_metadata][napt.versioning.msi.extract_msi_metadata].
+    Other file types raise [ConfigError][napt.exceptions.ConfigError] —
+    use a version-first strategy for those instead.
+
+    Args:
+        file_path: Path to the downloaded installer file.
+
+    Returns:
+        Version string from the file's metadata.
+
+    Raises:
+        ConfigError: If ``file_path`` is not an MSI installer.
+        NetworkError: If MSI metadata extraction fails.
+
+    """
+    if file_path.suffix.lower() != ".msi":
+        raise ConfigError(
+            f"Cannot extract version from file type: {file_path.suffix!r}. "
+            f"url_download strategy currently supports MSI files only. "
+            f"For other file types, use a version-first strategy "
+            f"(api_github, api_json, web_scrape) or ensure the file "
+            f"is an MSI installer."
+        )
+
+    try:
+        return extract_msi_metadata(file_path).product_version
+    except Exception as err:
+        raise NetworkError(
+            f"Failed to extract MSI ProductVersion from {file_path}: {err}"
+        ) from err

--- a/napt/discovery/web_scrape.py
+++ b/napt/discovery/web_scrape.py
@@ -12,154 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Web scraping discovery strategy for NAPT.
+r"""Web scraping discovery strategy.
 
-This is a VERSION-FIRST strategy that scrapes vendor download pages to find
-download links and extract version information from those links. This enables
-version discovery for vendors that don't provide APIs or static URLs.
+Fetches a vendor download page, locates a download link, and extracts
+the version from that link's URL. Use this when a vendor has neither a
+JSON API nor a GitHub releases feed.
 
-Key Advantages:
-
-- Discovers versions from vendor download pages
-- Works for vendors without APIs or GitHub releases
-- Version-first caching (can skip downloads when version unchanged)
-- Supports both CSS selectors (recommended) and regex (fallback)
-- No dependency on HTML structure stability (with good selectors)
-- Handles relative and absolute URLs automatically
-
-Supported Link Finding:
-
-- CSS selectors: Modern, robust, recommended approach
-- Regex patterns: Fallback for edge cases or when CSS won't work
-
-Version Extraction:
-
-- Extract version from the discovered download URL using regex
-- Support for captured groups with formatting
-- Transform version numbers (e.g., "2501" -> "25.01")
-
-Use Cases:
-
-- Vendors with download pages listing multiple versions (7-Zip, etc.)
-- Legacy software without modern APIs
-- Small vendors with simple download pages
-- When GitHub releases and JSON APIs aren't available
-
-Recipe Configuration:
+Recipe Example (CSS selector — recommended):
     ```yaml
-    source:
+    discovery:
       strategy: web_scrape
       page_url: "https://www.7-zip.org/download.html"
-      link_selector: 'a[href$="-x64.msi"]'        # CSS (recommended)
-      version_pattern: "7z(\\d{2})(\\d{2})-x64"   # Extract from URL
-      version_format: "{0}.{1}"                    # Transform to "25.01"
+      link_selector: 'a[href$="-x64.msi"]'
+      version_pattern: "7z(\\d{2})(\\d{2})-x64"
+      version_format: "{0}.{1}"     # transforms ("25", "01") -> "25.01"
     ```
 
-Alternative with regex:
+Recipe Example (regex fallback):
     ```yaml
-    source:
+    discovery:
       strategy: web_scrape
-      page_url: "https://vendor.com/downloads"
+      page_url: "https://vendor.example.com/downloads"
       link_pattern: 'href="(/files/app-v[0-9.]+-x64\\.msi)"'
       version_pattern: "app-v([0-9.]+)-x64"
     ```
 
 Configuration Fields:
+    - **page_url** (required): URL of the page to scrape.
+    - **link_selector** (optional): CSS selector identifying the download
+        link's ``<a>`` element. Recommended over regex.
+    - **link_pattern** (optional): Regex with one capture group around
+        the link URL. Used when a CSS selector cannot pin the link down.
+        Exactly one of ``link_selector`` / ``link_pattern`` is required.
+    - **version_pattern** (required): Regex applied to the discovered
+        link URL to extract the version. Capture groups are pulled out
+        and combined with ``version_format``.
+    - **version_format** (optional, default ``"{0}"``): Python format
+        string referencing capture groups by index (``{0}``, ``{1}``,
+        ...). Use this when a single version field needs to be assembled
+        from multiple captures.
 
-- **page_url** (str, required): URL of the page to scrape for download links
-- **link_selector** (str, optional): CSS selector to find download link.
-    Recommended approach. Example: 'a[href$=".msi"]' finds links ending with .msi
-- **link_pattern** (str, optional): Regex pattern as fallback when CSS won't
-    work. Must have one capture group for the URL. Example: 'href="([^"]*\\.msi)"'
-- **version_pattern** (str, required): Regex pattern to extract version from
-    the discovered URL. Use capture groups to extract version parts. Example:
-    "app-(\\d+\\.\\d+)" or "7z(\\d{2})(\\d{2})"
-- **version_format** (str, optional): Python format string to combine captured
-    groups. Use {0}, {1}, etc. for groups. Example: "{0}.{1}" transforms
-    captures "25", "01" into "25.01". Defaults to "{0}" (first capture group
-    only).
-
-Error Handling:
-
-- ValueError: Missing or invalid configuration fields
-- RuntimeError: Page download failures, selector/pattern not found
-- Errors are chained with 'from err' for better debugging
-
-Finding CSS Selectors:
-
-    Use browser DevTools:
-
-    1. Open download page in Chrome/Edge/Firefox
-    2. Right-click download link -> Inspect
-    3. Right-click highlighted element -> Copy -> Copy selector
-    4. Simplify selector (e.g., 'a[href$=".msi"]' instead of complex nth-child)
-
-Common CSS Patterns:
-
-- 'a[href$=".msi"]' - Links ending with .msi
-- 'a[href*="x64"]' - Links containing "x64"
-- 'a.download' - Links with class="download"
-- 'a[href$="-x64.msi"]:first-of-type' - First matching link
-
-Example:
-    In a recipe YAML:
-        ```yaml
-        apps:
-          - name: "7-Zip"
-            id: "napt-7zip"
-            source:
-              strategy: web_scrape
-              page_url: "https://www.7-zip.org/download.html"
-              link_selector: 'a[href$="-x64.msi"]'
-              version_pattern: "7z(\\d{2})(\\d{2})-x64"
-              version_format: "{0}.{1}"
-        ```
-
-    From Python (version-first approach):
-        ```python
-        from napt.discovery.web_scrape import WebScrapeStrategy
-        from napt.download import download_file
-
-        strategy = WebScrapeStrategy()
-        app_config = {
-            "source": {
-                "page_url": "https://www.7-zip.org/download.html",
-                "link_selector": 'a[href$="-x64.msi"]',
-                "version_pattern": "7z(\\d{2})(\\d{2})-x64",
-                "version_format": "{0}.{1}",
-            }
-        }
-
-        # Get version WITHOUT downloading installer
-        version_info = strategy.get_version_info(app_config)
-        print(f"Latest version: {version_info.version}")
-
-        # Download only if needed
-        if need_to_download:
-            result = download_file(
-                version_info.download_url, Path("./downloads/my-app")
-            )
-            print(f"Downloaded to {result.file_path}")
-        ```
-
-    From Python (using core orchestration):
-        ```python
-        from pathlib import Path
-        from napt.discovery import discover_recipe
-
-        # Automatically uses version-first optimization
-        result = discover_recipe(Path("recipe.yaml"), Path("./downloads"))
-        print(f"Version {result.version} at {result.file_path}")
-        ```
+Finding a CSS Selector:
+    1. Open the download page in Chrome / Edge / Firefox.
+    2. Right-click the download link -> Inspect.
+    3. Right-click the highlighted element -> Copy -> Copy selector.
+    4. Simplify the result. Common shapes:
+        - ``a[href$=".msi"]`` (links ending in .msi)
+        - ``a[href*="x64"]`` (links containing "x64")
+        - ``a.download`` (links with ``class="download"``)
 
 Note:
-    - Version discovery via web scraping (no installer download required)
-    - Core orchestration automatically skips download if version unchanged
-    - CSS selectors are recommended (more robust than regex)
-    - Use browser DevTools to find selectors easily
-    - Selector should match exactly one link (first match is used)
-    - BeautifulSoup4 required for CSS selectors
-    - Regex fallback works without BeautifulSoup
+    The selector / pattern is expected to match exactly one link; the
+    first match is used. Relative URLs in the page are resolved against
+    ``page_url``. CSS selector support requires BeautifulSoup4; the
+    regex fallback does not.
 
 """
 
@@ -182,58 +88,30 @@ _DEFAULT_VERSION_FORMAT = "{0}"
 
 
 class WebScrapeStrategy:
-    """Discovery strategy for web scraping download pages.
+    """Discovery strategy for scraping vendor download pages."""
 
-    Configuration example:
-        ```yaml
-        source:
-          strategy: web_scrape
-          page_url: "https://vendor.com/download.html"
-          link_selector: 'a[href$=".msi"]'
-          version_pattern: "app-v([0-9.]+)"
-        ```
-    """
+    def discover(self, app_config: dict[str, Any]) -> RemoteVersion:
+        r"""Discovers version and download URL by scraping a vendor page.
 
-    def get_version_info(
-        self,
-        app_config: dict[str, Any],
-    ) -> RemoteVersion:
-        r"""Scrapes download page for version and URL without downloading.
-
-        Version-first path: scrapes an HTML page, finds a download link using a
-        CSS selector or regex, extracts the version from that link, and returns
-        version info. If the version matches cached state, the download can be
-        skipped entirely.
+        Fetches ``discovery.page_url``, locates a download link with
+        either ``link_selector`` (CSS) or ``link_pattern`` (regex),
+        and extracts the version from the matched link using
+        ``version_pattern``.
 
         Args:
-            app_config: App configuration containing discovery.page_url,
-                discovery.link_selector or discovery.link_pattern, and
-                discovery.version_pattern.
+            app_config: Merged recipe configuration dict containing
+                ``discovery.page_url``, exactly one of
+                ``discovery.link_selector`` or ``discovery.link_pattern``,
+                and ``discovery.version_pattern``.
 
         Returns:
-            Version info with version string, download URL, and
-                source name.
+            Discovered version, the matched link's URL, and
+            ``"web_scrape"`` as the source identifier.
 
         Raises:
-            ValueError: If required config fields are missing, invalid, or if
-                selectors/patterns don't match anything.
-            RuntimeError: If page download fails (chained with 'from err').
-
-        Example:
-            Scrape 7-Zip download page:
-                ```python
-                strategy = WebScrapeStrategy()
-                config = {
-                    "discovery": {
-                        "page_url": "https://www.7-zip.org/download.html",
-                        "link_selector": 'a[href$="-x64.msi"]',
-                        "version_pattern": "7z(\\d{2})(\\d{2})-x64",
-                        "version_format": "{0}.{1}"
-                    }
-                }
-                version_info = strategy.get_version_info(config)
-                # version_info.version returns: '25.01'
-                ```
+            ConfigError: On missing required configuration or when
+                a selector / pattern matches nothing.
+            NetworkError: On page fetch failure.
 
         """
         from napt.logging import get_global_logger

--- a/napt/validation.py
+++ b/napt/validation.py
@@ -474,17 +474,24 @@ def validate_config(
                     f"'{app_name}' uses strategy: {strategy_name}",
                 )
 
-                # Check if strategy exists
-                try:
-                    strategy = get_strategy(strategy_name)
-                except ConfigError as err:
-                    errors.append(f"discovery.strategy: {err}")
+                # Validate strategy-specific configuration
+                if strategy_name == "url_download":
+                    from napt.discovery.url_download import (
+                        validate_url_download_config,
+                    )
+
+                    try:
+                        errors.extend(validate_url_download_config(config))
+                    except Exception as err:
+                        errors.append(f"Strategy validation failed: {err}")
                 else:
-                    # Validate strategy-specific configuration
-                    if hasattr(strategy, "validate_config"):
+                    try:
+                        strategy = get_strategy(strategy_name)
+                    except ConfigError as err:
+                        errors.append(f"discovery.strategy: {err}")
+                    else:
                         try:
-                            config_errors = strategy.validate_config(config)
-                            errors.extend(config_errors)
+                            errors.extend(strategy.validate_config(config))
                         except Exception as err:
                             errors.append(f"Strategy validation failed: {err}")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,8 +21,9 @@ class TestDiscoverRecipe:
     """Tests for discover_recipe orchestration function."""
 
     def test_discover_recipe_success(self, tmp_test_dir, create_yaml_file):
-        """Test successful recipe check workflow."""
-        # Create a minimal recipe
+        """Tests the successful url_download discovery workflow end to end."""
+        from napt.discovery.base import StrategyResult
+
         recipe_data = {
             "apiVersion": "napt/v1",
             "name": "Test App",
@@ -34,19 +35,16 @@ class TestDiscoverRecipe:
         }
         recipe_path = create_yaml_file("recipe.yaml", recipe_data)
 
-        # Mock the discovery strategy (url_download - file-first)
-        with patch("napt.discovery.manager.get_strategy") as mock_get_strategy:
-            mock_strategy = mock_get_strategy.return_value
-            # Ensure it doesn't have get_version_info (file-first strategy)
-            del mock_strategy.get_version_info
-            mock_strategy.discover_version.return_value = (
-                "1.2.3",
-                "url_download",
-                tmp_test_dir / "test.msi",
-                "abc123" * 8,  # fake SHA-256
-                {"ETag": 'W/"test123"'},  # HTTP headers
+        with patch("napt.discovery.manager.run_url_download") as mock_run:
+            mock_run.return_value = StrategyResult(
+                version="1.2.3",
+                version_source="url_download",
+                file_path=tmp_test_dir / "test.msi",
+                sha256="abc123" * 8,
+                headers={"ETag": 'W/"test123"'},
+                download_url="https://example.com/test.msi",
+                cached=False,
             )
-
             result = discover_recipe(recipe_path, tmp_test_dir)
 
         assert result.app_name == "Test App"
@@ -55,8 +53,6 @@ class TestDiscoverRecipe:
         assert result.version == "1.2.3"
         assert result.version_source == "url_download"
         assert result.status == "success"
-        assert hasattr(result, "file_path")
-        assert hasattr(result, "sha256")
 
     def test_discover_recipe_missing_strategy_in_empty_recipe_raises(
         self, tmp_test_dir, create_yaml_file
@@ -161,7 +157,7 @@ class TestVersionFirstFastPath:
                 mock_load_state.return_value = state
 
                 with patch("napt.discovery.manager.save_state"):
-                    with patch("napt.discovery.manager.download_file") as mock_download:
+                    with patch("napt.discovery.base.download_file") as mock_download:
                         result = discover_recipe(
                             recipe_path, tmp_test_dir, state_file=Path("state.json")
                         )
@@ -219,7 +215,7 @@ class TestVersionFirstFastPath:
                 mock_load_state.return_value = state
 
                 with patch("napt.discovery.manager.save_state"):
-                    with patch("napt.discovery.manager.download_file") as mock_download:
+                    with patch("napt.discovery.base.download_file") as mock_download:
                         from napt.results import DownloadResult
 
                         mock_download.return_value = DownloadResult(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,15 +1,7 @@
-"""
-Tests for napt.discovery module.
-
-Tests discovery strategies including:
-- Strategy registry
-- HTTP static strategy
-- Version extraction from downloaded files
-"""
+"""Tests for napt.discovery: strategy registry, strategies, url_download flow."""
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +10,7 @@ import requests_mock
 from napt.discovery.api_github import ApiGithubStrategy
 from napt.discovery.api_json import ApiJsonStrategy
 from napt.discovery.base import RemoteVersion, get_strategy, register_strategy
-from napt.discovery.url_download import UrlDownloadStrategy
+from napt.discovery.url_download import run_url_download
 from napt.discovery.web_scrape import WebScrapeStrategy
 from napt.exceptions import ConfigError, NetworkError
 from napt.versioning.msi import MSIMetadata
@@ -27,54 +19,49 @@ from napt.versioning.msi import MSIMetadata
 class TestStrategyRegistry:
     """Tests for discovery strategy registration and lookup."""
 
-    def test_get_url_download_strategy(self):
-        """Test that url_download strategy can be retrieved."""
-        strategy = get_strategy("url_download")
-        assert isinstance(strategy, UrlDownloadStrategy)
-
     def test_get_api_github_strategy(self):
-        """Test that api_github strategy can be retrieved."""
+        """Tests that api_github strategy can be retrieved from the registry."""
         strategy = get_strategy("api_github")
         assert isinstance(strategy, ApiGithubStrategy)
 
     def test_get_unknown_strategy_raises(self):
-        """Test that unknown strategy name raises ValueError."""
-
+        """Tests that an unregistered strategy name raises ConfigError."""
         with pytest.raises(ConfigError, match="Unknown discovery strategy"):
             get_strategy("nonexistent_strategy")
 
+    def test_url_download_not_in_registry(self):
+        """Tests that url_download is intentionally not a registered strategy."""
+        with pytest.raises(ConfigError, match="Unknown discovery strategy"):
+            get_strategy("url_download")
+
     def test_register_custom_strategy(self):
-        """Test registering a custom strategy."""
+        """Tests that a custom strategy can be registered and retrieved."""
 
         class CustomStrategy:
-            def discover_version(self, app_config, output_dir):
-                return (
-                    RemoteVersion(version="1.0.0", source="custom"),
-                    Path("/fake/path"),
-                    "fakehash",
-                    {},  # HTTP headers
+            def discover(self, app_config):
+                return RemoteVersion(
+                    version="1.0.0",
+                    download_url="https://example.com/installer.msi",
+                    source="custom",
                 )
+
+            def validate_config(self, app_config):
+                return []
 
         register_strategy("custom_test", CustomStrategy)
         strategy = get_strategy("custom_test")
         assert isinstance(strategy, CustomStrategy)
 
 
-class TestUrlDownloadStrategy:
-    """Tests for URL download strategy."""
+class TestUrlDownloadFlow:
+    """Tests for the url_download flow (run_url_download)."""
 
-    def test_discover_version_with_msi(self, tmp_test_dir):
-        """Test discovering version from MSI file."""
+    def test_discovers_version_from_msi(self, tmp_test_dir):
+        """Tests that the version is extracted from a freshly downloaded MSI."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
-        # Mock the download and MSI extraction
         fake_msi_content = b"fake MSI content"
 
         with requests_mock.Mocker() as m:
@@ -83,65 +70,44 @@ class TestUrlDownloadStrategy:
                 content=fake_msi_content,
                 headers={"Content-Length": str(len(fake_msi_content))},
             )
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.return_value = MSIMetadata(
                     product_name="", product_version="1.2.3", architecture="x64"
                 )
+                result = run_url_download(app_config, tmp_test_dir)
 
-                version, version_source, file_path, sha256, headers = (
-                    strategy.discover_version(app_config, tmp_test_dir)
-                )
+        assert result.version == "1.2.3"
+        assert result.version_source == "url_download"
+        assert result.file_path == tmp_test_dir / "test-app" / "installer.msi"
+        assert result.file_path.exists()
+        assert len(result.sha256) == 64
+        assert result.cached is False
+        assert result.download_url == "https://example.com/installer.msi"
 
-        assert version == "1.2.3"
-        assert version_source == "url_download"
-        assert file_path == tmp_test_dir / "test-app" / "installer.msi"
-        assert file_path.exists()
-        assert isinstance(sha256, str)
-        assert len(sha256) == 64  # SHA-256 hex length
-
-    def test_discover_version_missing_url_raises(self, tmp_test_dir):
-        """Test that missing URL raises ValueError."""
-        app_config = {"discovery": {}}
-
-        strategy = UrlDownloadStrategy()
-
+    def test_missing_url_raises(self, tmp_test_dir):
+        """Tests that a missing discovery.url raises ConfigError."""
         with pytest.raises(ConfigError, match="requires 'discovery.url'"):
-            strategy.discover_version(app_config, tmp_test_dir)
+            run_url_download({"discovery": {}}, tmp_test_dir)
 
-    def test_discover_version_download_failure_raises(self, tmp_test_dir):
-        """Test that download failures raise NetworkError."""
+    def test_download_failure_raises(self, tmp_test_dir):
+        """Tests that a non-2xx download response raises NetworkError."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
         with requests_mock.Mocker() as m:
             m.get("https://example.com/installer.msi", status_code=404)
-
-            from napt.exceptions import NetworkError
-
             with pytest.raises(NetworkError, match="download failed"):
-                strategy.discover_version(app_config, tmp_test_dir)
+                run_url_download(app_config, tmp_test_dir)
 
-    def test_discover_version_extraction_failure_raises(self, tmp_test_dir):
-        """Test that version extraction failures raise NetworkError."""
+    def test_extraction_failure_raises(self, tmp_test_dir):
+        """Tests that MSI extraction failures raise NetworkError."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-                "version": {"type": "msi"},
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
         fake_content = b"not a real MSI"
         with requests_mock.Mocker() as m:
             m.get(
@@ -149,103 +115,65 @@ class TestUrlDownloadStrategy:
                 content=fake_content,
                 headers={"Content-Length": str(len(fake_content))},
             )
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.side_effect = NetworkError("Invalid MSI")
-
                 with pytest.raises(
                     NetworkError, match="Failed to extract MSI ProductVersion"
                 ):
-                    strategy.discover_version(app_config, tmp_test_dir)
+                    run_url_download(app_config, tmp_test_dir)
 
 
-# TestApiGithubStrategy removed - discover_version() method no longer exists
-# Strategy now only has get_version_info() which is tested in TestVersionFirstStrategies
-# Integration testing covered by TestVersionFirstFastPath in test_core.py
+class TestUrlDownloadCacheBehavior:
+    """Tests for url_download's HTTP-conditional cache handling."""
 
-
-# TestApiJsonStrategy removed - discover_version() method no longer exists
-# Strategy now only has get_version_info() which is tested in TestVersionFirstStrategies
-# Integration testing covered by TestVersionFirstFastPath in test_core.py
-
-
-class TestCacheAndETagSupport:
-    """Tests for cache parameter and ETag-based conditional downloads."""
-
-    def test_url_download_with_cache_not_modified(self, tmp_test_dir):
-        """Test url_download with cache when file not modified (HTTP 304)."""
-
+    def test_cache_not_modified_uses_cached_file(self, tmp_test_dir):
+        """Tests that HTTP 304 reuses the cached file and version."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-                "version": {"type": "msi"},
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
-        # Create a fake cached file in the app-scoped directory
         app_dir = tmp_test_dir / "test-app"
         app_dir.mkdir()
         cached_file = app_dir / "installer.msi"
         cached_file.write_bytes(b"fake cached msi")
-
         cache = {
-            "version": "1.0.0",
             "etag": 'W/"abc123"',
             "file_path": str(cached_file),
             "sha256": "cached_sha256",
         }
 
         with requests_mock.Mocker() as m:
-            # Mock 304 Not Modified response
             m.get("https://example.com/installer.msi", status_code=304)
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.return_value = MSIMetadata(
                     product_name="", product_version="1.0.0", architecture="x64"
                 )
+                result = run_url_download(app_config, tmp_test_dir, cache=cache)
 
-                version, version_source, file_path, sha256, headers = (
-                    strategy.discover_version(app_config, tmp_test_dir, cache=cache)
-                )
+        assert result.file_path == cached_file
+        assert result.sha256 == "cached_sha256"
+        assert result.version == "1.0.0"
+        assert result.cached is True
+        assert result.headers.get("ETag") == 'W/"abc123"'
 
-        # Should use cached file from app-scoped directory
-        assert file_path == cached_file
-        assert sha256 == "cached_sha256"
-        assert version == "1.0.0"
-
-    # test_api_github_with_cache_not_modified removed -
-    # discover_version() no longer exists
-
-    def test_url_download_with_cache_modified(self, tmp_test_dir):
-        """Test url_download downloads when file modified (HTTP 200)."""
+    def test_cache_modified_redownloads(self, tmp_test_dir):
+        """Tests that HTTP 200 downloads the new file."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-                "version": {"type": "msi"},
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
         cache = {
-            "version": "1.0.0",
             "etag": 'W/"old_etag"',
             "file_path": str(tmp_test_dir / "test-app" / "old_installer.msi"),
             "sha256": "old_sha256",
         }
-
         fake_msi = b"new fake MSI content"
 
         with requests_mock.Mocker() as m:
-            # Mock 200 response (file changed)
             m.get(
                 "https://example.com/installer.msi",
                 content=fake_msi,
@@ -254,36 +182,26 @@ class TestCacheAndETagSupport:
                     "ETag": 'W/"new_etag"',
                 },
             )
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.return_value = MSIMetadata(
                     product_name="", product_version="2.0.0", architecture="x64"
                 )
+                result = run_url_download(app_config, tmp_test_dir, cache=cache)
 
-                version, version_source, file_path, sha256, headers = (
-                    strategy.discover_version(app_config, tmp_test_dir, cache=cache)
-                )
+        assert result.file_path == tmp_test_dir / "test-app" / "installer.msi"
+        assert result.file_path.exists()
+        assert result.version == "2.0.0"
+        assert result.cached is False
+        assert len(result.sha256) == 64
 
-        # Should download new file into app-scoped directory
-        assert file_path == tmp_test_dir / "test-app" / "installer.msi"
-        assert file_path.exists()
-        assert version == "2.0.0"
-        assert len(sha256) == 64
-
-    def test_strategy_without_cache_works(self, tmp_test_dir):
-        """Test that strategies work without cache (backward compatible)."""
+    def test_no_cache_works(self, tmp_test_dir):
+        """Tests that url_download works without a cache argument."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-                "version": {"type": "msi"},
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
         fake_msi = b"fake MSI no cache"
 
         with requests_mock.Mocker() as m:
@@ -292,48 +210,32 @@ class TestCacheAndETagSupport:
                 content=fake_msi,
                 headers={"Content-Length": str(len(fake_msi))},
             )
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.return_value = MSIMetadata(
                     product_name="", product_version="1.0.0", architecture="x64"
                 )
+                result = run_url_download(app_config, tmp_test_dir)
 
-                # Call without cache parameter (None is default)
-                version, version_source, file_path, sha256, headers = (
-                    strategy.discover_version(app_config, tmp_test_dir)
-                )
-
-        assert version == "1.0.0"
-        assert file_path == tmp_test_dir / "test-app" / "installer.msi"
-        assert file_path.exists()
+        assert result.version == "1.0.0"
+        assert result.file_path == tmp_test_dir / "test-app" / "installer.msi"
+        assert result.file_path.exists()
 
     def test_cache_with_missing_file_redownloads(self, tmp_test_dir):
-        """Test that 304 with a missing cached file forces a re-download."""
+        """Tests that HTTP 304 with a missing cached file forces a re-download."""
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/installer.msi",
-                "version": {"type": "msi"},
-            },
+            "discovery": {"url": "https://example.com/installer.msi"},
         }
-
-        strategy = UrlDownloadStrategy()
-
-        # Cache points to a file that no longer exists on disk
         cache = {
-            "version": "1.0.0",
             "etag": 'W/"abc123"',
             "file_path": str(tmp_test_dir / "test-app" / "nonexistent.msi"),
             "sha256": "cached_sha",
         }
-
         fake_msi = b"re-downloaded MSI content"
 
         with requests_mock.Mocker() as m:
-            # First request (conditional with ETag) returns 304
-            # Second request (forced unconditional re-download) returns 200
             m.get(
                 "https://example.com/installer.msi",
                 [
@@ -344,45 +246,34 @@ class TestCacheAndETagSupport:
                     },
                 ],
             )
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.return_value = MSIMetadata(
                     product_name="", product_version="1.0.0", architecture="x64"
                 )
+                result = run_url_download(app_config, tmp_test_dir, cache=cache)
 
-                version, version_source, file_path, sha256, headers = (
-                    strategy.discover_version(app_config, tmp_test_dir, cache=cache)
-                )
-
-        assert version == "1.0.0"
-        assert file_path.exists()
+        assert result.version == "1.0.0"
+        assert result.file_path.exists()
+        assert result.cached is False
 
     def test_304_uses_cached_file_path_not_url(self, tmp_test_dir):
-        """Test that 304 uses cache's file_path, not the URL-derived filename.
+        """Tests that HTTP 304 reuses the stored file_path, not a URL-derived name.
 
-        Covers the bug where Content-Disposition gives a different filename
-        than the URL path. On the next run (304), we must use the stored path.
+        Guards against the bug where Content-Disposition gave the original
+        download a different filename than the URL path. On 304, the stored
+        path must be used so the file is found again.
         """
         app_config = {
             "id": "test-app",
-            "discovery": {
-                "url": "https://example.com/download?token=abc",
-            },
+            "discovery": {"url": "https://example.com/download?token=abc"},
         }
-
-        strategy = UrlDownloadStrategy()
-
-        # Simulate: original download had Content-Disposition filename
-        # that differs from the URL (no filename in URL path at all)
         app_dir = tmp_test_dir / "test-app"
         app_dir.mkdir()
         cd_named_file = app_dir / "MyApp-Setup-2.1.0.msi"
         cd_named_file.write_bytes(b"fake msi from cd header")
-
         cache = {
-            "version": "2.1.0",
             "etag": 'W/"xyz"',
             "file_path": str(cd_named_file),
             "sha256": "deadbeef" * 8,
@@ -390,29 +281,25 @@ class TestCacheAndETagSupport:
 
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download", status_code=304)
-
             with patch(
                 "napt.discovery.url_download.extract_msi_metadata"
             ) as mock_extract:
                 mock_extract.return_value = MSIMetadata(
                     product_name="", product_version="2.1.0", architecture="x64"
                 )
+                result = run_url_download(app_config, tmp_test_dir, cache=cache)
 
-                version, version_source, file_path, sha256, headers = (
-                    strategy.discover_version(app_config, tmp_test_dir, cache=cache)
-                )
-
-        # Must use the CD-derived cached path, not "download.bin" from URL
-        assert file_path == cd_named_file
-        assert version == "2.1.0"
-        assert sha256 == "deadbeef" * 8
+        assert result.file_path == cd_named_file
+        assert result.version == "2.1.0"
+        assert result.sha256 == "deadbeef" * 8
+        assert result.cached is True
 
 
 class TestVersionFirstStrategies:
     """Tests for version-first strategies (web_scrape, api_github, api_json)."""
 
     def test_web_scrape_with_css_selector(self):
-        """Test web_scrape.get_version_info() with CSS selector."""
+        """Test web_scrape.discover() with CSS selector."""
         strategy = WebScrapeStrategy()
         app_config = {
             "discovery": {
@@ -438,7 +325,7 @@ class TestVersionFirstStrategies:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download.html", text=html_content)
 
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
 
         assert isinstance(version_info, RemoteVersion)
         assert version_info.version == "25.01"
@@ -446,7 +333,7 @@ class TestVersionFirstStrategies:
         assert version_info.source == "web_scrape"
 
     def test_web_scrape_with_regex_pattern(self):
-        """Test web_scrape.get_version_info() with regex fallback."""
+        """Test web_scrape.discover() with regex fallback."""
         strategy = WebScrapeStrategy()
         app_config = {
             "discovery": {
@@ -461,7 +348,7 @@ class TestVersionFirstStrategies:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download.html", text=html_content)
 
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
 
         assert isinstance(version_info, RemoteVersion)
         assert version_info.version == "1.2.3"
@@ -471,8 +358,8 @@ class TestVersionFirstStrategies:
         )
         assert version_info.source == "web_scrape"
 
-    def test_api_github_get_version_info(self):
-        """Test api_github.get_version_info() returns RemoteVersion without
+    def test_api_github_discover(self):
+        """Test api_github.discover() returns RemoteVersion without
         downloading."""
         strategy = ApiGithubStrategy()
         app_config = {
@@ -500,15 +387,15 @@ class TestVersionFirstStrategies:
                 json=release_data,
             )
 
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
 
         assert isinstance(version_info, RemoteVersion)
         assert version_info.version == "1.2.3"
         assert "github.com" in version_info.download_url
         assert version_info.source == "api_github"
 
-    def test_api_json_get_version_info(self):
-        """Test api_json.get_version_info() returns RemoteVersion without downloading."""
+    def test_api_json_discover(self):
+        """Test api_json.discover() returns RemoteVersion without downloading."""
         strategy = ApiJsonStrategy()
         app_config = {
             "discovery": {
@@ -526,7 +413,7 @@ class TestVersionFirstStrategies:
         with requests_mock.Mocker() as m:
             m.get("https://api.example.com/latest", json=api_response)
 
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
 
         assert isinstance(version_info, RemoteVersion)
         assert version_info.version == "1.2.3"
@@ -540,13 +427,13 @@ class TestVersionFirstStrategies:
 
 
 class TestWebScrapeStrategyErrors:
-    """Tests error handling in WebScrapeStrategy.get_version_info()."""
+    """Tests error handling in WebScrapeStrategy.discover()."""
 
     def test_missing_page_url_raises(self):
         """Tests that missing page_url raises ConfigError."""
         strategy = WebScrapeStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.page_url'"):
-            strategy.get_version_info(
+            strategy.discover(
                 {"discovery": {"link_selector": "a", "version_pattern": "."}}
             )
 
@@ -554,7 +441,7 @@ class TestWebScrapeStrategyErrors:
         """Tests that omitting both link_selector and link_pattern raises ConfigError."""
         strategy = WebScrapeStrategy()
         with pytest.raises(ConfigError, match="link_selector.*link_pattern"):
-            strategy.get_version_info(
+            strategy.discover(
                 {
                     "discovery": {
                         "page_url": "https://example.com",
@@ -567,7 +454,7 @@ class TestWebScrapeStrategyErrors:
         """Tests that missing version_pattern raises ConfigError."""
         strategy = WebScrapeStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.version_pattern'"):
-            strategy.get_version_info(
+            strategy.discover(
                 {
                     "discovery": {
                         "page_url": "https://example.com",
@@ -589,7 +476,7 @@ class TestWebScrapeStrategyErrors:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/dl.html", status_code=503)
             with pytest.raises(NetworkError, match="Failed to fetch page"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_css_selector_not_found_raises(self):
         """Tests that a CSS selector matching nothing raises ConfigError."""
@@ -607,7 +494,7 @@ class TestWebScrapeStrategyErrors:
                 text="<html><body>no links here</body></html>",
             )
             with pytest.raises(ConfigError, match="did not match any elements"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_regex_link_pattern_not_found_raises(self):
         """Tests that a regex link_pattern matching nothing raises ConfigError."""
@@ -624,7 +511,7 @@ class TestWebScrapeStrategyErrors:
                 "https://example.com/dl.html", text="<html><body>nothing</body></html>"
             )
             with pytest.raises(ConfigError, match="did not match anything"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_version_pattern_no_match_raises(self):
         """Tests that a version_pattern not matching the URL raises ConfigError."""
@@ -642,7 +529,7 @@ class TestWebScrapeStrategyErrors:
                 text='<a href="/files/installer.msi">Download</a>',
             )
             with pytest.raises(ConfigError, match="did not match"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_version_format_with_multiple_groups(self):
         """Tests that version_format combines multiple capture groups correctly."""
@@ -660,7 +547,7 @@ class TestWebScrapeStrategyErrors:
                 "https://example.com/dl.html",
                 text='<a href="/app-v3.14.1-x64.msi">Download</a>',
             )
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
         assert version_info.version == "3.14.1"
         assert version_info.source == "web_scrape"
 
@@ -746,27 +633,25 @@ class TestWebScrapeValidateConfig:
 
 
 class TestApiGithubStrategyErrors:
-    """Tests error handling in ApiGithubStrategy.get_version_info()."""
+    """Tests error handling in ApiGithubStrategy.discover()."""
 
     def test_missing_repo_raises(self):
         """Tests that missing repo raises ConfigError."""
         strategy = ApiGithubStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.repo'"):
-            strategy.get_version_info({"discovery": {"asset_pattern": ".*"}})
+            strategy.discover({"discovery": {"asset_pattern": ".*"}})
 
     def test_invalid_repo_format_raises(self):
         """Tests that repo without slash raises ConfigError."""
         strategy = ApiGithubStrategy()
         with pytest.raises(ConfigError, match="Invalid repo format"):
-            strategy.get_version_info(
-                {"discovery": {"repo": "noslash", "asset_pattern": ".*"}}
-            )
+            strategy.discover({"discovery": {"repo": "noslash", "asset_pattern": ".*"}})
 
     def test_missing_asset_pattern_raises(self):
         """Tests that missing asset_pattern raises ConfigError."""
         strategy = ApiGithubStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.asset_pattern'"):
-            strategy.get_version_info({"discovery": {"repo": "owner/repo"}})
+            strategy.discover({"discovery": {"repo": "owner/repo"}})
 
     def test_repo_not_found_raises(self):
         """Tests that a 404 API response raises NetworkError."""
@@ -778,7 +663,7 @@ class TestApiGithubStrategyErrors:
                 status_code=404,
             )
             with pytest.raises(NetworkError, match="not found"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_rate_limited_raises(self):
         """Tests that a 403 API response raises NetworkError mentioning rate limit."""
@@ -790,7 +675,7 @@ class TestApiGithubStrategyErrors:
                 status_code=403,
             )
             with pytest.raises(NetworkError, match="rate limit"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_prerelease_rejected_when_flag_false(self):
         """Tests that a prerelease latest release is rejected when prerelease=False."""
@@ -818,7 +703,7 @@ class TestApiGithubStrategyErrors:
                 json=release_data,
             )
             with pytest.raises(NetworkError, match="pre-release"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_no_assets_raises(self):
         """Tests that a release with no assets raises NetworkError."""
@@ -831,7 +716,7 @@ class TestApiGithubStrategyErrors:
                 json=release_data,
             )
             with pytest.raises(NetworkError, match="has no assets"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_no_matching_asset_raises(self):
         """Tests that no asset matching the pattern raises ConfigError."""
@@ -853,7 +738,7 @@ class TestApiGithubStrategyErrors:
                 json=release_data,
             )
             with pytest.raises(ConfigError, match="No assets matched"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_named_version_capture_group(self):
         """Tests that a named 'version' capture group is used correctly."""
@@ -880,7 +765,7 @@ class TestApiGithubStrategyErrors:
                 "https://api.github.com/repos/owner/repo/releases/latest",
                 json=release_data,
             )
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
         assert version_info.version == "3.5.0"
         assert version_info.source == "api_github"
 
@@ -937,13 +822,13 @@ class TestApiGithubValidateConfig:
 
 
 class TestApiJsonStrategyErrors:
-    """Tests error handling in ApiJsonStrategy.get_version_info()."""
+    """Tests error handling in ApiJsonStrategy.discover()."""
 
     def test_missing_api_url_raises(self):
         """Tests that missing api_url raises ConfigError."""
         strategy = ApiJsonStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.api_url'"):
-            strategy.get_version_info(
+            strategy.discover(
                 {
                     "discovery": {
                         "version_path": "version",
@@ -956,7 +841,7 @@ class TestApiJsonStrategyErrors:
         """Tests that missing version_path raises ConfigError."""
         strategy = ApiJsonStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.version_path'"):
-            strategy.get_version_info(
+            strategy.discover(
                 {
                     "discovery": {
                         "api_url": "https://api.example.com",
@@ -969,7 +854,7 @@ class TestApiJsonStrategyErrors:
         """Tests that missing download_url_path raises ConfigError."""
         strategy = ApiJsonStrategy()
         with pytest.raises(ConfigError, match="requires 'discovery.download_url_path'"):
-            strategy.get_version_info(
+            strategy.discover(
                 {
                     "discovery": {
                         "api_url": "https://api.example.com",
@@ -991,7 +876,7 @@ class TestApiJsonStrategyErrors:
         with requests_mock.Mocker() as m:
             m.get("https://api.example.com/latest", status_code=500)
             with pytest.raises(NetworkError, match="API request failed"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_invalid_json_response_raises(self):
         """Tests that a non-JSON response raises NetworkError."""
@@ -1010,7 +895,7 @@ class TestApiJsonStrategyErrors:
                 status_code=200,
             )
             with pytest.raises(NetworkError, match="Invalid JSON"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_version_path_not_found_raises(self):
         """Tests that a version_path that matches nothing raises ConfigError."""
@@ -1028,7 +913,7 @@ class TestApiJsonStrategyErrors:
                 json={"version": "1.0.0", "download_url": "https://example.com/f.msi"},
             )
             with pytest.raises(ConfigError, match="did not match"):
-                strategy.get_version_info(app_config)
+                strategy.discover(app_config)
 
     def test_post_method(self):
         """Tests that method=POST sends a POST request."""
@@ -1050,7 +935,7 @@ class TestApiJsonStrategyErrors:
                     "download_url": "https://example.com/v2.msi",
                 },
             )
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
         assert version_info.version == "2.0.0"
         assert version_info.source == "api_json"
 
@@ -1074,7 +959,7 @@ class TestApiJsonStrategyErrors:
                     "download_url": "https://example.com/file.msi",
                 },
             )
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
             assert m.last_request.headers.get("Authorization") == "secret123"
         assert version_info.version == "1.0.0"
 
@@ -1098,7 +983,7 @@ class TestApiJsonStrategyErrors:
                     }
                 },
             )
-            version_info = strategy.get_version_info(app_config)
+            version_info = strategy.discover(app_config)
         assert version_info.version == "3.1.4"
         assert "3.1.4" in version_info.download_url
 


### PR DESCRIPTION
## Description

Consolidates the discovery strategy interface into a single `Protocol` shape. Previously the codebase had two implicit shapes (version-first and file-first) hidden behind one `DiscoveryStrategy` Protocol — a contract that didn't match what the strategies actually implemented. This caused pyright errors and forced duck-typed `hasattr` dispatch in the manager.

After this change, `DiscoveryStrategy` describes one shape that all registered strategies implement, and `url_download` is honestly modeled as the separate flow it always was.

## Motivation

- Pyright surfaced the protocol/implementation mismatch as a bundle of type errors. Patching the Protocol to model the union of two shapes would have been a band-aid; the real issue was that two unlike things were being forced through a single interface.
- The `url_download` flow has a fundamentally different shape from the other strategies: it has to download the file before it can determine the version. Modeling it as a fourth `DiscoveryStrategy` was always a fiction.
- The manager's `hasattr(strategy, "get_version_info")` branching dispatch was a code smell that fell out of the same root cause.

## Changes

**Discovery contract:**
- `DiscoveryStrategy` Protocol now has one method: `discover(app_config) -> RemoteVersion`
- All registered strategies (`api_github`, `api_json`, `web_scrape`) implement it. Method renamed from `get_version_info`.
- `url_download` is no longer a registered strategy. It moves to a dedicated `run_url_download` function dispatched directly by the manager.
- New `StrategyResult` dataclass replaces the loose 5-tuple return.
- New `resolve_with_cache` helper in `base.py` owns the version-first cache decision (skip download when version unchanged + file present).

**Orchestration:**
- `manager.py` shrinks from ~130 to ~60 lines. Dispatch is now an explicit `if strategy_name == "url_download":` at the top, with no `hasattr`/`isinstance` branching afterwards.
- `validation.py` mirrors the same dispatch for the validate command.

**Docstrings & docs:**
- All discovery module/class docstrings rewritten in current tone; outdated `source:` references corrected to `discovery:`; "From Python" library-style examples removed.
- Cross-references converted from Sphinx (`:class:`, `:func:`, `:meth:`) to mkdocstrings format (`[Display][full.dotted.path]`) so they render as links instead of literal text.
- `docs/api/index.md` updated to describe the new architecture.

**CLAUDE.md additions:**
- **Audience rule** (Project Principles): NAPT is a CLI tool, not a library. Don't write framing aimed at third-party Python consumers.
- **Cross-references rule** (Docstrings): Use mkdocstrings markdown reference link format; never Sphinx-style.
- **No meta-commentary rule** (Docstrings): Describe the subject, not the writing. Skip defensive denials and syntax explanations.

**Public surface:**
- No CLI behavior changes. Recipes using `strategy: url_download` still work identically.
- No state file format changes.
- No public Python API changes (`discover_recipe`, `validate_recipe` exports unchanged).

## Testing

- [x] Unit tests added/updated — `tests/test_discovery.py` rewritten to match new surface; `tests/test_core.py` mocks updated for new dispatch
- [x] Integration tests added/updated — existing integration tests pass unchanged
- [x] Manual testing performed — full test suite (443 tests, including integration) passes

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (docs/api/index.md only — no user-facing changes)
- [x] Tests pass (443/443)
- [x] No linting errors