### PR TITLE
chore: Prepare release 0.6.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-04
+
 ### Added
 
 - **Auto-generated MSI install/uninstall commands** - `napt build` now
@@ -273,7 +275,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.1...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.3.1...0.4.0

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.5.1"
+version = "0.6.0"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description
Release PR for NAPT 0.6.0. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[0.6.0]`, and adds a fresh empty `[Unreleased]` section.

## Motivation
Cuts the 0.6.0 release. Squash-merge this PR, then `/release 0.6.0` again to tag and publish.

## Changes
Release mechanics:
- Bump `pyproject.toml` version to 0.6.0
- Bump `napt/__init__.py` `__version__` to 0.6.0
- Promote `[Unreleased]` to `[0.6.0] - 2026-07-04` in `docs/changelog.md`, add fresh `[Unreleased]`, add comparison link `[0.6.0]: ...compare/0.5.1...0.6.0`

User-facing changes shipping in 0.6.0 (already merged to main):
- **BREAKING: Recipe variable syntax** now uses `{{...}}`; `${...}` is reserved for environment variables in `discovery.token`/`discovery.headers`
- Auto-generated MSI install/uninstall commands (uninstall by ProductName, not ProductCode)
- Automatic app icon extraction from MSI/EXE/MSIX, uploaded as the Intune/Company Portal logo
- New `{{installer_filename}}` recipe variable and unrecognized-variable warnings
- `intune.logo_path` restricted to PNG/JPEG with fallback to the extracted icon
- Fixes: version variable substitution in install/uninstall scripts, 7-Zip wildcard `-FilePath` failures, `intune.logo_path` relative-path resolution

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (run via `pytest tests/`)
- [x] Manual testing performed (n/a — release prep only, no code changes)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (changelog promoted)
- [x] Tests pass
- [x] No linting errors