### PR TITLE
fix: Correct detection and requirements script bugs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed system-scope MSIX detection and requirements scripts matching any
     installed package instead of only the target app, which could cause Intune
     to report the wrong install state
+- Fixed malformed timestamps in detection and requirements script logs when
+    the device is in a UTC+ timezone, which made CMTrace display incorrect
+    log times
 - Fixed crash when an MSIX manifest's `<PublisherDisplayName/>` element is present but contains no text. Publisher now defaults to an empty string in that case instead of triggering a downstream `TypeError`.
 
 ## [0.5.0] - 2026-04-05

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed system-scope MSIX detection and requirements scripts matching any
+    installed package instead of only the target app, which could cause Intune
+    to report the wrong install state
 - Fixed crash when an MSIX manifest's `<PublisherDisplayName/>` element is present but contains no text. Publisher now defaults to an empty string in that case instead of triggering a downstream `TypeError`.
 
 ## [0.5.0] - 2026-04-05

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     log times
 - Fixed detection and requirements scripts failing to detect installed apps
     whose registry version contains non-numeric text (e.g. `5.2 (64-bit)`)
+- Fixed generated detection and requirements scripts breaking when the app
+    name contains special characters such as quotes or dollar signs
 - Fixed crash when an MSIX manifest's `<PublisherDisplayName/>` element is present but contains no text. Publisher now defaults to an empty string in that case instead of triggering a downstream `TypeError`.
 
 ## [0.5.0] - 2026-04-05

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed malformed timestamps in detection and requirements script logs when
     the device is in a UTC+ timezone, which made CMTrace display incorrect
     log times
+- Fixed detection and requirements scripts failing to detect installed apps
+    whose registry version contains non-numeric text (e.g. `5.2 (64-bit)`)
 - Fixed crash when an MSIX manifest's `<PublisherDisplayName/>` element is present but contains no text. Publisher now defaults to an empty string in that case instead of triggering a downstream `TypeError`.
 
 ## [0.5.0] - 2026-04-05

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 | PowerShell Validation | 💡 Idea | Code Quality | High | High |
 | Recipe Linting & Best Practices | 💡 Idea | Code Quality | High | Medium |
 | Unrecognized Config Field Warnings | ✅ Completed | Code Quality | Low | Medium |
+| Prerelease Version Ranking in Detection Scripts | 💡 Idea | Code Quality | Medium | Low |
 | Typed Config with Dataclasses | 💡 Idea | Code Quality | Medium | Medium |
 | EXE Version Extraction | 💡 Idea | Technical | High | Medium |
 | Parallel Package Building | 💡 Idea | Technical | Medium | Medium |
@@ -43,8 +44,8 @@ This roadmap is a living document showing potential future directions for NAPT. 
 
 - ✅ **Completed**: 3
 - 🔬 **Investigating**: 1
-- 💡 **Ideas**: 12
-- **Total**: 16 features
+- 💡 **Ideas**: 13
+- **Total**: 17 features
 
 ---
 
@@ -217,6 +218,32 @@ style guide enforcement.
 - Warns on deprecated patterns or old v3 functions
 - Suggests improvements (e.g., use Uninstall-ADTApplication)
 - Warns about unknown fields (e.g., deprecated keys from old schema versions)
+
+#### Prerelease Version Ranking in Detection Scripts
+
+**Status**: 💡 Idea
+**Complexity**: Medium (1-3 days)
+**Value**: Low
+
+**Description**: Rank prerelease identifiers (beta, alpha, rc) when comparing
+versions in detection and requirements scripts.
+`Compare-VersionString` in `_shared_functions.ps1` strips non-numeric
+decoration, so `1.2.3-beta` currently compares equal to `1.2.3`.
+Semver-style ordering would treat prereleases as older than the release.
+
+**Benefits**:
+
+- Correct upgrade behavior when a prerelease of the target version is
+    installed (currently treated as already up to date)
+- More accurate version logging in CMTrace output
+
+**Prerequisites**:
+
+- Evidence that deployed apps actually publish prerelease `DisplayVersion`
+    strings (Windows uninstall metadata rarely follows semver)
+
+**Related**: First iteration shipped with non-numeric segments counted as 0
+and a CMTrace warning when decoration is stripped
 
 #### Typed Config with Dataclasses
 

--- a/napt/build/_ps_templates.py
+++ b/napt/build/_ps_templates.py
@@ -56,6 +56,27 @@ def _load_ps_template(name: str) -> str:
     return _INCLUDE_RE.sub(_resolve_include, content)
 
 
+def escape_ps_string(value: str) -> str:
+    """Escapes a value for embedding inside a double-quoted PowerShell string.
+
+    Backticks, double quotes, and dollar signs are prefixed with PowerShell's
+    backtick escape character so the value reads as literal text instead of
+    terminating the string or interpolating variables. App names in particular
+    come from vendor-controlled MSI ProductName metadata and can contain any
+    of these characters.
+
+    Args:
+        value: Raw string destined for a double-quoted PowerShell string.
+
+    Returns:
+        Escaped string safe to pass to substitute_ps_template() for
+        placeholders that appear inside double quotes.
+    """
+    return (
+        value.replace("`", "``").replace('"', '`"').replace("$", "`$")
+    )
+
+
 def substitute_ps_template(template: str, substitutions: dict[str, str]) -> str:
     """Substitutes $Napt* variables in a PowerShell template string.
 

--- a/napt/build/msix_scripts.py
+++ b/napt/build/msix_scripts.py
@@ -197,6 +197,7 @@ def generate_msix_detection_script(
     from napt.build._ps_templates import (
         _TEMPLATES_DIR,
         _load_ps_template,
+        escape_ps_string,
         substitute_ps_template,
     )
     from napt.logging import get_global_logger
@@ -215,9 +216,9 @@ def generate_msix_detection_script(
     script_content = substitute_ps_template(
         template,
         {
-            "$NaptPackageIdentityName": config.identity_name,
-            "$NaptAppName": config.app_name,
-            "$NaptVersion": config.version,
+            "$NaptPackageIdentityName": escape_ps_string(config.identity_name),
+            "$NaptAppName": escape_ps_string(config.app_name),
+            "$NaptVersion": escape_ps_string(config.version),
             "$NaptExactMatch": "$True" if config.exact_match else "$False",
             "$NaptLogRotationMb": str(config.log_rotation_mb),
             "$NaptScriptType": "Detection",
@@ -283,6 +284,7 @@ def generate_msix_requirements_script(
     from napt.build._ps_templates import (
         _TEMPLATES_DIR,
         _load_ps_template,
+        escape_ps_string,
         substitute_ps_template,
     )
     from napt.logging import get_global_logger
@@ -302,9 +304,9 @@ def generate_msix_requirements_script(
     script_content = substitute_ps_template(
         template,
         {
-            "$NaptPackageIdentityName": config.identity_name,
-            "$NaptAppName": config.app_name,
-            "$NaptVersion": config.version,
+            "$NaptPackageIdentityName": escape_ps_string(config.identity_name),
+            "$NaptAppName": escape_ps_string(config.app_name),
+            "$NaptVersion": escape_ps_string(config.version),
             "$NaptLogRotationMb": str(config.log_rotation_mb),
             "$NaptScriptType": "Requirements",
             "$NaptLogBaseName": "NAPTRequirements",

--- a/napt/build/registry_scripts.py
+++ b/napt/build/registry_scripts.py
@@ -208,7 +208,11 @@ def generate_detection_script(config: DetectionConfig, output_path: Path) -> Pat
             ```
 
     """
-    from napt.build._ps_templates import _load_ps_template, substitute_ps_template
+    from napt.build._ps_templates import (
+        _load_ps_template,
+        escape_ps_string,
+        substitute_ps_template,
+    )
     from napt.logging import get_global_logger
 
     logger = get_global_logger()
@@ -219,8 +223,8 @@ def generate_detection_script(config: DetectionConfig, output_path: Path) -> Pat
     script_content = substitute_ps_template(
         template,
         {
-            "$NaptAppName": config.app_name,
-            "$NaptVersion": config.version,
+            "$NaptAppName": escape_ps_string(config.app_name),
+            "$NaptVersion": escape_ps_string(config.version),
             "$NaptExactMatch": "$True" if config.exact_match else "$False",
             "$NaptLogRotationMb": str(config.log_rotation_mb),
             "$NaptIsMsiInstaller": "$True" if config.is_msi_installer else "$False",
@@ -293,7 +297,11 @@ def generate_requirements_script(
             ```
 
     """
-    from napt.build._ps_templates import _load_ps_template, substitute_ps_template
+    from napt.build._ps_templates import (
+        _load_ps_template,
+        escape_ps_string,
+        substitute_ps_template,
+    )
     from napt.logging import get_global_logger
 
     logger = get_global_logger()
@@ -306,8 +314,8 @@ def generate_requirements_script(
     script_content = substitute_ps_template(
         template,
         {
-            "$NaptAppName": config.app_name,
-            "$NaptVersion": config.version,
+            "$NaptAppName": escape_ps_string(config.app_name),
+            "$NaptVersion": escape_ps_string(config.version),
             "$NaptLogRotationMb": str(config.log_rotation_mb),
             "$NaptIsMsiInstaller": "$True" if config.is_msi_installer else "$False",
             "$NaptExpectedArchitecture": config.expected_architecture,

--- a/napt/build/templates/_msix_shared_system.ps1
+++ b/napt/build/templates/_msix_shared_system.ps1
@@ -6,7 +6,7 @@ function Get-InstalledAppxPackage {
 
     try {
         $Provisioned = Get-AppxProvisionedPackage -Online -ErrorAction Stop |
-            Where-Object { $_.PackageName -like "$PackageIdentityName_*" } |
+            Where-Object { $_.PackageName -like "${PackageIdentityName}_*" } |
             Sort-Object { [Version]($_.PackageName -split '_')[1] } -Descending |
             Select-Object -First 1
         if ($Provisioned) {

--- a/napt/build/templates/_shared_functions.ps1
+++ b/napt/build/templates/_shared_functions.ps1
@@ -45,6 +45,59 @@ function Write-CMTraceLog {
     }
 }
 
+# Parse a version string into numeric parts. Each '.'- or '-'-separated
+# segment contributes its leading digits; segments without leading digits
+# count as 0, so prerelease identifiers are not ranked ("1.2.3-beta"
+# parses the same as "1.2.3.0").
+function ConvertTo-VersionParts {
+    param(
+        [string]$Version
+    )
+
+    $Parts = @()
+    $HasNonNumeric = $false
+
+    foreach ($Segment in ($Version -split '[.\-]')) {
+        if ($Segment -match '^(\d+)') {
+            $Parts += [int64]$Matches[1]
+            if ($Segment -ne $Matches[1]) { $HasNonNumeric = $true }
+        } else {
+            $Parts += [int64]0
+            $HasNonNumeric = $true
+        }
+    }
+
+    if ($HasNonNumeric) {
+        Write-CMTraceLog -Message "[$NaptScriptType] Version '$Version' contains non-numeric segments, comparing as '$($Parts -join '.')'" -Type "WARNING"
+    }
+
+    return ,$Parts
+}
+
+# Compare two version strings numerically. Returns -1 if Left < Right,
+# 0 if equal, 1 if Left > Right. Missing trailing parts count as 0.
+function Compare-VersionString {
+    param(
+        [string]$LeftVersion,
+        [string]$RightVersion
+    )
+
+    $LeftParts = ConvertTo-VersionParts -Version $LeftVersion
+    $RightParts = ConvertTo-VersionParts -Version $RightVersion
+
+    $MaxLength = [Math]::Max($LeftParts.Count, $RightParts.Count)
+
+    for ($i = 0; $i -lt $MaxLength; $i++) {
+        $LeftPart = if ($i -lt $LeftParts.Count) { $LeftParts[$i] } else { [int64]0 }
+        $RightPart = if ($i -lt $RightParts.Count) { $RightParts[$i] } else { [int64]0 }
+
+        if ($LeftPart -gt $RightPart) { return 1 }
+        if ($LeftPart -lt $RightPart) { return -1 }
+    }
+
+    return 0
+}
+
 # Determine log file location
 function Initialize-LogFile {
     $script:CurrentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()

--- a/napt/build/templates/_shared_functions.ps1
+++ b/napt/build/templates/_shared_functions.ps1
@@ -22,11 +22,12 @@ function Write-CMTraceLog {
         default { 1 }  # Default to INFO if unknown
     }
 
-    # Format time: HH:mm:ss.fff-offset (offset in minutes, e.g., -480 for -08:00)
+    # Format time: HH:mm:ss.fff+bias. ConfigMgr bias is UTC minus local time
+    # in minutes with an explicit sign (e.g., +480 for UTC-8, -120 for UTC+2).
     $Now = [DateTimeOffset](Get-Date)
     $TimeFormatted = $Now.ToString("HH:mm:ss.fff")
-    $OffsetMinutes = [int]$Now.Offset.TotalMinutes
-    $TimeWithOffset = "$TimeFormatted$OffsetMinutes"
+    $BiasMinutes = -[int]$Now.Offset.TotalMinutes
+    $TimeWithOffset = "$TimeFormatted$($BiasMinutes.ToString('+000;-000'))"
 
     # Format date: M-d-yyyy (single digit month/day when appropriate)
     $DateFormatted = $Now.ToString("M-d-yyyy")

--- a/napt/build/templates/msix_detection_script.ps1
+++ b/napt/build/templates/msix_detection_script.ps1
@@ -14,39 +14,6 @@ param(
 
 $NaptMsixSharedHelper
 
-# Version comparison function
-function Compare-Version {
-    param(
-        [string]$InstalledVersion,
-        [string]$ExpectedVersion,
-        [bool]$ExactMatch
-    )
-
-    if ($ExactMatch) {
-        return $InstalledVersion -eq $ExpectedVersion
-    }
-
-    # Minimum version comparison (installed >= expected)
-    $InstalledParts = $InstalledVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-    $ExpectedParts = $ExpectedVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-
-    $MaxLength = [Math]::Max($InstalledParts.Count, $ExpectedParts.Count)
-
-    for ($i = 0; $i -lt $MaxLength; $i++) {
-        $InstalledPart = if ($i -lt $InstalledParts.Count) { $InstalledParts[$i] } else { 0 }
-        $ExpectedPart = if ($i -lt $ExpectedParts.Count) { $ExpectedParts[$i] } else { 0 }
-
-        if ($InstalledPart -gt $ExpectedPart) {
-            return $true
-        }
-        if ($InstalledPart -lt $ExpectedPart) {
-            return $false
-        }
-    }
-
-    return $true  # Versions are equal
-}
-
 # Main detection logic
 Initialize-LogFile
 
@@ -65,7 +32,12 @@ if ($Package) {
     Write-CMTraceLog -Message "[Detection] Match found: $($Package.Name) (Found: $InstalledVersion, Arch: $($Package.Architecture))" -Type "INFO"
 
     if ($InstalledVersion) {
-        if (Compare-Version -InstalledVersion $InstalledVersion -ExpectedVersion $ExpectedVersion -ExactMatch $ExactMatch) {
+        $VersionSatisfied = if ($ExactMatch) {
+            $InstalledVersion -eq $ExpectedVersion
+        } else {
+            (Compare-VersionString -LeftVersion $InstalledVersion -RightVersion $ExpectedVersion) -ge 0
+        }
+        if ($VersionSatisfied) {
             Write-CMTraceLog -Message "[Detection] Version check passed: $InstalledVersion $(if ($ExactMatch) { '=' } else { '>=' }) $ExpectedVersion" -Type "INFO"
             Write-CMTraceLog -Message "[Result] Detected: $NaptAppName (Found: $InstalledVersion, Expected: $(if ($ExactMatch) { '=' } else { '>=' }) $ExpectedVersion, Mode: $(if ($ExactMatch) { 'Exact' } else { 'Minimum' }))" -Type "INFO"
             Write-Output "Installed"

--- a/napt/build/templates/msix_requirements_script.ps1
+++ b/napt/build/templates/msix_requirements_script.ps1
@@ -13,34 +13,6 @@ param(
 
 $NaptMsixSharedHelper
 
-# Version comparison function - returns true if Installed < Target
-function Compare-VersionLessThan {
-    param(
-        [string]$InstalledVersion,
-        [string]$TargetVersion
-    )
-
-    # Parse version parts
-    $InstalledParts = $InstalledVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-    $TargetParts = $TargetVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-
-    $MaxLength = [Math]::Max($InstalledParts.Count, $TargetParts.Count)
-
-    for ($i = 0; $i -lt $MaxLength; $i++) {
-        $InstalledPart = if ($i -lt $InstalledParts.Count) { $InstalledParts[$i] } else { 0 }
-        $TargetPart = if ($i -lt $TargetParts.Count) { $TargetParts[$i] } else { 0 }
-
-        if ($InstalledPart -lt $TargetPart) {
-            return $true
-        }
-        if ($InstalledPart -gt $TargetPart) {
-            return $false
-        }
-    }
-
-    return $false  # Versions are equal, so not less than
-}
-
 # Main requirements logic
 Initialize-LogFile
 
@@ -59,7 +31,7 @@ if ($Package) {
     Write-CMTraceLog -Message "[Requirements] Match found: $($Package.Name) (Found: $InstalledVersion, Arch: $($Package.Architecture))" -Type "INFO"
 
     if ($InstalledVersion) {
-        if (Compare-VersionLessThan -InstalledVersion $InstalledVersion -TargetVersion $TargetVersion) {
+        if ((Compare-VersionString -LeftVersion $InstalledVersion -RightVersion $TargetVersion) -lt 0) {
             Write-CMTraceLog -Message "[Requirements] Version check passed: $InstalledVersion < $TargetVersion" -Type "INFO"
             Write-CMTraceLog -Message "[Result] Update Required: $NaptAppName (Found: $InstalledVersion, Expected: < $TargetVersion)" -Type "INFO"
             Write-Output "Required"

--- a/napt/build/templates/registry_detection_script.ps1
+++ b/napt/build/templates/registry_detection_script.ps1
@@ -14,39 +14,6 @@ param(
 
 # <include _shared_functions.ps1>
 
-# Version comparison function
-function Compare-Version {
-    param(
-        [string]$InstalledVersion,
-        [string]$ExpectedVersion,
-        [bool]$ExactMatch
-    )
-
-    if ($ExactMatch) {
-        return $InstalledVersion -eq $ExpectedVersion
-    }
-
-    # Minimum version comparison (installed >= expected)
-    $InstalledParts = $InstalledVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-    $ExpectedParts = $ExpectedVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-
-    $MaxLength = [Math]::Max($InstalledParts.Count, $ExpectedParts.Count)
-
-    for ($i = 0; $i -lt $MaxLength; $i++) {
-        $InstalledPart = if ($i -lt $InstalledParts.Count) { $InstalledParts[$i] } else { 0 }
-        $ExpectedPart = if ($i -lt $ExpectedParts.Count) { $ExpectedParts[$i] } else { 0 }
-
-        if ($InstalledPart -gt $ExpectedPart) {
-            return $true
-        }
-        if ($InstalledPart -lt $ExpectedPart) {
-            return $false
-        }
-    }
-
-    return $true  # Versions are equal
-}
-
 # Main detection logic
 Initialize-LogFile
 
@@ -114,7 +81,12 @@ foreach ($KeyInfo in $AllKeys) {
             Write-CMTraceLog -Message "[Detection] Match found: $DisplayName (Found: $(if ($InstalledVersion) { $InstalledVersion } else { 'None' }), Type: $(if ($IsMSIEntry) { 'MSI' } else { 'Non-MSI' }), Arch: $($KeyInfo.View), Path: $RegKeyPath)" -Type "INFO"
 
             if ($InstalledVersion) {
-                if (Compare-Version -InstalledVersion $InstalledVersion -ExpectedVersion $ExpectedVersion -ExactMatch $ExactMatch) {
+                $VersionSatisfied = if ($ExactMatch) {
+                    $InstalledVersion -eq $ExpectedVersion
+                } else {
+                    (Compare-VersionString -LeftVersion $InstalledVersion -RightVersion $ExpectedVersion) -ge 0
+                }
+                if ($VersionSatisfied) {
                     Write-CMTraceLog -Message "[Detection] Version check passed: $InstalledVersion $(if ($ExactMatch) { '=' } else { '>=' }) $ExpectedVersion" -Type "INFO"
                     $Found = $true
                     break

--- a/napt/build/templates/registry_requirements_script.ps1
+++ b/napt/build/templates/registry_requirements_script.ps1
@@ -13,34 +13,6 @@ param(
 
 # <include _shared_functions.ps1>
 
-# Version comparison function - returns true if Installed < Target
-function Compare-VersionLessThan {
-    param(
-        [string]$InstalledVersion,
-        [string]$TargetVersion
-    )
-
-    # Parse version parts
-    $InstalledParts = $InstalledVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-    $TargetParts = $TargetVersion -split '[.\-]' | ForEach-Object { [int]$_ }
-
-    $MaxLength = [Math]::Max($InstalledParts.Count, $TargetParts.Count)
-
-    for ($i = 0; $i -lt $MaxLength; $i++) {
-        $InstalledPart = if ($i -lt $InstalledParts.Count) { $InstalledParts[$i] } else { 0 }
-        $TargetPart = if ($i -lt $TargetParts.Count) { $TargetParts[$i] } else { 0 }
-
-        if ($InstalledPart -lt $TargetPart) {
-            return $true
-        }
-        if ($InstalledPart -gt $TargetPart) {
-            return $false
-        }
-    }
-
-    return $false  # Versions are equal, so not less than
-}
-
 # Main requirements logic
 Initialize-LogFile
 
@@ -108,7 +80,7 @@ foreach ($KeyInfo in $AllKeys) {
             Write-CMTraceLog -Message "[Requirements] Match found: $DisplayName (Found: $(if ($InstalledVersion) { $InstalledVersion } else { 'None' }), Type: $(if ($IsMSIEntry) { 'MSI' } else { 'Non-MSI' }), Arch: $($KeyInfo.View), Path: $RegKeyPath)" -Type "INFO"
 
             if ($InstalledVersion) {
-                if (Compare-VersionLessThan -InstalledVersion $InstalledVersion -TargetVersion $TargetVersion) {
+                if ((Compare-VersionString -LeftVersion $InstalledVersion -RightVersion $TargetVersion) -lt 0) {
                     Write-CMTraceLog -Message "[Requirements] Version check passed: $InstalledVersion < $TargetVersion" -Type "INFO"
                     $FoundOlderVersion = $true
                     break

--- a/tests/build/test_ps_templates.py
+++ b/tests/build/test_ps_templates.py
@@ -1,0 +1,78 @@
+"""Tests for napt.build._ps_templates module.
+
+Tests PowerShell template handling including:
+- Escaping values for double-quoted PowerShell strings
+- Escaped values surviving template substitution
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from napt.build._ps_templates import escape_ps_string
+from napt.build.registry_scripts import (
+    DetectionConfig,
+    generate_detection_script,
+)
+
+# All tests in this file are unit tests (fast, mocked)
+
+
+class TestEscapePsString:
+    """Tests for escaping values embedded in double-quoted PowerShell strings."""
+
+    def test_plain_string_unchanged(self):
+        """Tests that a string without special characters is unchanged."""
+        assert escape_ps_string("Google Chrome") == "Google Chrome"
+
+    def test_double_quote_escaped(self):
+        """Tests that double quotes are backtick-escaped."""
+        assert escape_ps_string('App "Pro" Edition') == 'App `"Pro`" Edition'
+
+    def test_dollar_sign_escaped(self):
+        """Tests that dollar signs are backtick-escaped."""
+        assert escape_ps_string("Cost$aver Pro") == "Cost`$aver Pro"
+
+    def test_backtick_escaped(self):
+        """Tests that backticks are doubled."""
+        assert escape_ps_string("a`b") == "a``b"
+
+    def test_backtick_escaped_before_other_characters(self):
+        """Tests that pre-existing backticks don't double-escape added ones."""
+        assert escape_ps_string('`"') == '```"'
+
+    def test_empty_string(self):
+        """Tests that an empty string passes through."""
+        assert escape_ps_string("") == ""
+
+
+class TestEscapedGeneration:
+    """Tests that special characters in config values reach scripts escaped."""
+
+    def test_app_name_with_quotes_is_escaped(self, tmp_path: Path):
+        """Tests that quotes in app_name are escaped in the generated script."""
+        config = DetectionConfig(
+            app_name='VMware Horizon "FIPS" Client',
+            version="1.0.0",
+        )
+        output_path = tmp_path / "detection.ps1"
+
+        generate_detection_script(config, output_path)
+
+        content = output_path.read_text(encoding="utf-8-sig")
+        assert 'VMware Horizon `"FIPS`" Client' in content
+        assert 'VMware Horizon "FIPS" Client' not in content
+
+    def test_app_name_with_dollar_is_escaped(self, tmp_path: Path):
+        """Tests that dollar signs in app_name are escaped in the script."""
+        config = DetectionConfig(
+            app_name="Cost$aver Pro",
+            version="1.0.0",
+        )
+        output_path = tmp_path / "detection.ps1"
+
+        generate_detection_script(config, output_path)
+
+        content = output_path.read_text(encoding="utf-8-sig")
+        assert "Cost`$aver Pro" in content
+        assert "Cost$aver Pro" not in content

--- a/tests/build/test_requirements.py
+++ b/tests/build/test_requirements.py
@@ -141,7 +141,7 @@ class TestGenerateRequirementsScript:
         # Check for Required output logic
         assert 'Write-Output "Required"' in content
         # Check for version comparison function
-        assert "Compare-VersionLessThan" in content
+        assert "Compare-VersionString" in content
         # Check that script always exits 0
         assert "exit 0" in content
 


### PR DESCRIPTION
## Description
Fixes four bugs in the generated detection and requirements scripts (registry and MSIX) that could cause Intune to misreport install state or break the scripts outright.

## Motivation
These scripts run on managed devices to report install/applicability state. Each bug below could produce a wrong result or a hard failure in the field. Landing these on `main` so a patch release can be cut.

## Changes
- Scope the system-scope MSIX detection/requirements filter to the target app instead of matching any installed package
- Write the CMTrace timezone bias with a sign so logs render correct times in UTC+ timezones
- Handle registry versions containing non-numeric text (e.g. `5.2 (64-bit)`) during detection
- Escape values embedded in generated scripts so app names with quotes or `$` no longer break them

## Testing
How was this tested?
- [x] Unit tests added/updated (`tests/build/test_ps_templates.py`, `tests/build/test_requirements.py`)
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (changelog)
- [x] Tests pass
- [x] No linting errors