### PR TITLE
chore: Prepare release 0.5.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-22
+
 ### Fixed
 
 - Fixed system-scope MSIX detection and requirements scripts matching any
@@ -223,7 +225,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.1...HEAD
+[0.5.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.0...0.3.1

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.5.0"
+version = "0.5.1"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description
Release PR for NAPT 0.5.1. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[0.5.1] - 2026-06-22`, and adds a fresh empty `[Unreleased]` section.

## Motivation
Cuts the 0.5.1 patch release — a bundle of detection/requirements script fixes. Squash-merge this PR, then `/release 0.5.1` again to tag and publish.

## Changes
- Bump `pyproject.toml` version to 0.5.1
- Bump `napt/__init__.py` `__version__` to 0.5.1
- Promote `[Unreleased]` to `[0.5.1] - 2026-06-22` in `docs/changelog.md`
- Add comparison link `[0.5.1]: ...compare/0.5.0...0.5.1`

Release contents (all bug fixes):
- Scope system-scope MSIX detection/requirements to the target app instead of any installed package
- Write CMTrace timezone bias with a sign so UTC+ timezones log correct times
- Detect installed apps whose registry version contains non-numeric text (e.g. `5.2 (64-bit)`)
- Escape values embedded in generated scripts so app names with quotes or `$` don't break them
- Default MSIX publisher to empty string when `<PublisherDisplayName/>` is present but empty

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (run via `pytest tests/`)
- [x] Manual testing performed (n/a — release prep only, no code changes)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (changelog promoted)
- [x] Tests pass
- [x] No linting errors