### PR TITLE
chore: Harden project skills

### DIFF
--- a/.claude/skills/add-recipe-field/SKILL.md
+++ b/.claude/skills/add-recipe-field/SKILL.md
@@ -1,45 +1,15 @@
 ---
 name: add-recipe-field
-description: Add a new field to the NAPT recipe YAML schema. Walks through validation, documentation, categorization (org-policy / strategy-specific / required / optional / computed), and the per-category checklist.
+description: Add a new field to the NAPT recipe YAML schema. Categorizes the field (org-policy / strategy-specific / required / optional / computed) first, then walks the per-category checklist, documentation, changelog, and tests.
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read Edit Write Glob Grep Bash(*python* -m *)
 argument-hint: "field name (and optionally a brief description)"
 ---
 
-You are adding a new field to the NAPT recipe schema. Follow every step in order.
+You are adding a new field to the NAPT recipe schema. Categorize first — the category determines where validation, defaults, and access logic live. Follow every step in order.
 
-## Step 1: Update validation
-
-Add the field to the schema in `napt/validation.py`. For installed-check fields, use the `_INSTALLED_CHECK_FIELDS` pattern:
-
-```python
-_INSTALLED_CHECK_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
-    "new_field": (str, ["value1", "value2"], "field description"),
-    # type, allowed_values (or None), description
-}
-```
-
-For other fields, add type/value validation in the appropriate `validate_*` function.
-
-## Step 2: Document in `docs/recipe-reference.md`
-
-Add field documentation following the standard format:
-
-```markdown
-#### field_name
-
-**Type:** `string`
-**Required:** No
-**Default:** `"default_value"`
-**Allowed values:** `"value1"`, `"value2"`
-
-Description of what the field does and when to use it.
-```
-
-**Field documentation order:** Type → Required → Default (if applicable) → Allowed values (if applicable) → Description → Examples (if helpful)
-
-## Step 3: Categorize the new setting
+## Step 1: Categorize the new field
 
 Every config value belongs to exactly one category. Use this flowchart:
 
@@ -57,9 +27,9 @@ Is this field set the same way across all/most recipes?
       NO  → Absent-means-skip
 ```
 
-Tell the user which category you've assigned and why.
+Tell the user which category you've assigned and why before writing any code.
 
-## Step 4: Follow the checklist for that category
+## Step 2: Implement per the category checklist
 
 **Org-policy** (e.g., `run_as_account`, `log_format`, `build_types`):
 - [ ] Add to `DEFAULT_CONFIG` in `napt/config/defaults.py`
@@ -91,16 +61,58 @@ A test (`test_org_yaml_template_covers_all_sections`) validates that all section
 - [ ] Use provenance to detect explicit overrides vs defaults
 - [ ] Document the computed behavior in `docs/recipe-reference.md`
 
-## Step 5: Verify implementation
+**Validation patterns.** For installed-check fields, use the `_INSTALLED_CHECK_FIELDS` pattern in `napt/validation.py`:
+
+```python
+_INSTALLED_CHECK_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
+    "new_field": (str, ["value1", "value2"], "field description"),
+    # type, allowed_values (or None), description
+}
+```
+
+For other fields, add type/value validation in the appropriate `validate_*` function (or the strategy's `validate_config()` for strategy-specific fields).
+
+## Step 3: Document in `docs/recipe-reference.md`
+
+Add field documentation following the standard format:
+
+```markdown
+#### field_name
+
+**Type:** `string`
+**Required:** No
+**Default:** `"default_value"`
+**Allowed values:** `"value1"`, `"value2"`
+
+Description of what the field does and when to use it.
+```
+
+**Field documentation order:** Type → Required → Default (if applicable) → Allowed values (if applicable) → Description → Examples (if helpful)
+
+## Step 4: Update examples
+
+Add the field to example recipes in `docs/common-tasks.md` if it's commonly used, or note it as optional in relevant strategy examples.
+
+## Step 5: Update the changelog
+
+Recipe schema changes are user-facing. Add an entry under `[Unreleased]` in `docs/changelog.md` following Keep a Changelog format (usually `### Added` for a new field). Describe what recipe authors can now do, not the implementation.
+
+## Step 6: Verify implementation
 
 Check these to ensure the field is actually used:
 - Search codebase: grep for the field name in `napt/`
 - Verify it's read from config in relevant modules
 - Check if field exists in defaults but isn't used (planned feature — flag this)
 
-## Step 6: Update examples
+## Step 7: Add tests and run the suite
 
-Add the field to example recipes in `docs/common-tasks.md` if it's commonly used, or note it as optional in relevant strategy examples.
+- Add or extend validation tests for the new field: a valid value, an invalid value, and the missing-field behavior appropriate to its category (error for recipe-required, skip for absent-means-skip, default for the rest).
+- Org-policy fields: confirm `test_org_yaml_template_covers_all_sections` still passes.
+- Run unit tests:
+  ```
+  .venv/Scripts/python.exe -m pytest tests/ -m "not integration" -q
+  ```
+  If anything fails, fix it before finishing.
 
 ## Final invariants
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -3,7 +3,7 @@ name: release
 description: Prepare and ship a NAPT release. Phase 1 opens the release PR (version bumps + changelog promotion). Phase 2 (after merge) tags and publishes the GitHub release. Detects phase automatically.
 disable-model-invocation: true
 user-invocable: true
-allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Glob Grep
+allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Write Glob Grep
 argument-hint: "version: X.Y.Z"
 ---
 
@@ -13,17 +13,18 @@ You are preparing a NAPT release. Semver (no `v` prefix). Follow every step in o
 
 The user passes the target version as `X.Y.Z`. If absent, ask before proceeding.
 
-Phase detection keys off `origin/main`, not your current checkout — Phase 1 forks the
-release branch from `origin/main` regardless of what you have checked out, so the branch
-you are standing on never affects the release. Check state:
+Phase detection keys off `origin/main`, not your current checkout — both phases operate
+on `origin/main` regardless of what you have checked out, so the branch you are standing
+on never affects the release. Check state:
 - `git fetch origin` — refresh remote refs first.
 - `git tag -l X.Y.Z` — does the tag already exist? If yes, stop — release already published.
-- `git log -1 --format=%s origin/main` — last commit subject on main.
+- `git show origin/main:pyproject.toml` — read `version` under `[project]`.
 
-**Phase 2 (tag and publish):** Tag does not exist and `origin/main`'s last commit subject is
-`chore: Prepare release X.Y.Z` (the release PR was just squash-merged).
-**Phase 1 (open release PR):** Tag does not exist and `origin/main`'s last commit is anything
-else.
+**Phase 2 (tag and publish):** Tag does not exist and the pyproject version on
+`origin/main` is already `X.Y.Z` (the release PR was squash-merged). This detection holds
+even if unrelated commits landed on main after the merge — Phase 2 locates the exact
+release commit to tag.
+**Phase 1 (open release PR):** Tag does not exist and the version is anything else.
 
 Report which phase you detected before proceeding.
 
@@ -36,7 +37,12 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
 1. **Verify clean working tree.** Run `git status`. If there are uncommitted changes, stop
    and ask the user how to handle them — switching branches would carry or lose them.
 
-2. **Create the release branch from latest main.** You already ran `git fetch origin` in
+2. **Check `[Unreleased]` has content.** Read it from the release base, not your checkout:
+   `git show origin/main:docs/changelog.md`. If the `[Unreleased]` section is empty, stop —
+   there is nothing to release. Checking before creating the branch means an abort here
+   leaves nothing behind.
+
+3. **Create the release branch from latest main.** You already ran `git fetch origin` in
    Step 1.
    - Guard: `git rev-parse --verify chore/prepare-release-X.Y.Z` and
      `git ls-remote --exit-code --heads origin chore/prepare-release-X.Y.Z`. If either
@@ -46,8 +52,6 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
 
    This forks from the current tip of `origin/main` no matter which branch was checked out,
    so all remaining steps operate on a clean release base.
-
-3. **Check `[Unreleased]` has content.** Read `docs/changelog.md`. If the `[Unreleased]` section is empty, stop — there is nothing to release.
 
 4. **Run lint and tests** sequentially:
    ```
@@ -108,17 +112,28 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
 
 ## Phase 2: Tag and publish
 
-1. **Pull latest main:** `git pull origin main`
+Phase 2 never touches your checkout — no pull, no checkout, no branch switch. Everything
+reads from `origin/main` (already fetched in Step 1) and the tag is created directly on
+the release commit, so it works from whatever branch you happen to be standing on.
 
-2. **Verify version files.** Read `pyproject.toml` and `napt/__init__.py` to confirm both show X.Y.Z. If not, stop and report.
+1. **Locate the release commit.** Find the squash-merge of the release PR:
+   `git log origin/main --format="%H %s" -20` and take the most recent commit whose
+   subject starts with `chore: Prepare release X.Y.Z`. If none is found, stop and report —
+   the merge subject may have been edited at merge time; ask the user which commit to tag.
 
-3. **Tag and push the tag:**
+2. **Verify version files at that commit.** `git show <sha>:pyproject.toml` and
+   `git show <sha>:napt/__init__.py` must both show X.Y.Z. If not, stop and report.
+
+3. **Tag the release commit and push the tag:**
    ```
-   git tag -a X.Y.Z -m "Release X.Y.Z"
+   git tag -a X.Y.Z <sha> -m "Release X.Y.Z"
    git push origin X.Y.Z
    ```
+   Tagging `<sha>` directly — not HEAD, not the tip of main — keeps the tag exact even if
+   other commits landed on main after the release PR merged.
 
-4. **Build release notes** following the template below. Read the `[X.Y.Z]` section of `docs/changelog.md` for source content.
+4. **Build release notes** following the template below. Read the `[X.Y.Z]` section from
+   `git show <sha>:docs/changelog.md` for source content.
 
 5. **Create the GitHub release.** `gh release create` has no `--body` flag — write the
    notes to a file and pass it with `-F` (this also avoids heredoc quoting pitfalls).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,33 +13,51 @@ You are preparing a NAPT release. Semver (no `v` prefix). Follow every step in o
 
 The user passes the target version as `X.Y.Z`. If absent, ask before proceeding.
 
-Check current state to decide which phase to run:
+Phase detection keys off `origin/main`, not your current checkout — Phase 1 forks the
+release branch from `origin/main` regardless of what you have checked out, so the branch
+you are standing on never affects the release. Check state:
+- `git fetch origin` — refresh remote refs first.
 - `git tag -l X.Y.Z` — does the tag already exist? If yes, stop — release already published.
-- `git branch --show-current` — current branch
-- `git log -1 --format=%s` — last commit subject
+- `git log -1 --format=%s origin/main` — last commit subject on main.
 
-**Phase 1 (open release PR):** Tag does not exist; we are on `main` or any non-release branch.
-**Phase 2 (tag and publish):** Tag does not exist; we are on `main` and the last commit subject is `chore: Prepare release X.Y.Z` (i.e., the release PR was just squash-merged).
+**Phase 2 (tag and publish):** Tag does not exist and `origin/main`'s last commit subject is
+`chore: Prepare release X.Y.Z` (the release PR was just squash-merged).
+**Phase 1 (open release PR):** Tag does not exist and `origin/main`'s last commit is anything
+else.
 
 Report which phase you detected before proceeding.
 
 ## Phase 1: Open the release PR
 
-1. **Verify clean state.** Run `git status`. If unstaged changes unrelated to the release exist, stop and ask the user how to handle them.
+The release must be cut from a clean `main`, never from whatever branch you happen to be
+on. Forking the branch from `origin/main` guarantees the PR diff contains only the version
+bump and changelog promotion — nothing from an unrelated feature branch can leak in.
 
-2. **Check `[Unreleased]` has content.** Read `docs/changelog.md`. If the `[Unreleased]` section is empty, stop — there is nothing to release.
+1. **Verify clean working tree.** Run `git status`. If there are uncommitted changes, stop
+   and ask the user how to handle them — switching branches would carry or lose them.
 
-3. **Run lint and tests** sequentially:
+2. **Create the release branch from latest main.** You already ran `git fetch origin` in
+   Step 1.
+   - Guard: `git rev-parse --verify chore/prepare-release-X.Y.Z` and
+     `git ls-remote --exit-code --heads origin chore/prepare-release-X.Y.Z`. If either
+     succeeds (the branch already exists locally or on the remote), stop and report — a
+     prior Phase 1 run is in flight; don't clobber it.
+   - `git checkout -b chore/prepare-release-X.Y.Z origin/main`
+
+   This forks from the current tip of `origin/main` no matter which branch was checked out,
+   so all remaining steps operate on a clean release base.
+
+3. **Check `[Unreleased]` has content.** Read `docs/changelog.md`. If the `[Unreleased]` section is empty, stop — there is nothing to release.
+
+4. **Run lint and tests** sequentially:
    ```
    .venv/Scripts/python.exe -m ruff check napt/ tests/
    .venv/Scripts/python.exe -m pytest tests/ -q
    ```
    If anything fails, stop and report. Do not continue.
 
-4. **Create branch:** `git checkout -b chore/prepare-release-X.Y.Z`
-
 5. **Bump version in two places** — both must match exactly:
-   - `pyproject.toml` → `version = "X.Y.Z"` under `[tool.poetry]`
+   - `pyproject.toml` → `version = "X.Y.Z"` under `[project]`
    - `napt/__init__.py` → `__version__ = "X.Y.Z"`
 
 6. **Promote changelog** in `docs/changelog.md`:
@@ -102,12 +120,13 @@ Report which phase you detected before proceeding.
 
 4. **Build release notes** following the template below. Read the `[X.Y.Z]` section of `docs/changelog.md` for source content.
 
-5. **Create the GitHub release:**
+5. **Create the GitHub release.** `gh release create` has no `--body` flag — write the
+   notes to a file and pass it with `-F` (this also avoids heredoc quoting pitfalls).
+   `--verify-tag` aborts if the tag isn't already on the remote, which it always is by
+   this step.
    ```
-   gh release create X.Y.Z --title "NAPT X.Y.Z" --body "$(cat <<'EOF'
-   <release notes here>
-   EOF
-   )"
+   # Write the notes to a temp file first (e.g. via the Write tool), then:
+   gh release create X.Y.Z --title "NAPT X.Y.Z" --verify-tag --latest -F <notes-file>
    ```
 
 6. **Report the release URL.**

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -15,9 +15,14 @@ Run these in parallel:
 - `git branch --show-current` to check if on a feature branch or main
 - `git status` to see what's changed (never use -uall)
 - `git diff --stat` to understand scope of changes
+- `git log main..HEAD --oneline` to see commits already on the branch
 
 Tell the user what you found: branch name, number of files changed, and a
 one-line summary of the changes.
+
+If the working tree is clean and `git log main..HEAD` is empty (nothing
+uncommitted and no commits ahead of main), there is nothing to ship — report
+that and stop.
 
 ## Step 2: Lint, format, and type-check
 
@@ -69,6 +74,13 @@ If user-facing changes exist:
 
 If changes are purely internal (refactor, test, chore with no user impact),
 skip changelog and doc updates. Tell the user you skipped this and why.
+
+If any file under `docs/` was added or edited — by you in this step or
+already in the diff — validate that the site builds:
+```
+.venv/Scripts/python.exe -m mkdocs build --strict
+```
+If the build fails, fix the docs before continuing.
 
 ## Step 6: Run napt-reviewer
 


### PR DESCRIPTION
## Description
Fixes logical failures and gaps in the project skills (`/release`, `/ship`, `/add-recipe-field`).

## Motivation
The release skill's Phase 2 could tag the wrong commit when run from a non-main checkout, and phase detection broke if unrelated commits landed on main after the release PR merged. The other skills had ordering flaws and missing steps that let work ship without required changelog/test coverage.

## Changes
- **release**: Phase 2 is now checkout-independent — locates the `chore: Prepare release X.Y.Z` squash-merge commit on `origin/main`, verifies version files at that commit via `git show`, and tags that SHA directly (no `git pull` into the current branch)
- **release**: Phase detection keys off the pyproject version on `origin/main` instead of the last commit subject, surviving intervening merges
- **release**: `[Unreleased]` content check moved before branch creation so an abort leaves no stray branch; `Write` added to `allowed-tools` (Phase 2 already instructed its use)
- **ship**: early exit when there is nothing to ship (clean tree, no commits ahead of main); `mkdocs build --strict` validation when `docs/` files are touched
- **add-recipe-field**: categorization moved to Step 1 so validation lands in the category-correct location (strategy `validate_config()`, loader, or `validation.py`); added the missing changelog step and a tests step (valid/invalid/missing-field cases + unit-test run)

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (run via `pytest tests/`)
- [x] Manual testing performed (n/a — skill markdown only, no code changes)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (n/a — contributor tooling, not user-facing)
- [x] Tests pass
- [x] No linting errors