### PR TITLE
fix: Overhaul recipe variable substitution

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,15 +16,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the size closest to Intune's recommended 256px. Drop a custom PNG at
     `icons/{id}.png` to override (NAPT never overwrites existing files),
     or set `intune.logo_path` to disable extraction for a recipe
+- **`{{installer_filename}}` recipe variable** - Substituted at build time
+    in `psadt.install`, `psadt.uninstall`, and `psadt.app_vars` with the
+    exact filename of the downloaded installer in the package's Files
+    directory. Replaces wildcard paths, which PSADT does not support
+- **Unrecognized variable warning** - `napt build` warns when an install
+    or uninstall script contains a `{{snake_case}}` token that is not a
+    supported NAPT variable
 
 ### Changed
 
+- **BREAKING: Recipe variable syntax** - NAPT build-time variables now use
+    `{{...}}` instead of `${...}`. Replace `${discovered_version}` with
+    `{{discovered_version}}` in recipes. `${...}` now exclusively means
+    environment variables, which work only in `discovery.token` and
+    `discovery.headers`
 - **`intune.logo_path` file types restricted to PNG and JPEG** - Other
     file types now warn and fall back to the extracted icon instead of
     uploading with a guessed MIME type
 
 ### Fixed
 
+- Fixed the version variable never being substituted in `psadt.install`
+    and `psadt.uninstall` scripts, where it reached PowerShell as literal
+    `${...}` syntax and silently expanded to an empty string at deploy time
+- Fixed 7-Zip recipes failing at deploy time because PSADT resolves
+    `-FilePath` literally and does not expand wildcards; the recipes now
+    use `{{installer_filename}}`
 - Fixed `intune.logo_path` relative paths resolving from the current
     working directory instead of the recipe file's location as documented
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,9 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in `psadt.install`, `psadt.uninstall`, and `psadt.app_vars` with the
     exact filename of the downloaded installer in the package's Files
     directory. Replaces wildcard paths, which PSADT does not support
-- **Unrecognized variable warning** - `napt build` warns when an install
-    or uninstall script contains a `{{snake_case}}` token that is not a
-    supported NAPT variable
+- **Unrecognized variable warning** - `napt build` warns when an
+    `app_vars` value or an install/uninstall script contains a
+    `{{snake_case}}` token that is not a supported NAPT variable
 
 ### Changed
 

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -127,9 +127,9 @@ intune:
 psadt:
   app_vars:
     AppName: "Git for Windows"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
-    Start-ADTProcess -Path "$dirFiles\Git-${discovered_version}-64-bit.exe" -Parameters "/VERYSILENT /NORESTART"
+    Start-ADTProcess -FilePath "Git-{{discovered_version}}-64-bit.exe" -ArgumentList "/VERYSILENT /NORESTART"
   uninstall: |
     Uninstall-ADTApplication -Name "Git"
 ```
@@ -182,9 +182,9 @@ intune:
 psadt:
   app_vars:
     AppName: "7-Zip"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
-    Start-ADTMsiProcess -Action Install -Path "$dirFiles\7z*-x64.msi" -Parameters "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
   uninstall: |
     Uninstall-ADTApplication -Name "7-Zip"
 ```
@@ -232,9 +232,9 @@ discovery:
 psadt:
   app_vars:
     AppName: "Application Name"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
-    Start-ADTProcess -Path "$dirFiles\app-installer.exe" -Parameters "/S"
+    Start-ADTProcess -FilePath "{{installer_filename}}" -ArgumentList "/S"
   uninstall: |
     Uninstall-ADTApplication -Name "Application Name"
 ```
@@ -296,7 +296,7 @@ discovery:
 psadt:
   app_vars:
     AppName: "Slack"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
 ```
 
 2. Validate and test:
@@ -365,9 +365,9 @@ discovery:
 psadt:
   app_vars:
     AppName: "Google Chrome"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
-    Start-ADTMsiProcess -Action Install -Path "$dirFiles\googlechromestandaloneenterprise64.msi" -Parameters "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "googlechromestandaloneenterprise64.msi" -ArgumentList "ALLUSERS=1"
   uninstall: |
     Uninstall-ADTApplication -Name "Google Chrome"
 ```

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -367,7 +367,7 @@ psadt:
     AppName: "Google Chrome"
     AppVersion: "{{discovered_version}}"
   install: |
-    Start-ADTMsiProcess -Action Install -FilePath "googlechromestandaloneenterprise64.msi" -ArgumentList "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
   uninstall: |
     Uninstall-ADTApplication -Name "Google Chrome"
 ```

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -306,9 +306,9 @@ psadt:
   release: "latest"                      # Optional: PSADT release version
   app_vars:                              # Optional: PSADT application variables
     AppName: "Application Name"
-    AppVersion: "${discovered_version}"  # Use for auto-substitution
+    AppVersion: "{{discovered_version}}" # Substituted at build time
   install: |                             # Required: PowerShell installation script
-    Start-ADTMsiProcess -Action Install -Path "$dirFiles\installer.msi" -Parameters "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
   uninstall: |                           # Required: PowerShell uninstallation script
     Uninstall-ADTApplication -Name "Application Name"
 ```
@@ -337,16 +337,20 @@ PSADT application variables set in the generated `Invoke-AppDeployToolkit.ps1` f
 **Common Variables:**
 
 - `AppName`: Display name shown in PSADT dialogs
-- `AppVersion`: Application version (use `${discovered_version}` for auto-substitution)
+- `AppVersion`: Application version (use `{{discovered_version}}` for auto-substitution)
 - `AppVendor`: Vendor name (typically set in vendor defaults)
 - `AppArch`: Architecture (`x64`, `x86`, or `All`)
 - `AppLang`: Application language
 
-**Special Variable:** `${discovered_version}` is automatically substituted with the version
-discovered by NAPT. Use this in `AppVersion` to ensure the version matches the downloaded
-installer.
+**Build-time variables:** NAPT substitutes `{{discovered_version}}` (the version
+discovered by NAPT) and `{{installer_filename}}` (the exact filename of the downloaded
+installer) in all `app_vars` values.
+Use `{{discovered_version}}` in `AppVersion` to ensure the version matches the
+downloaded installer.
 
-**Environment Variable Substitution:** All values support `${VARIABLE_NAME}` syntax.
+For org-wide values such as `AppVendor`, set them once in `defaults/org.yaml`
+(or a vendor file) instead of repeating them per recipe — the configuration
+layers are deep-merged into every recipe.
 
 ### override_msix_commands
 
@@ -399,12 +403,17 @@ psadt:
 PowerShell script executed during installation. Inserted into the generated
 `Invoke-AppDeployToolkit.ps1` in the installation section.
 
-**Available Variables:**
+**Build-time variables** (substituted by NAPT when the script is generated —
+these are not PowerShell variables):
 
-- `$($adtSession.DirFiles)`: Path to installer files directory (contains downloaded installer)
-- `$discovered_version`: Version discovered by NAPT
-- Standard PSADT variables: `$dirApp`, `$dirSupportFiles`, etc.
-- All `app_vars` are available (e.g., `$AppName`, `$AppVersion`)
+- `{{discovered_version}}`: Version discovered by NAPT
+- `{{installer_filename}}`: Exact filename of the downloaded installer in the
+  package's `Files` directory
+
+**PowerShell variables** (available at deploy time):
+
+- `$($adtSession.DirFiles)`: Path to the installer files directory
+- `$adtSession.AppName`, `$adtSession.AppVersion`, etc.: Values from `app_vars`
 
 **Commonly Used PSADT Functions:**
 
@@ -412,10 +421,14 @@ PowerShell script executed during installation. Inserted into the generated
 - `Start-ADTMsiProcess`: Install MSI files with parameters
 - `Uninstall-ADTApplication`: Uninstall applications by name
 
+**Note:** PSADT resolves a relative `-FilePath` against the `Files` directory
+and does not expand wildcards.
+Use `{{installer_filename}}` instead of a wildcard pattern.
+
 **Example:**
 ```yaml
 install: |
-  Start-ADTMsiProcess -Action Install -Path "$dirFiles\installer.msi" -Parameters "ALLUSERS=1 /qn"
+  Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
 ```
 
 ### uninstall
@@ -749,9 +762,11 @@ generated script filenames.
 characters removed). Script filenames follow the pattern:
 `{DisplayName}_{Version}-Detection.ps1` and `{DisplayName}_{Version}-Requirements.ps1`.
 
-**Template Variable Support:** `${discovered_version}` is automatically substituted with the
+**Template Variable Support:** `{{discovered_version}}` is automatically substituted with the
 discovered version. Use this when the registry DisplayName includes the version number (e.g.,
 "7-Zip 25.01 (x64)").
+This is the only build-time variable supported here; `{{installer_filename}}` never appears
+in a registry DisplayName.
 
 **Wildcard Support:** When `display_name` contains wildcards (`*` or `?`), scripts use
 PowerShell's `-like` operator instead of exact `-eq` matching:
@@ -772,7 +787,7 @@ intune:
 ```yaml
 intune:
   detection:
-    display_name: "7-Zip ${discovered_version} (x64)"  # Matches "7-Zip 25.01 (x64)"
+    display_name: "7-Zip {{discovered_version}} (x64)"  # Matches "7-Zip 25.01 (x64)"
 ```
 
 **Example with wildcard (for MSI with override):**
@@ -947,30 +962,45 @@ it does not exist and verifying write access). If that fails (e.g., permissions)
 to `C:\ProgramData\NAPT\` (system) or `%LOCALAPPDATA%\NAPT\` (user). If both fail, a warning is
 written to stderr and the script runs without a log file.
 
-## Environment Variable Substitution
+## Variable Substitution
 
-NAPT supports environment variable substitution throughout recipe files using `${VARIABLE_NAME}`
-syntax.
+Recipes use two distinct substitution mechanisms with different syntax.
 
-### Where It Works
+### NAPT build-time variables: `{{...}}`
 
-- **Discovery configuration:** API tokens, authentication headers
-- **PSADT app_vars:** Any variable value
-- **Special variable:** `${discovered_version}` is automatically substituted with the discovered
-  version
+NAPT substitutes these while generating the package (they are not PowerShell
+variables):
+
+| Variable | Value | Supported fields |
+|----------|-------|------------------|
+| `{{discovered_version}}` | Version discovered by NAPT | `psadt.app_vars`, `psadt.install`, `psadt.uninstall`, `intune.detection.display_name` |
+| `{{installer_filename}}` | Exact filename of the downloaded installer | `psadt.app_vars`, `psadt.install`, `psadt.uninstall` |
+
+`napt build` logs a warning if an install or uninstall script contains a
+`{{snake_case}}` token that is not a supported variable.
+
+### Environment variables: `${VARIABLE_NAME}`
+
+Environment variable substitution exists for secrets that must not be committed
+to YAML.
+It works **only** in `discovery.token` and `discovery.headers`.
+
+For non-secret org-wide values (e.g., `AppVendor`), use the configuration layers
+(`defaults/org.yaml`, `defaults/vendors/{Vendor}.yaml`) instead.
 
 ### Syntax
 
 ```yaml
 discovery:
-  token: "${GITHUB_TOKEN}"
+  token: "${GITHUB_TOKEN}"               # Environment variable (secrets only)
   headers:
-    Authorization: "Bearer ${API_TOKEN}"
+    Authorization: "Bearer ${API_TOKEN}" # Environment variable (secrets only)
 
 psadt:
   app_vars:
-    AppVersion: "${discovered_version}"  # NAPT auto-substitution
-    AppVendor: "${ORG_NAME}"             # Environment variable
+    AppVersion: "{{discovered_version}}" # NAPT build-time substitution
+  install: |
+    Start-ADTProcess -FilePath "{{installer_filename}}" -ArgumentList "/S"
 ```
 
 ### Setting Environment Variables
@@ -1015,9 +1045,9 @@ intune:
 psadt:
   app_vars:
     AppName: "Example Application"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
-    Start-ADTProcess -Path "$dirFiles\*.exe" -Parameters "/S"
+    Start-ADTProcess -FilePath "{{installer_filename}}" -ArgumentList "/S"
   uninstall: |
     Uninstall-ADTApplication -Name "Example Application"
 ```

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -976,8 +976,8 @@ variables):
 | `{{discovered_version}}` | Version discovered by NAPT | `psadt.app_vars`, `psadt.install`, `psadt.uninstall`, `intune.detection.display_name` |
 | `{{installer_filename}}` | Exact filename of the downloaded installer | `psadt.app_vars`, `psadt.install`, `psadt.uninstall` |
 
-`napt build` logs a warning if an install or uninstall script contains a
-`{{snake_case}}` token that is not a supported variable.
+`napt build` logs a warning if an `app_vars` value or an install/uninstall
+script contains a `{{snake_case}}` token that is not a supported variable.
 
 ### Environment variables: `${VARIABLE_NAME}`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -481,7 +481,7 @@ discovery:             # Discovery configuration
 psadt:                 # PSADT configuration
   app_vars:
     AppName: "Application Name"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |           # Installation script
     # PowerShell code here
   uninstall: |         # Uninstallation script
@@ -498,7 +498,7 @@ intune:                # Optional: Intune-specific settings
 - **Top-level fields:** `apiVersion` (required), `name` (required), `id` (required),
   `discovery` (required), `psadt` (required), `intune` (optional), `logging` (optional)
 - **Discovery strategies:** See [Discovery Strategies](#discovery-strategies) section above for strategy selection and examples
-- **PSADT scripts:** Use `${discovered_version}` for auto-substituted version, `$($adtSession.DirFiles)` for installer path (PSADT 4.x)
+- **PSADT scripts:** NAPT substitutes `{{discovered_version}}` and `{{installer_filename}}` at build time (these are not PowerShell variables); `${UPPERCASE}` env vars work only in `discovery.token`/`discovery.headers`; use `$($adtSession.DirFiles)` for the files directory path (PSADT 4.x)
 
 ### Complete Documentation
 

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -481,7 +481,7 @@ def _resolve_app_info(
         installer_file: Path to the installer file.
         config: Recipe configuration.
         version: Extracted version string (used for
-            ${discovered_version} substitution).
+            {{discovered_version}} substitution).
         msi_metadata: Pre-extracted MSI metadata (non-None for MSI
             installers).
         msix_metadata: Pre-extracted MSIX metadata (non-None for MSIX
@@ -564,8 +564,7 @@ def _resolve_app_info(
                     "override_msi_display_name."
                 )
             app_name = detection_settings["display_name"]
-            if "${discovered_version}" in app_name:
-                app_name = app_name.replace("${discovered_version}", version)
+            app_name = app_name.replace("{{discovered_version}}", version)
             logger.verbose("BUILD", f"Using display_name (override): {app_name}")
         else:
             if not msi_metadata.product_name:
@@ -598,8 +597,7 @@ def _resolve_app_info(
 
     elif detection_settings.get("display_name"):
         app_name = detection_settings["display_name"]
-        if "${discovered_version}" in app_name:
-            app_name = app_name.replace("${discovered_version}", version)
+        app_name = app_name.replace("{{discovered_version}}", version)
         logger.verbose("BUILD", f"Using intune.detection.display_name: {app_name}")
 
         if detection_settings.get("architecture"):
@@ -1220,7 +1218,8 @@ def build_package(
 
     template_path = psadt_cache_dir / "Invoke-AppDeployToolkit.ps1"
     invoke_script = generate_invoke_script(
-        template_path, config, version, psadt_version, architecture
+        template_path, config, version, psadt_version, architecture,
+        installer_file.name,
     )
 
     # Write generated script

--- a/napt/build/template.py
+++ b/napt/build/template.py
@@ -35,7 +35,9 @@ Example:
             template_path=Path("cache/psadt/4.1.7/Invoke-AppDeployToolkit.ps1"),
             config=recipe_config,
             version="141.0.7390.123",
-            psadt_version="4.1.7"
+            psadt_version="4.1.7",
+            architecture="x64",
+            installer_filename="installer.msi",
         )
 
         Path("builds/app/version/Invoke-AppDeployToolkit.ps1").write_text(script)
@@ -88,8 +90,66 @@ def _format_powershell_value(value: Any) -> str:
         return f"'{str(value)}'"
 
 
+# Leftover {{snake_case}} tokens after substitution; digit-led sequences like
+# the .NET format-string escape "{{0}}" intentionally don't match.
+_UNRECOGNIZED_TOKEN_RE = re.compile(r"\{\{[a-z][a-z0-9_]*\}\}")
+
+_SUPPORTED_VARIABLES = "{{discovered_version}}, {{installer_filename}}"
+
+
+def _substitute_variables(text: str, version: str, installer_filename: str) -> str:
+    """Substitutes NAPT build-time variables in recipe-provided text.
+
+    Replaces {{discovered_version}} with the discovered application version
+    and {{installer_filename}} with the exact filename of the installer
+    copied into the package's Files directory.
+
+    Args:
+        text: Recipe-provided text that may contain variable tokens.
+        version: Discovered application version.
+        installer_filename: Installer filename in the Files directory.
+
+    Returns:
+        Text with all supported variable tokens replaced.
+    """
+    # str.replace, not re.sub: filenames may contain regex-special characters
+    text = text.replace("{{discovered_version}}", version)
+    return text.replace("{{installer_filename}}", installer_filename)
+
+
+def _warn_unrecognized_tokens(code: str, block_name: str) -> None:
+    """Warns about unrecognized variable tokens left after substitution.
+
+    Called after [_substitute_variables][napt.build.template._substitute_variables]
+    has run, so any remaining {{snake_case}} token is not a supported NAPT
+    variable. Unrecognized tokens pass through to the generated PowerShell
+    script verbatim.
+
+    Args:
+        code: Install or uninstall code after substitution.
+        block_name: Recipe field name for the warning message (e.g.,
+            "psadt.install").
+    """
+    from napt.logging import get_global_logger
+
+    tokens = sorted(set(_UNRECOGNIZED_TOKEN_RE.findall(code)))
+    if tokens:
+        logger = get_global_logger()
+        logger.warning(
+            "BUILD",
+            f"{block_name} contains unrecognized variable(s): "
+            f"{', '.join(tokens)}. Supported NAPT variables: "
+            f"{_SUPPORTED_VARIABLES}. Unrecognized tokens are left as-is "
+            "in the generated script.",
+        )
+
+
 def _build_adtsession_vars(
-    config: dict[str, Any], version: str, psadt_version: str, architecture: str
+    config: dict[str, Any],
+    version: str,
+    psadt_version: str,
+    architecture: str,
+    installer_filename: str,
 ) -> dict[str, Any]:
     """Build the $adtSession hashtable variables from configuration.
 
@@ -101,6 +161,7 @@ def _build_adtsession_vars(
         psadt_version: PSADT version being used.
         architecture: Resolved installer architecture (e.g., "x64", "x86",
             "arm64", "any"). "any" is skipped — AppArch is left unset.
+        installer_filename: Installer filename in the Files directory.
 
     Returns:
         Dictionary of variable name -> value mappings.
@@ -108,7 +169,8 @@ def _build_adtsession_vars(
     Note:
         psadt.app_vars is the already-deep-merged result from code defaults,
         org.yaml, vendor.yaml, and the recipe. No manual merge needed here.
-        Special handling for ${discovered_version} placeholder.
+        String values get {{discovered_version}} and {{installer_filename}}
+        substituted.
         Auto-generates AppScriptDate if not set.
         AppArch is set automatically from architecture (skipped for "any").
         DeployAppScriptVersion is always set to psadt_version.
@@ -116,10 +178,11 @@ def _build_adtsession_vars(
     # psadt.app_vars is already fully merged by the config loader
     merged_vars = dict(config.get("psadt", {}).get("app_vars", {}))
 
-    # Replace ${discovered_version} placeholder
     for key, value in merged_vars.items():
-        if isinstance(value, str) and "${discovered_version}" in value:
-            merged_vars[key] = value.replace("${discovered_version}", version)
+        if isinstance(value, str):
+            merged_vars[key] = _substitute_variables(
+                value, version, installer_filename
+            )
 
     # Add auto-generated fields
     merged_vars.setdefault("AppScriptDate", date.today().strftime("%Y-%m-%d"))
@@ -229,12 +292,15 @@ def generate_invoke_script(
     version: str,
     psadt_version: str,
     architecture: str,
+    installer_filename: str,
 ) -> str:
     """Generate Invoke-AppDeployToolkit.ps1 from PSADT template and config.
 
     Reads the PSADT template, replaces the $adtSession hashtable with
     values from the configuration, and inserts recipe-specific install/
-    uninstall code.
+    uninstall code. NAPT variables ({{discovered_version}},
+    {{installer_filename}}) are substituted in app_vars values and in the
+    install/uninstall code blocks.
 
     Args:
         template_path: Path to PSADT's Invoke-AppDeployToolkit.ps1 template.
@@ -244,6 +310,8 @@ def generate_invoke_script(
         architecture: Resolved installer architecture (e.g., "x64", "x86",
             "arm64", "any"). Sets AppArch in the $adtSession hashtable;
             "any" leaves AppArch unset.
+        installer_filename: Exact filename of the installer copied into the
+            package's Files directory.
 
     Returns:
         Generated PowerShell script text.
@@ -262,6 +330,7 @@ def generate_invoke_script(
                 "141.0.7390.123",
                 "4.1.7",
                 "x64",
+                "installer.msi",
             )
             ```
     """
@@ -278,7 +347,9 @@ def generate_invoke_script(
 
     # Build $adtSession variables
     logger.verbose("BUILD", "Building $adtSession variables...")
-    session_vars = _build_adtsession_vars(config, version, psadt_version, architecture)
+    session_vars = _build_adtsession_vars(
+        config, version, psadt_version, architecture, installer_filename
+    )
 
     logger.debug("BUILD", "--- $adtSession Variables ---")
     for key, value in session_vars.items():
@@ -295,8 +366,14 @@ def generate_invoke_script(
 
     if install_code:
         logger.verbose("BUILD", "Inserting install code from recipe")
+        install_code = _substitute_variables(install_code, version, installer_filename)
+        _warn_unrecognized_tokens(install_code, "psadt.install")
     if uninstall_code:
         logger.verbose("BUILD", "Inserting uninstall code from recipe")
+        uninstall_code = _substitute_variables(
+            uninstall_code, version, installer_filename
+        )
+        _warn_unrecognized_tokens(uninstall_code, "psadt.uninstall")
 
     script = _insert_recipe_code(script, install_code, uninstall_code)
 

--- a/napt/build/template.py
+++ b/napt/build/template.py
@@ -94,7 +94,9 @@ def _format_powershell_value(value: Any) -> str:
 # the .NET format-string escape "{{0}}" intentionally don't match.
 _UNRECOGNIZED_TOKEN_RE = re.compile(r"\{\{[a-z][a-z0-9_]*\}\}")
 
-_SUPPORTED_VARIABLES = "{{discovered_version}}, {{installer_filename}}"
+# Single source for supported tokens; _substitute_variables zips values to
+# these in order, and the unrecognized-token warning lists them.
+_NAPT_VARIABLES = ("{{discovered_version}}", "{{installer_filename}}")
 
 
 def _substitute_variables(text: str, version: str, installer_filename: str) -> str:
@@ -113,8 +115,9 @@ def _substitute_variables(text: str, version: str, installer_filename: str) -> s
         Text with all supported variable tokens replaced.
     """
     # str.replace, not re.sub: filenames may contain regex-special characters
-    text = text.replace("{{discovered_version}}", version)
-    return text.replace("{{installer_filename}}", installer_filename)
+    for token, value in zip(_NAPT_VARIABLES, (version, installer_filename)):
+        text = text.replace(token, value)
+    return text
 
 
 def _warn_unrecognized_tokens(code: str, block_name: str) -> None:
@@ -126,7 +129,7 @@ def _warn_unrecognized_tokens(code: str, block_name: str) -> None:
     script verbatim.
 
     Args:
-        code: Install or uninstall code after substitution.
+        code: Recipe-provided text after substitution.
         block_name: Recipe field name for the warning message (e.g.,
             "psadt.install").
     """
@@ -139,8 +142,8 @@ def _warn_unrecognized_tokens(code: str, block_name: str) -> None:
             "BUILD",
             f"{block_name} contains unrecognized variable(s): "
             f"{', '.join(tokens)}. Supported NAPT variables: "
-            f"{_SUPPORTED_VARIABLES}. Unrecognized tokens are left as-is "
-            "in the generated script.",
+            f"{', '.join(_NAPT_VARIABLES)}. Unrecognized tokens are left "
+            "as-is in the generated script.",
         )
 
 
@@ -183,6 +186,7 @@ def _build_adtsession_vars(
             merged_vars[key] = _substitute_variables(
                 value, version, installer_filename
             )
+            _warn_unrecognized_tokens(merged_vars[key], f"psadt.app_vars.{key}")
 
     # Add auto-generated fields
     merged_vars.setdefault("AppScriptDate", date.today().strftime("%Y-%m-%d"))

--- a/recipes/7-Zip/7zip-x64-exe.yaml
+++ b/recipes/7-Zip/7zip-x64-exe.yaml
@@ -18,12 +18,13 @@ intune:
 psadt:
   app_vars:
     AppName: "7-Zip"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
     AppVendor: "Igor Pavlov"
   install: |
     # Install 7-Zip EXE with system-wide deployment
-    # Note: Filename uses compact version (e.g., 7z2501-x64.exe for v25.01)
-    Start-ADTProcess -FilePath "7z*-x64.exe" -ArgumentList "/S"
+    # Note: NAPT substitutes the exact downloaded filename at build time
+    # (PSADT resolves -FilePath literally; wildcards are not supported)
+    Start-ADTProcess -FilePath "{{installer_filename}}" -ArgumentList "/S"
   uninstall: |
     # Uninstall 7-Zip automatically (handles registry lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/7-Zip/7zip-x64-msi.yaml
+++ b/recipes/7-Zip/7zip-x64-msi.yaml
@@ -18,12 +18,13 @@ intune:
 psadt:
   app_vars:
     AppName: "7-Zip"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
     AppVendor: "Igor Pavlov"
   install: |
     # Install 7-Zip MSI with system-wide deployment
-    # Note: Filename uses compact version (e.g., 7z2501-x64.msi for v25.01)
-    Start-ADTMsiProcess -Action Install -FilePath "7z*-x64.msi" -ArgumentList "ALLUSERS=1"
+    # Note: NAPT substitutes the exact downloaded filename at build time
+    # (PSADT resolves -FilePath literally; wildcards are not supported)
+    Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
   uninstall: |
     # Uninstall 7-Zip automatically (handles MSI ProductCode lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/7-Zip/7zip-x86-exe.yaml
+++ b/recipes/7-Zip/7zip-x86-exe.yaml
@@ -18,12 +18,13 @@ intune:
 psadt:
   app_vars:
     AppName: "7-Zip"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
     AppVendor: "Igor Pavlov"
   install: |
     # Install 7-Zip EXE with system-wide deployment
-    # Note: Filename uses compact version (e.g., 7z2501.exe for v25.01)
-    Start-ADTProcess -FilePath "7z*.exe" -ArgumentList "/S"
+    # Note: NAPT substitutes the exact downloaded filename at build time
+    # (PSADT resolves -FilePath literally; wildcards are not supported)
+    Start-ADTProcess -FilePath "{{installer_filename}}" -ArgumentList "/S"
   uninstall: |
     # Uninstall 7-Zip automatically (handles registry lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/7-Zip/7zip-x86-msi.yaml
+++ b/recipes/7-Zip/7zip-x86-msi.yaml
@@ -18,12 +18,13 @@ intune:
 psadt:
   app_vars:
     AppName: "7-Zip"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
     AppVendor: "Igor Pavlov"
   install: |
     # Install 7-Zip MSI with system-wide deployment
-    # Note: Filename uses compact version (e.g., 7z2501.msi for v25.01)
-    Start-ADTMsiProcess -Action Install -FilePath "7z*.msi" -ArgumentList "ALLUSERS=1"
+    # Note: NAPT substitutes the exact downloaded filename at build time
+    # (PSADT resolves -FilePath literally; wildcards are not supported)
+    Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
   uninstall: |
     # Uninstall 7-Zip automatically (handles MSI ProductCode lookup)
     Uninstall-ADTApplication -Name "7-Zip"

--- a/recipes/Git/git.yaml
+++ b/recipes/Git/git.yaml
@@ -17,10 +17,10 @@ intune:
 psadt:
   app_vars:
     AppName: "Git for Windows"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
     # Git for Windows silent install with default options
-    Start-ADTProcess -FilePath "Git-${discovered_version}-64-bit.exe" -ArgumentList "/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /COMPONENTS=`"icons,ext\reg\shellhere,assoc,assoc_sh`""
+    Start-ADTProcess -FilePath "Git-{{discovered_version}}-64-bit.exe" -ArgumentList "/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /COMPONENTS=`"icons,ext\reg\shellhere,assoc,assoc_sh`""
   uninstall: |
     # Git for Windows uninstall (handles Inno Setup uninstaller automatically)
     Uninstall-ADTApplication -Name "Git"

--- a/recipes/Google/chrome.yaml
+++ b/recipes/Google/chrome.yaml
@@ -13,7 +13,7 @@ psadt:
     AppVersion: "{{discovered_version}}"
   install: |
     # Install Chrome MSI with system-wide deployment
-    Start-ADTMsiProcess -Action Install -FilePath "googlechromestandaloneenterprise64.msi" -ArgumentList "ALLUSERS=1"
+    Start-ADTMsiProcess -Action Install -FilePath "{{installer_filename}}" -ArgumentList "ALLUSERS=1"
   uninstall: |
     # Uninstall Chrome automatically (handles MSI ProductCode lookup)
     Uninstall-ADTApplication -Name "Google Chrome"

--- a/recipes/Google/chrome.yaml
+++ b/recipes/Google/chrome.yaml
@@ -10,7 +10,7 @@ discovery:
 psadt:
   app_vars:
     AppName: "Google Chrome"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
   install: |
     # Install Chrome MSI with system-wide deployment
     Start-ADTMsiProcess -Action Install -FilePath "googlechromestandaloneenterprise64.msi" -ArgumentList "ALLUSERS=1"

--- a/recipes/Microsoft/vscode.yaml
+++ b/recipes/Microsoft/vscode.yaml
@@ -22,11 +22,11 @@ intune:
 psadt:
   app_vars:
     AppName: "Visual Studio Code"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"
     AppVendor: "Microsoft"
   install: |
     # VS Code system installer - silent install for all users
-    Start-ADTProcess -FilePath "VSCodeSetup-x64-${discovered_version}.exe" -ArgumentList "/VERYSILENT /NORESTART /MERGETASKS=!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath"
+    Start-ADTProcess -FilePath "VSCodeSetup-x64-{{discovered_version}}.exe" -ArgumentList "/VERYSILENT /NORESTART /MERGETASKS=!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath"
   uninstall: |
     # VS Code uninstall via registry (Inno Setup uninstaller)
     Uninstall-ADTApplication -Name "Microsoft Visual Studio Code"

--- a/recipes/Slack/slack-msix.yaml
+++ b/recipes/Slack/slack-msix.yaml
@@ -17,4 +17,4 @@ discovery:
 psadt:
   app_vars:
     AppName: "Slack"
-    AppVersion: "${discovered_version}"
+    AppVersion: "{{discovered_version}}"

--- a/tests/build/test_template.py
+++ b/tests/build/test_template.py
@@ -119,6 +119,27 @@ class TestBuildAdtSessionVars:
 
         assert result["AppScriptAuthor"] == "Installer: 7z2501-x64.msi"
 
+    def test_unknown_token_in_app_vars_warns(self, capsys):
+        """Tests that a typo'd token in an app_vars value triggers a warning."""
+        from napt.logging import get_global_logger, get_logger, set_global_logger
+
+        config = {
+            "psadt": {
+                "app_vars": {"AppVersion": "{{discoverd_version}}"},
+            },
+        }
+
+        previous = get_global_logger()
+        set_global_logger(get_logger(verbose=True))
+        try:
+            _build_adtsession_vars(config, "1.0", "4.1.7", "x64", "app.msi")
+        finally:
+            set_global_logger(previous)
+
+        captured = capsys.readouterr()
+        assert "{{discoverd_version}}" in captured.out
+        assert "psadt.app_vars.AppVersion" in captured.out
+
     def test_auto_generated_fields(self):
         """Test auto-generated fields like AppScriptDate."""
         from datetime import date

--- a/tests/build/test_template.py
+++ b/tests/build/test_template.py
@@ -17,6 +17,9 @@ from napt.build.template import (
     _format_powershell_value,
     _insert_recipe_code,
     _replace_session_block,
+    _substitute_variables,
+    _warn_unrecognized_tokens,
+    generate_invoke_script,
 )
 
 
@@ -83,7 +86,7 @@ class TestBuildAdtSessionVars:
             },
         }
 
-        result = _build_adtsession_vars(config, "1.0.0", "4.1.7", "x64")
+        result = _build_adtsession_vars(config, "1.0.0", "4.1.7", "x64", "app.msi")
 
         assert result["AppLang"] == "EN"
         assert result["AppRevision"] == "01"
@@ -91,16 +94,30 @@ class TestBuildAdtSessionVars:
         assert result["AppName"] == "Test App"
 
     def test_discovered_version_substitution(self):
-        """Test ${discovered_version} placeholder replacement."""
+        """Tests that {{discovered_version}} is replaced in app_vars."""
         config = {
             "psadt": {
-                "app_vars": {"AppVersion": "${discovered_version}"},
+                "app_vars": {"AppVersion": "{{discovered_version}}"},
             },
         }
 
-        result = _build_adtsession_vars(config, "2.3.4", "4.1.7", "x64")
+        result = _build_adtsession_vars(config, "2.3.4", "4.1.7", "x64", "app.msi")
 
         assert result["AppVersion"] == "2.3.4"
+
+    def test_installer_filename_substitution(self):
+        """Tests that {{installer_filename}} is replaced in app_vars."""
+        config = {
+            "psadt": {
+                "app_vars": {"AppScriptAuthor": "Installer: {{installer_filename}}"},
+            },
+        }
+
+        result = _build_adtsession_vars(
+            config, "2.3.4", "4.1.7", "x64", "7z2501-x64.msi"
+        )
+
+        assert result["AppScriptAuthor"] == "Installer: 7z2501-x64.msi"
 
     def test_auto_generated_fields(self):
         """Test auto-generated fields like AppScriptDate."""
@@ -108,7 +125,7 @@ class TestBuildAdtSessionVars:
 
         config = {"psadt": {"app_vars": {}}}
 
-        result = _build_adtsession_vars(config, "1.0.0", "4.1.7", "x64")
+        result = _build_adtsession_vars(config, "1.0.0", "4.1.7", "x64", "app.msi")
 
         assert "AppScriptDate" in result
         assert result["AppScriptDate"] == date.today().strftime("%Y-%m-%d")
@@ -210,3 +227,177 @@ Write-Host 'Done'
         result = _insert_recipe_code(script, None, None)
 
         assert result == script
+
+
+class TestSubstituteVariables:
+    """Tests for NAPT build-time variable substitution."""
+
+    def test_substitutes_discovered_version(self):
+        """Tests that {{discovered_version}} is replaced."""
+        result = _substitute_variables(
+            "Git-{{discovered_version}}-64-bit.exe", "2.47.1", "git.exe"
+        )
+
+        assert result == "Git-2.47.1-64-bit.exe"
+
+    def test_substitutes_installer_filename(self):
+        """Tests that {{installer_filename}} is replaced."""
+        result = _substitute_variables(
+            'FilePath "{{installer_filename}}"', "25.01", "7z2501-x64.msi"
+        )
+
+        assert result == 'FilePath "7z2501-x64.msi"'
+
+    def test_substitutes_both_tokens_multiple_occurrences(self):
+        """Tests that both tokens are replaced at every occurrence."""
+        text = (
+            "{{installer_filename}} v{{discovered_version}} "
+            "({{discovered_version}}) from {{installer_filename}}"
+        )
+
+        result = _substitute_variables(text, "1.2", "app.exe")
+
+        assert result == "app.exe v1.2 (1.2) from app.exe"
+
+    def test_text_without_tokens_unchanged(self):
+        """Tests that text without tokens passes through unchanged."""
+        text = 'Start-ADTProcess -FilePath "setup.exe" -ArgumentList "/S"'
+
+        assert _substitute_variables(text, "1.0", "setup.exe") == text
+
+    def test_filename_with_special_characters(self):
+        """Tests that regex-special characters in filenames stay literal."""
+        result = _substitute_variables(
+            "{{installer_filename}}", "25.01", "7z25.01 (x64)$+.msi"
+        )
+
+        assert result == "7z25.01 (x64)$+.msi"
+
+
+class TestWarnUnrecognizedTokens:
+    """Tests for the unrecognized-token warning."""
+
+    @pytest.fixture(autouse=True)
+    def _verbose_logger(self, capsys):
+        """Installs a visible logger and restores the default afterward."""
+        from napt.logging import get_global_logger, get_logger, set_global_logger
+
+        previous = get_global_logger()
+        set_global_logger(get_logger(verbose=True))
+        yield
+        set_global_logger(previous)
+
+    def test_warns_for_unknown_token(self, capsys):
+        """Tests that an unknown {{snake_case}} token triggers a warning."""
+        _warn_unrecognized_tokens('FilePath "{{my_var}}"', "psadt.install")
+
+        captured = capsys.readouterr()
+        assert "{{my_var}}" in captured.out
+        assert "psadt.install" in captured.out
+
+    def test_warning_names_uninstall_block(self, capsys):
+        """Tests that the warning names the uninstall block."""
+        _warn_unrecognized_tokens("{{other}}", "psadt.uninstall")
+
+        captured = capsys.readouterr()
+        assert "psadt.uninstall" in captured.out
+
+    def test_no_warning_for_env_var_syntax(self, capsys):
+        """Tests that ${...} env-var and PowerShell syntax is ignored."""
+        code = '${GITHUB_TOKEN} and ${env:ProgramFiles} and "$($adtSession.DirFiles)"'
+
+        _warn_unrecognized_tokens(code, "psadt.install")
+
+        assert capsys.readouterr().out == ""
+
+    def test_no_warning_for_format_string_escape(self, capsys):
+        """Tests that .NET format-string escapes like {{0}} are ignored."""
+        _warn_unrecognized_tokens('"{{0}}" -f $value', "psadt.install")
+
+        assert capsys.readouterr().out == ""
+
+    def test_no_warning_for_clean_code(self, capsys):
+        """Tests that code without leftover tokens stays silent."""
+        _warn_unrecognized_tokens('FilePath "setup.exe"', "psadt.install")
+
+        assert capsys.readouterr().out == ""
+
+
+class TestGenerateInvokeScript:
+    """Tests for end-to-end script generation."""
+
+    TEMPLATE = """$adtSession = @{
+    AppName = ''
+    AppVersion = ''
+}
+
+function Install-ADTDeployment {
+    ## <Perform Installation tasks here>
+}
+
+function Uninstall-ADTDeployment {
+    ## <Perform Uninstallation tasks here>
+}
+"""
+
+    def _write_template(self, tmp_path):
+        template_path = tmp_path / "Invoke-AppDeployToolkit.ps1"
+        template_path.write_text(self.TEMPLATE, encoding="utf-8")
+        return template_path
+
+    def test_substitutes_variables_in_install_and_uninstall(self, tmp_path):
+        """Tests that both variables are substituted in recipe code blocks."""
+        config = {
+            "psadt": {
+                "app_vars": {"AppName": "Test", "AppVersion": "{{discovered_version}}"},
+                "install": 'Start-ADTMsiProcess -FilePath "{{installer_filename}}"',
+                "uninstall": 'Write-Host "Removing v{{discovered_version}}"',
+            },
+        }
+
+        result = generate_invoke_script(
+            self._write_template(tmp_path), config, "25.01", "4.1.7", "x64",
+            "7z2501-x64.msi",
+        )
+
+        assert 'FilePath "7z2501-x64.msi"' in result
+        assert 'Write-Host "Removing v25.01"' in result
+        assert "AppVersion = '25.01'" in result
+        assert "{{discovered_version}}" not in result
+        assert "{{installer_filename}}" not in result
+
+    def test_none_code_blocks_still_generate(self, tmp_path):
+        """Tests that missing install/uninstall blocks don't break generation."""
+        config = {"psadt": {"app_vars": {"AppName": "Test"}}}
+
+        result = generate_invoke_script(
+            self._write_template(tmp_path), config, "1.0", "4.1.7", "any", "app.msix"
+        )
+
+        assert "AppName = 'Test'" in result
+        assert "## <Perform Installation tasks here>" in result
+
+    def test_unknown_token_warning_fires(self, tmp_path, capsys):
+        """Tests that generation warns about unrecognized tokens."""
+        from napt.logging import get_global_logger, get_logger, set_global_logger
+
+        previous = get_global_logger()
+        set_global_logger(get_logger(verbose=True))
+        try:
+            config = {
+                "psadt": {
+                    "app_vars": {"AppName": "Test"},
+                    "install": 'FilePath "{{my_var}}"',
+                },
+            }
+
+            generate_invoke_script(
+                self._write_template(tmp_path), config, "1.0", "4.1.7", "x64",
+                "app.msi",
+            )
+        finally:
+            set_global_logger(previous)
+
+        captured = capsys.readouterr()
+        assert "{{my_var}}" in captured.out
+        assert "psadt.install" in captured.out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def sample_recipe_data() -> dict[str, Any]:
         "psadt": {
             "app_vars": {
                 "AppName": "Test App",
-                "AppVersion": "${discovered_version}",
+                "AppVersion": "{{discovered_version}}",
             },
         },
     }


### PR DESCRIPTION
## Description
NAPT build-time recipe variables now use mustache syntax (`{{discovered_version}}`, new `{{installer_filename}}`) and are now properly substituted in `psadt.install`/`psadt.uninstall` scripts. `${...}` now exclusively means environment variables (`discovery.token`/`discovery.headers`).

## Motivation
Two deploy-time bugs shared a root cause:

- `${discovered_version}` was never substituted in install/uninstall scripts. Because `${...}` is valid PowerShell and `$discovered_version` is never defined, tokens silently expanded to empty strings at deploy time (`Git--64-bit.exe`).
- PSADT resolves `-FilePath` with `-LiteralPath` (verified in PSADT source) and does not expand wildcards, so the 7-Zip recipes threw `FileNotFoundException` at deploy time.

Mustache syntax fixes the failure mode itself: `{{token}}` is not PowerShell syntax, so anything that slips through fails visibly instead of vanishing. Docs also falsely claimed `${ENV_VAR}` substitution works in `app_vars`; corrected to point at `defaults/org.yaml` layering.

## Changes
- **BREAKING:** `${discovered_version}` renamed to `{{discovered_version}}` (app_vars, install/uninstall, `intune.detection.display_name`)
- New `{{installer_filename}}` variable: exact filename of the downloaded installer in `Files/` (replaces unsupported wildcards)
- Substitution now applies to `psadt.install`/`psadt.uninstall` (previously inserted verbatim)
- `napt build` warns on unrecognized `{{snake_case}}` tokens in app_vars and install/uninstall
- Migrated all recipes; corrected recipe-reference, common-tasks, and user-guide docs (including PSADT v4 `-FilePath`/`-ArgumentList` syntax in examples)

Note: `recipes/Git/git.yaml` keeps `Git-{{discovered_version}}-64-bit.exe`. Git patch releases (`v2.47.1.windows.2` -> `Git-2.47.1.2-64-bit.exe`) diverge from the extracted version; switch to `{{installer_filename}}` if that bites.

## Testing
- [x] Unit tests added/updated (substitution helpers, app_vars, generate_invoke_script end-to-end, warning cases; 533 unit tests pass)
- [x] Integration tests pass (547 total)
- [x] Manual testing performed (`napt build` of 7-Zip MSI produces `-FilePath "7z2602-x64.msi"` with no leftover tokens; bogus `{{my_var}}` triggers the build warning)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors