### PR TITLE
feat: Split state into cache and deployment state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,7 @@ test_downloads/
 
 # NAPT build and cache directories
 # - builds/: PSADT package builds (napt build output)
-# - cache/: Cached PSADT releases and tools
+# - cache/: Discovery cache, cached PSADT releases and tools (disposable)
 # - packages/: .intunewin packages (napt package output)
 # - icons/: App icons extracted at build time (napt build output)
 builds/
@@ -191,10 +191,9 @@ cache/
 packages/
 icons/
 
-# NAPT state files (machine-managed, regenerate from discovery)
-state/versions.json
-state/*.json
-!state/.gitignore
+# NAPT deployment state from local testing
+/state/
+!/state/.gitignore
 
 .DS_Store
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -39,8 +39,9 @@ napt/
 ├── psadt/                   # PSADT release management
 │   └── release.py              # PSADT release download and caching
 │
-├── state/                   # Version tracking and caching
-│   └── tracker.py              # State file management
+├── state/                   # State persistence
+│   ├── cache.py                # Discovery cache (disposable optimization)
+│   └── deployment.py           # Per-app deployment state (authoritative)
 │
 ├── upload/                  # Intune upload pipeline
 │   ├── manager.py              # Upload orchestration
@@ -64,7 +65,9 @@ Recipe YAML
     ↓
 [discovery/] Discover version and download
     ↓
-[state/tracker.py] Update version cache
+[state/cache.py] Update discovery cache
+    ↓
+[state/deployment.py] Record pending release
     ↓
 [build/manager.py] Build PSADT package
     ↓
@@ -84,7 +87,7 @@ Result (dataclass)
 
 - **Discovery Strategies:** Protocol-based, stateless, registered in global registry (api_github, api_json, web_scrape). All return a `RemoteVersion` from configuration alone. The orchestrator runs the result through `resolve_with_cache` to skip the download when the version is unchanged. `url_download` is a separate flow (not a registered strategy) because it must download the file to determine the version.
 - **Configuration:** 3-layer system (org → vendor → recipe) with deep merging
-- **State Management:** Tracks versions in `state/versions.json` for caching
+- **State Management:** Two kinds with opposite philosophies — the disposable discovery cache (`cache/discovery.json`) for download optimization, and authoritative per-app deployment state (`state/deployment/<id>.json`) recording what is published and pending
 - **Exceptions:** All NAPT domain errors use custom exceptions inheriting from `NAPTError` (ConfigError, NetworkError, PackagingError) - allows catching all NAPT errors or specific types
 - **Return Types:** Frozen dataclasses from `results.py` for public API functions only (type-safe, immutable returns)
 

--- a/docs/api/state.md
+++ b/docs/api/state.md
@@ -1,4 +1,5 @@
 # state
 
-::: napt.state
+::: napt.state.cache
 
+::: napt.state.deployment

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Deployment state files** - `napt discover` records each discovered
+    release in `state/deployment/{id}.json` as a pending publication
+    candidate. One file per app; the newest discovery wins
+
+### Changed
+
+- **BREAKING: Discovery cache moved** - `state/versions.json` is now
+    `cache/discovery.json`, and `napt discover --state-file` was renamed
+    to `--cache-file`. Delete the old file; the cache rebuilds on the
+    next run
+    - New `directories.cache` and `directories.state` settings
+    - `--stateless` also skips deployment state writes
+    - `napt init` additionally creates `state/deployment/`
+
 ## [0.6.0] - 2026-07-04
 
 ### Added

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -712,11 +712,11 @@ When a recipe needs changes (new version format, different download URL, etc.).
    napt discover recipes/Vendor/app.yaml --verbose
    ```
 
-4. **If version format changed, clear state:**
+4. **If version format changed, clear the cache:**
    ```bash
-   # Delete state entry for this app
-   # Or delete entire state file to start fresh
-   rm state/versions.json
+   # Delete cache entry for this app
+   # Or delete the entire discovery cache to start fresh
+   rm cache/discovery.json
    ```
 
 5. **Test full workflow:**
@@ -799,25 +799,28 @@ Common issues and solutions when `napt discover` fails.
 
 4. Use `--verbose` to see HTTP request/response details
 
-### Issue: "State file corrupted"
+### Issue: "Discovery cache corrupted"
 
-**Problem:** `state/versions.json` has invalid JSON or is corrupted.
+**Problem:** `cache/discovery.json` has invalid JSON or is corrupted.
 
 **Solution:**
 
-NAPT automatically handles corruption:
+NAPT automatically handles cache corruption:
 
-1. Creates backup of corrupted file: `state/versions.json.backup`
+1. Creates backup of corrupted file: `cache/discovery.json.backup`
 
-2. Creates a fresh state file automatically
+2. Creates a fresh cache file automatically
 
 3. Reports the issue with an error message
 
-The state file is already fixed - just run your command again. Alternatively, use `--stateless` to bypass state tracking temporarily:
+The cache is already fixed - just run your command again. Alternatively, use `--stateless` to bypass state tracking temporarily:
 
 ```bash
 napt discover recipes/app.yaml --stateless
 ```
+
+**Note:** Deployment state files (`state/deployment/`) are authoritative and are never auto-replaced.
+If one is corrupted, fix the JSON or restore the file from a backup.
 
 ## What's Next?
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -115,6 +115,7 @@ This creates:
 - `recipes/` - Directory for your recipe files
 - `defaults/org.yaml` - Organization-wide configuration (commented template)
 - `defaults/vendors/` - Directory for vendor-specific defaults
+- `state/deployment/` - Per-app deployment state files
 
 ### Validate a Recipe
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 | Recipe Schema Redesign | ✅ Completed | User-Facing | High | High |
 | Microsoft Intune Upload | ✅ Completed | User-Facing | High | Very High |
 | `napt auth setup` Command | 💡 Idea | User-Facing | Low | High |
-| Deployment Wave Management | 🔬 Investigating | User-Facing | Very High | High |
+| Deployment Wave Management | 🚧 In Progress | User-Facing | Very High | High |
 | Pre/Post Install/Uninstall Script Support | 💡 Idea | User-Facing | Low | Medium |
 | Enhanced CLI Help Menu | 💡 Idea | User-Facing | Low | Medium |
 | Intune App Categorization & Scope Tags | 💡 Idea | User-Facing | Medium | Medium |
@@ -43,7 +43,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 **Summary:**
 
 - ✅ **Completed**: 3
-- 🔬 **Investigating**: 1
+- 🚧 **In Progress**: 1
 - 💡 **Ideas**: 13
 - **Total**: 17 features
 
@@ -51,30 +51,76 @@ This roadmap is a living document showing potential future directions for NAPT. 
 
 ## Active Work
 
-### Investigating 🔬
+### In Progress 🚧
 
 #### Deployment Wave Management
 
-**Status**: 🔬 Investigating
+**Status**: 🚧 In Progress
 **Complexity**: Very High (5-10 days)
 **Value**: High
 
-**Description**: Phased deployment with rings (Pilot → Production) and gradual
-rollout.
+**Description**: Ring-based promotion of published apps via a new
+`napt promote` command with Terraform-style `plan`/`apply` subcommands.
+Apps upload unassigned; promotion advances the newest version through an
+ordered list of rings (Microsoft Entra ID group assignments), replacing
+whatever version each ring currently holds.
+
+Agreed design:
+
+- **Ring model**: A ring is a named set of groups plus `promote_after_days`.
+  Each ring holds at most one version of an app's Update entry — the newest
+  version that has reached it.
+  The install entry gets static assignments (set once); rings control update
+  velocity only.
+- **Plan/apply split**: `napt promote plan` is a pure function of
+  (deployment state, config, clock) and writes a reviewable
+  `state/plan.json`; `napt promote apply` executes it with per-entry
+  validate-then-act, making both safe to re-run.
+- **State split**: The discovery cache moves to `cache/discovery.json`
+  (disposable).
+  Authoritative per-app deployment state lives in
+  `state/deployment/<recipe-id>.json` (deployed, pending, rings, retained),
+  serialized deterministically for clean diffs.
+- **Identity and ownership**: Uploads stamp `napt/v1 id=<recipe>
+  sha256=<hash>` into the Intune notes field; `recipe_id + sha256` is the
+  identity key.
+  The `intune.notes` recipe field is removed — the field is reserved for
+  NAPT.
+- **Approval binding**: Upload verifies the installer hash against the
+  approved pending entry, so what a reviewer approved is byte-for-byte what
+  ships.
+- **Idempotent upload**: Reconcile-before-act — adopt an existing stamped
+  app instead of creating a duplicate.
+- **Newest wins**: The pending slot holds one candidate; a newer discovery
+  replaces an unpublished one.
+- **Retention**: Displaced versions are kept per `retain_versions` (default
+  1) for instant rollback, then deleted; only stamped apps are ever touched.
+- **Drift**: Manual admin changes are warned about, never reverted.
+- **GitOps-friendly, not git-aware**: Deterministic state files, detailed
+  exit codes, and reference CI workflows in docs; NAPT itself performs no
+  git or PR operations.
 
 **Benefits**:
 
 - Enables controlled, staged deployments to reduce risk
 - Supports ring-based deployment (Pilot, UAT, Production)
-- Allows gradual rollout with percentage-based scheduling
 - Provides rollback capabilities for failed deployments
+- Lets orgs gate publishes and promotions through PR review when state files
+  are committed to git
 - Useful for organizations requiring careful change management
 
 **Dependencies**:
 
-- Requires Intune upload implementation first
-- Requires Graph API for assignment groups
-- May need separate monitoring/alerting
+- Requires Graph API assignment endpoints and `Group.Read.All` for group
+  name resolution
+- Delivered across eight PRs: state split, upload provenance and hash gate,
+  idempotent upload, deployment config and assignment client, `promote plan`
+  and `napt status`, `promote apply` with retention, drift detection, GitOps
+  docs and schema versioning
+
+**Related**: Health-gated promotion (block on install failure rates) and
+native Intune supersedence are deliberate follow-ups, not part of this
+iteration.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -673,6 +673,8 @@ to its own:
 | Command | Flag | Purpose | Config key | Built-in default |
 |---------|------|---------|-----------|-----------------|
 | `napt discover` | `--output-dir` | Where to save downloaded installers | `directories.discover` | `downloads` |
+| `napt discover` | `--cache-file` | Discovery cache file (`<dir>/discovery.json`) | `directories.cache` | `cache` |
+| `napt discover` | `--state-dir` | Per-app deployment state (`<dir>/deployment/`) | `directories.state` | `state` |
 | `napt build` | `--downloads-dir` | Where to find the installer | `directories.discover` | `downloads` |
 | `napt build` | `--output-dir` | Where to save builds | `directories.build` | `builds` |
 | `napt package` | `--builds-dir` | Where to find the build | `directories.build` | `builds` |
@@ -691,10 +693,12 @@ To change the defaults org-wide, add to `defaults/org.yaml`:
 
 ```yaml
 directories:
-  discover: "cache/downloads"   # used by both discover and build
-  build: "artifacts/builds"     # used by both build and package
+  discover: "artifacts/downloads"  # used by both discover and build
+  build: "artifacts/builds"        # used by both build and package
   package: "artifacts/packages"
-  icons: "artifacts/icons"      # written by build, read by upload
+  icons: "artifacts/icons"         # written by build, read by upload
+  cache: "artifacts/cache"         # discovery cache (disposable)
+  state: "deployment-state"        # per-app deployment state (authoritative)
 ```
 
 Any CLI flag still overrides the config value for that single run:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,14 +12,15 @@ The discovery process finds the latest version and downloads the installer:
 
 1. **Load Configuration** - Merges organization defaults, vendor defaults, and recipe configuration
 2. **Check Version** - Uses the configured discovery strategy to check for new versions
-3. **Compare with Cache** - Compares discovered version to cached `known_version` in state file
+3. **Compare with Cache** - Compares discovered version to cached `known_version` in the discovery cache
 4. **Skip or Download**:
     - If version unchanged and file exists → Skip download 
     - If version changed or file missing → Download installer
 5. **Extract Version** - Extracts version from installer (MSI ProductVersion) or uses discovered version
-6. **Update State** - Updates `state/versions.json` with new version, file path, SHA-256 hash, and ETag (if download occurred). 
+6. **Update Cache** - Updates `cache/discovery.json` with new version, file path, SHA-256 hash, and ETag (if download occurred)
+7. **Record Pending Release** - Updates `state/deployment/{app_id}.json` with the discovered release as the pending publication candidate when it differs from the deployed version. The pending slot holds one candidate and the newest discovery wins.
 
-**Output**: Downloaded installer in `downloads/` directory, updated state file
+**Output**: Downloaded installer in `downloads/` directory, updated discovery cache, updated deployment state
 
 ### Build Process (`napt build`)
 
@@ -27,7 +28,7 @@ The build process creates a complete PSADT package from the recipe and downloade
 
 1. **Load Configuration** - Merges configuration layers (org → vendor → recipe)
 2. **Find Installer** - Locates installer in `downloads/` directory (tries URL filename, then app name/id, then most recent). Supports `.msi`, `.exe`, and `.msix` files
-3. **Extract Version** - Extracts version from installer file (MSI from ProductVersion, MSIX from AppxManifest.xml), otherwise uses state file version
+3. **Extract Version** - Extracts version from installer file (MSI from ProductVersion, MSIX from AppxManifest.xml), otherwise uses discovery cache version
 4. **Get PSADT Release** - Downloads/caches PSADT Template_v4 from GitHub if not already cached
 5. **Create Build Directory** - Creates versioned directory using discovered app version: `builds/{app_id}/{version}/`
 6. **Copy PSADT Template** - Copies entire PSADT template structure (unmodified) from cache:
@@ -355,8 +356,12 @@ packages/
           ├── Google-Chrome-142.0.7444.163-Detection.ps1    # Copied by napt package
           └── Google-Chrome-142.0.7444.163-Requirements.ps1 # Copied by napt package
 
+cache/
+  └── discovery.json                       # Discovery cache (disposable)
+
 state/
-  └── versions.json                        # Version tracking
+  └── deployment/
+      └── napt-chrome.json                 # Deployment state (authoritative)
 ```
 
 ## Commands Reference
@@ -365,7 +370,7 @@ state/
 
 ### napt init
 
-Initializes a new NAPT project with the recommended directory structure. Creates `recipes/`, `defaults/org.yaml`, and `defaults/vendors/`. Existing files are preserved by default; use `--force` to backup and overwrite.
+Initializes a new NAPT project with the recommended directory structure. Creates `recipes/`, `defaults/org.yaml`, `defaults/vendors/`, and `state/deployment/`. Existing files are preserved by default; use `--force` to backup and overwrite.
 
 ```bash
 napt init [DIRECTORY] [OPTIONS]
@@ -508,9 +513,19 @@ For practical workflows and copy-paste examples, see [Common Tasks](common-tasks
 
 ## State Management & Caching
 
-NAPT automatically tracks discovered versions and optimizes subsequent runs by avoiding unnecessary downloads. This version-based caching is critical for CI/CD with frequent scheduled checks, providing fast feedback when applications haven't changed.
+NAPT keeps two kinds of state with different purposes:
 
-### How It Works
+- **Discovery cache** (`cache/discovery.json`) - A disposable optimization file tracking discovered versions, ETags, and download metadata.
+Deleting it costs one full re-download per app and nothing else.
+Safe to gitignore.
+- **Deployment state** (`state/deployment/<app_id>.json`) - Authoritative per-app records of what NAPT has published to Intune (`deployed`) and what is awaiting publication (`pending`).
+Not regenerable.
+Written deterministically (sorted keys, no timestamps), so unchanged state produces byte-identical files and clean diffs — commit these files to version control if you want an auditable record or a PR-based review workflow.
+
+### Discovery Cache
+
+The discovery cache avoids unnecessary downloads.
+This version-based caching is critical for CI/CD with frequent scheduled checks, providing fast feedback when applications haven't changed.
 
 NAPT uses two caching approaches depending on the discovery strategy:
 
@@ -535,34 +550,49 @@ flowchart TD
     FileExists2 -->|Yes| SkipDownload2([✓ Skip Download<br/>Use cached file])
     FileExists2 -->|No| Download2
     
-    Download1 --> UpdateState[Update state.json]
-    Download2 --> UpdateState
-    SkipDownload1 --> UpdateState
-    SkipDownload2 --> UpdateState
-    UpdateState --> Ready([✓ Ready for napt build])
+    Download1 --> UpdateCache[Update discovery cache]
+    Download2 --> UpdateCache
+    SkipDownload1 --> UpdateCache
+    SkipDownload2 --> UpdateCache
+    UpdateCache --> Pending[Record pending release]
+    Pending --> Ready([✓ Ready for napt build])
 ```
 
 **Performance:** Version-first strategies (api_github, api_json, web_scrape) check versions before downloading (~100-300ms) and skip downloads entirely if unchanged. File-first strategy (url_download) uses HTTP conditional requests (~500ms) with ETag caching.
 
-**Note:** State is updated after every discovery run, even when skipping downloads. This updates the `last_updated` timestamp and confirms the cached version is still current.
+**Note:** The cache is updated after every discovery run, even when skipping downloads. This updates the `last_updated` timestamp and confirms the cached version is still current.
+
+### Deployment State
+
+Each app gets its own file, `state/deployment/<app_id>.json`, so concurrent changes to different apps never conflict and each file's diff is scoped to one app.
+A file holds four sections:
+
+- `deployed` - The version currently published to Intune, with its SHA-256 hash and Intune app IDs. Null until the first upload.
+- `pending` - The discovered release awaiting publication (version, SHA-256 hash, download URL). A single slot: a newer discovery replaces an unpublished candidate (newest wins), and discovering the already-deployed release clears it. Identity is the SHA-256 hash, so a vendor re-release of the same version with a different binary counts as new.
+- `rings` - Which version currently holds each deployment ring (used by upcoming promotion features).
+- `retained` - Superseded versions kept in Intune for rollback (used by upcoming promotion features).
+
+`napt discover` records the pending candidate.
+Later pipeline stages consume it.
 
 ### Default Behavior (Stateful)
 
 ```bash
-# State tracking enabled by default
+# Cache and deployment state tracking enabled by default
 napt discover recipes/Google/chrome.yaml
 
-# Creates/updates: state/versions.json
+# Creates/updates: cache/discovery.json
+# Creates/updates: state/deployment/napt-chrome.json
 ```
 
 ### Stateless Mode
 
 ```bash
-# Disable state tracking for one-off checks
+# Disable the discovery cache and deployment state writes for one-off checks
 napt discover recipes/Google/chrome.yaml --stateless
 
-# Always downloads, no caching
-# Useful for CI/CD clean builds
+# Always downloads, no caching, records nothing
+# Useful for ad-hoc checks that should leave no trace
 ```
 
 ## Configuration Layers
@@ -745,9 +775,9 @@ Organize recipes by vendor: `recipes/<Vendor>/<app>.yaml`. NAPT automatically de
 
 ### State Management
 
-**Production:** Keep state tracking enabled (default), use version control for state files, run on schedule to detect updates, use `--verbose` in CI/CD.
+**Production:** Keep state tracking enabled (default), use version control for deployment state files, run on schedule to detect updates, use `--verbose` in CI/CD.
 
-**Development:** Use `--stateless` for testing, `--debug` for troubleshooting, delete state file to force re-discovery.
+**Development:** Use `--stateless` for testing, `--debug` for troubleshooting, delete the discovery cache to force re-discovery.
 
 ### Scripting
 
@@ -771,11 +801,11 @@ sudo apt-get install msitools  # Debian/Ubuntu
 brew install msitools           # macOS
 ```
 
-**Problem**: State file corrupted
+**Problem**: Discovery cache corrupted
 
 ```bash
 # NAPT automatically creates backup
-# Backup saved to: state/versions.json.backup
+# Backup saved to: cache/discovery.json.backup
 
 # Force re-download
 napt discover recipes/app.yaml --stateless

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -1261,6 +1261,7 @@ def build_package(
         "update_only" generates detection and requirements.
     """
     from napt.logging import get_global_logger
+    from napt.state import cache_file_path
 
     logger = get_global_logger()
     # Load configuration
@@ -1279,7 +1280,7 @@ def build_package(
 
     # Find installer file
     logger.step(2, 8, "Finding installer...")
-    cache_file = Path(config["directories"]["cache"]) / "discovery.json"
+    cache_file = cache_file_path(config)
     installer_file = _find_installer_file(downloads_dir, config, cache_file)
 
     # Extract version from installer or cache (filesystem is truth)

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -119,20 +119,20 @@ def sanitize_filename(name: str, app_id: str = "") -> str:
 
 
 def _get_installer_version(
-    installer_file: Path, config: dict[str, Any], state_file: Path | None = None
+    installer_file: Path, config: dict[str, Any], cache_file: Path | None = None
 ) -> str:
     """Get version for the installer file.
 
     Priority:
         1. Auto-detect MSI files (`.msi` extension) and extract version
         2. Auto-detect MSIX files (`.msix` extension) and extract version
-        3. Fall back to known_version from state file
+        3. Fall back to known_version from the discovery cache
         4. If all else fails, raise an error
 
     Args:
         installer_file: Path to the installer file.
         config: Recipe configuration.
-        state_file: Path to state file for fallback version lookup.
+        cache_file: Path to discovery cache for fallback version lookup.
 
     Returns:
         Extracted version string.
@@ -165,42 +165,42 @@ def _get_installer_version(
         logger.verbose("BUILD", f"Extracted version: {metadata.version}")
         return metadata.version
 
-    # Non-MSI/MSIX: fall back to state file
-    if state_file and state_file.exists():
-        from napt.state import load_state
+    # Non-MSI/MSIX: fall back to discovery cache
+    if cache_file and cache_file.exists():
+        from napt.state import load_cache
 
-        logger.verbose("BUILD", "Using version from state file")
-        state = load_state(state_file)
-        app_state = state.get("apps", {}).get(app_id, {})
-        known_version = app_state.get("known_version")
+        logger.verbose("BUILD", "Using version from discovery cache")
+        cache_data = load_cache(cache_file)
+        app_entry = cache_data.get("apps", {}).get(app_id, {})
+        known_version = app_entry.get("known_version")
 
         if known_version:
-            logger.verbose("BUILD", f"Using version from state: {known_version}")
+            logger.verbose("BUILD", f"Using version from cache: {known_version}")
             return known_version
 
     # No version found - provide error
     raise ConfigError(
         f"Could not determine version for {app_id}. Either:\n"
         f"  - Use an MSI or MSIX installer (auto-detected from file extension)\n"
-        f"  - Run 'napt discover' first to populate state file with version"
+        f"  - Run 'napt discover' first to populate the discovery cache"
     )
 
 
 def _find_installer_file(
-    downloads_dir: Path, config: dict[str, Any], state_file: Path | None = None
+    downloads_dir: Path, config: dict[str, Any], cache_file: Path | None = None
 ) -> Path:
     """Find the installer file in the downloads directory.
 
     Uses multiple strategies to locate the installer:
     1. URL from recipe (for url_download strategy)
-    2. URL from state file (for web_scrape, api_github, api_json strategies)
+    2. URL from discovery cache (for web_scrape, api_github, api_json strategies)
     3. Filename matching by app name/id
     4. Most recent installer (last resort)
 
     Args:
         downloads_dir: Downloads directory to search.
         config: Recipe configuration.
-        state_file: Optional state file to check for cached URL.
+        cache_file: Optional discovery cache to check for cached URL.
 
     Returns:
         Path to the installer file.
@@ -231,28 +231,28 @@ def _find_installer_file(
                 )
                 return installer_path
 
-    # Strategy 2: Extract filename from state file URL (for web_scrape, etc.)
-    if state_file and state_file.exists():
+    # Strategy 2: Extract filename from discovery cache URL (for web_scrape, etc.)
+    if cache_file and cache_file.exists():
         try:
-            from napt.state import load_state
+            from napt.state import load_cache
 
-            state = load_state(state_file)
-            app_state = state.get("apps", {}).get(app_id, {})
-            state_url = app_state.get("url", "")
+            cache_data = load_cache(cache_file)
+            app_entry = cache_data.get("apps", {}).get(app_id, {})
+            cached_url = app_entry.get("url", "")
 
-            if state_url:
-                parsed = urlparse(state_url)
+            if cached_url:
+                parsed = urlparse(cached_url)
                 filename = Path(parsed.path).name
                 if filename:
                     installer_path = app_dir / filename
 
                     if installer_path.exists():
                         logger.verbose(
-                            "BUILD", f"Found installer from state URL: {installer_path}"
+                            "BUILD", f"Found installer from cache URL: {installer_path}"
                         )
                         return installer_path
         except Exception as err:
-            logger.warning("BUILD", f"Could not check state file: {err}")
+            logger.warning("BUILD", f"Could not check discovery cache: {err}")
 
     # Strategy 3: Fallback - Search for installer matching app name/id
     app_name = config["name"].lower()
@@ -1279,12 +1279,12 @@ def build_package(
 
     # Find installer file
     logger.step(2, 8, "Finding installer...")
-    state_file = Path("state/versions.json")  # Default state file location
-    installer_file = _find_installer_file(downloads_dir, config, state_file)
+    cache_file = Path(config["directories"]["cache"]) / "discovery.json"
+    installer_file = _find_installer_file(downloads_dir, config, cache_file)
 
-    # Extract version from installer or state (filesystem + state are truth)
+    # Extract version from installer or cache (filesystem is truth)
     logger.step(3, 8, "Determining version...")
-    version = _get_installer_version(installer_file, config, state_file)
+    version = _get_installer_version(installer_file, config, cache_file)
 
     logger.info("BUILD", f"Building {app_name} v{version}")
 

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -214,19 +214,24 @@ def cmd_discover(args: argparse.Namespace) -> int:
     and downloading the installer. This command validates the recipe YAML,
     uses the configured discovery strategy to find the latest version,
     downloads the installer (or uses cached version via ETag), extracts
-    version information, and updates the state file with caching info.
+    version information, updates the discovery cache, and records the
+    release as a pending publication candidate in deployment state when it
+    differs from the deployed version.
 
     Args:
         args: Parsed command-line arguments containing
-            recipe path, output directory, state file path, and flags.
+            recipe path, output directory, cache file path, deployment
+            state directory, and flags.
 
     Returns:
         Exit code (0 for success, 1 for failure).
 
     Note:
         Downloads installer file to output_dir (or uses cached version).
-        Updates state file with version and ETag information. Prints progress
-        and results to stdout. Prints errors with optional traceback if verbose/debug.
+        Updates the discovery cache with version and ETag information and
+        the app's deployment state file with the pending release. Prints
+        progress and results to stdout. Prints errors with optional
+        traceback if verbose/debug.
 
     """
     # Configure global logger
@@ -249,7 +254,8 @@ def cmd_discover(args: argparse.Namespace) -> int:
         result = discover_recipe(
             recipe_path,
             output_dir,
-            state_file=args.state_file if not args.stateless else None,
+            cache_file=args.cache_file,
+            state_dir=args.state_dir,
             stateless=args.stateless,
         )
     except (ConfigError, NetworkError, PackagingError) as err:
@@ -627,7 +633,8 @@ def cmd_init(args: argparse.Namespace) -> int:
 
     Initializes a new NAPT project by creating the directory structure and
     default configuration files. This command creates the recipes/ directory,
-    defaults/ directory with org.yaml template, and defaults/vendors/ directory.
+    defaults/ directory with org.yaml template, defaults/vendors/ directory,
+    and state/deployment/ directory for per-app deployment state.
 
     Args:
         args: Parsed command-line arguments containing
@@ -677,6 +684,16 @@ def cmd_init(args: argparse.Namespace) -> int:
     else:
         skipped.append("defaults/vendors/")
         logger.verbose("INIT", "Skipped: defaults/vendors/ (already exists)")
+
+    # Create state/deployment/ directory
+    deployment_dir = target_dir / "state" / "deployment"
+    if not deployment_dir.exists():
+        deployment_dir.mkdir(parents=True)
+        created.append("state/deployment/")
+        logger.verbose("INIT", "Created: state/deployment/")
+    else:
+        skipped.append("state/deployment/")
+        logger.verbose("INIT", "Skipped: state/deployment/ (already exists)")
 
     # Step 2: Create configuration files
     logger.step(2, 2, "Creating configuration files...")
@@ -824,18 +841,30 @@ def main() -> None:
         help="Directory to save downloaded files (default: from config or ./downloads)",
     )
     parser_discover.add_argument(
-        "--state-file",
+        "--cache-file",
         type=Path,
-        default=Path("state/versions.json"),
+        default=None,
         help=(
-            "State file for version tracking and ETag caching "
-            "(default: state/versions.json)"
+            "Discovery cache file for version tracking and ETag caching "
+            "(default: cache/discovery.json from directories.cache)"
+        ),
+    )
+    parser_discover.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory for per-app deployment state files "
+            "(default: state/deployment from directories.state)"
         ),
     )
     parser_discover.add_argument(
         "--stateless",
         action="store_true",
-        help="Disable state tracking (no caching, always download full files)",
+        help=(
+            "Disable the discovery cache and deployment state writes "
+            "(always download full files, record nothing)"
+        ),
     )
     parser_discover.add_argument(
         "-v",
@@ -968,7 +997,8 @@ def main() -> None:
             "Creates:\n"
             "  - recipes/              Directory for recipe YAML files\n"
             "  - defaults/org.yaml     Organization defaults template\n"
-            "  - defaults/vendors/     Directory for vendor-specific defaults\n\n"
+            "  - defaults/vendors/     Directory for vendor-specific defaults\n"
+            "  - state/deployment/     Per-app deployment state files\n\n"
             "Examples:\n"
             "  napt init\n"
             "  napt init ./my-project\n"

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -48,6 +48,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "build": "builds",
         "package": "packages",
         "icons": "icons",
+        "cache": "cache",
+        "state": "state",
     },
     # PSADT (PowerShell App Deployment Toolkit) settings.
     # Merged with recipe psadt: section via the config loader.
@@ -195,6 +197,10 @@ apiVersion: napt/v1
 #   package: "packages"
 #   # App icons extracted by build and uploaded by upload
 #   icons: "icons"
+#   # Discovery cache (disposable optimization)
+#   cache: "cache"
+#   # Authoritative deployment state
+#   state: "state"
 
 # intunewin:
 #   # IntuneWinAppUtil.exe release: "latest" or specific version (e.g., "1.8.6")

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -17,7 +17,8 @@
 This module owns the top-level [discover_recipe][napt.discovery.manager.discover_recipe]
 entry point used by ``napt discover``. It loads the merged configuration,
 picks a flow based on the recipe's ``discovery.strategy`` value, persists
-state for the next run, and returns the public
+the discovery cache for the next run, records the release as a pending
+publication candidate in deployment state, and returns the public
 [DiscoverResult][napt.results.DiscoverResult].
 
 Two Flows:
@@ -59,21 +60,30 @@ from napt.discovery.url_download import run_url_download
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import DiscoverResult
-from napt.state import load_state, save_state
+from napt.state import (
+    deployment_state_path,
+    load_cache,
+    load_deployment_state,
+    record_pending,
+    save_cache,
+    save_deployment_state,
+)
 
 
 def discover_recipe(
     recipe_path: Path,
     output_dir: Path | None = None,
-    state_file: Path | None = Path("state/versions.json"),
+    cache_file: Path | None = None,
+    state_dir: Path | None = None,
     stateless: bool = False,
 ) -> DiscoverResult:
     """Discovers the latest version of an app and resolves its installer.
 
     Loads the recipe configuration, dispatches to the appropriate
     discovery flow (version-first registered strategy or ``url_download``),
-    persists the result to the state cache, and returns the public
-    discovery result.
+    persists the result to the discovery cache, records the release as the
+    pending publication candidate in deployment state when it differs from
+    the deployed version, and returns the public discovery result.
 
     Args:
         recipe_path: Path to the recipe YAML file. Must exist and be
@@ -81,11 +91,15 @@ def discover_recipe(
         output_dir: Directory to download the installer into. When
             omitted, falls back to ``directories.discover`` from the
             merged configuration. Created if it does not exist.
-        state_file: Path to the state file used for caching. Defaults
-            to ``state/versions.json``. Set to ``None`` to disable
-            persistence (run still uses an in-memory cache).
-        stateless: When True, skips loading and saving state entirely.
-            Forces every run to behave as if no prior cache existed.
+        cache_file: Path to the discovery cache file. When omitted,
+            falls back to ``<directories.cache>/discovery.json`` from
+            the merged configuration.
+        state_dir: Directory holding per-app deployment state files.
+            When omitted, falls back to ``<directories.state>/deployment``
+            from the merged configuration.
+        stateless: When True, skips loading and saving the discovery
+            cache and deployment state entirely. Forces every run to
+            behave as if no prior cache existed.
 
     Returns:
         Public discovery result containing the resolved version,
@@ -93,19 +107,24 @@ def discover_recipe(
 
     Raises:
         ConfigError: On missing or invalid configuration, including
-            an unknown ``discovery.strategy`` value.
+            an unknown ``discovery.strategy`` value or a corrupted
+            deployment state file.
         NetworkError: On download or version-extraction failures from
             either flow.
 
     """
     logger = get_global_logger()
 
-    state = _load_state(state_file, stateless, logger)
-
     logger.step(1, 4, "Loading configuration...")
     config = load_effective_config(recipe_path)
     if output_dir is None:
         output_dir = Path(config["directories"]["discover"])
+    if cache_file is None:
+        cache_file = Path(config["directories"]["cache"]) / "discovery.json"
+    if state_dir is None:
+        state_dir = Path(config["directories"]["state"]) / "deployment"
+
+    cache_data = _load_cache(cache_file, stateless, logger)
 
     app_name = config["name"]
     app_id = config["id"]
@@ -115,7 +134,7 @@ def discover_recipe(
     if not strategy_name:
         raise ConfigError(f"No 'discovery.strategy' defined for app: {app_name}")
 
-    cache = _get_cache_for_app(state, app_id, logger)
+    cache = _get_cache_for_app(cache_data, app_id, logger)
 
     logger.step(2, 4, "Discovering version...")
     if strategy_name == "url_download":
@@ -129,8 +148,12 @@ def discover_recipe(
         result = resolve_with_cache(info, config, output_dir, cache)
 
     logger.step(4, 4, "Updating state...")
-    if state is not None and app_id and state_file:
-        _save_app_state(state, state_file, app_id, strategy_name, result, logger)
+    if not stateless and app_id:
+        if cache_data is not None:
+            _save_app_cache(
+                cache_data, cache_file, app_id, strategy_name, result, logger
+            )
+        _record_pending_release(state_dir, app_id, result, logger)
 
     return DiscoverResult(
         app_name=app_name,
@@ -144,25 +167,25 @@ def discover_recipe(
     )
 
 
-def _load_state(
-    state_file: Path | None, stateless: bool, logger: Any
+def _load_cache(
+    cache_file: Path | None, stateless: bool, logger: Any
 ) -> dict[str, Any] | None:
-    """Loads the state file, or returns a fresh state dict if missing."""
-    if stateless or not state_file:
+    """Loads the discovery cache, or returns a fresh cache dict if missing."""
+    if stateless or not cache_file:
         return None
     try:
-        state = load_state(state_file)
-        logger.verbose("STATE", f"Loaded state from {state_file}")
-        return state
+        cache_data = load_cache(cache_file)
+        logger.verbose("STATE", f"Loaded discovery cache from {cache_file}")
+        return cache_data
     except FileNotFoundError:
-        logger.verbose("STATE", f"State file not found, will create: {state_file}")
+        logger.verbose("STATE", f"Cache file not found, will create: {cache_file}")
         return {
             "metadata": {"napt_version": __version__, "schema_version": "2"},
             "apps": {},
         }
     except Exception as err:
-        logger.warning("STATE", f"Failed to load state: {err}")
-        logger.verbose("STATE", "Continuing without state tracking")
+        logger.warning("STATE", f"Failed to load discovery cache: {err}")
+        logger.verbose("STATE", "Continuing without cache tracking")
         return None
 
 
@@ -183,15 +206,15 @@ def _get_cache_for_app(
     return cache
 
 
-def _save_app_state(
-    state: dict[str, Any],
-    state_file: Path,
+def _save_app_cache(
+    cache_data: dict[str, Any],
+    cache_file: Path,
     app_id: str,
     strategy_name: str,
     result: StrategyResult,
     logger: Any,
 ) -> None:
-    """Writes the resolved discovery result back to the state file."""
+    """Writes the resolved discovery result back to the discovery cache."""
     etag = result.headers.get("ETag")
     last_modified = result.headers.get("Last-Modified")
     if etag:
@@ -209,15 +232,60 @@ def _save_app_state(
         "strategy": strategy_name,
     }
 
-    state.setdefault("apps", {})[app_id] = cache_entry
-    state["metadata"] = {
+    cache_data.setdefault("apps", {})[app_id] = cache_entry
+    cache_data["metadata"] = {
         "napt_version": __version__,
         "last_updated": datetime.now(UTC).isoformat(),
         "schema_version": "2",
     }
 
     try:
-        save_state(state, state_file)
-        logger.verbose("STATE", f"Updated state file: {state_file}")
+        save_cache(cache_data, cache_file)
+        logger.verbose("STATE", f"Updated discovery cache: {cache_file}")
     except Exception as err:
-        logger.warning("STATE", f"Failed to save state: {err}")
+        logger.warning("STATE", f"Failed to save discovery cache: {err}")
+
+
+def _record_pending_release(
+    state_dir: Path,
+    app_id: str,
+    result: StrategyResult,
+    logger: Any,
+) -> None:
+    """Records the discovered release in the app's deployment state.
+
+    Updates the pending publication candidate when the discovered release
+    differs from the deployed version (single slot, newest wins). Unlike
+    the discovery cache, deployment state failures are not swallowed —
+    a corrupted authoritative file must surface to the caller.
+    """
+    state_path = deployment_state_path(state_dir, app_id)
+    state = load_deployment_state(state_path)
+
+    action = record_pending(
+        state,
+        version=result.version,
+        sha256=result.sha256,
+        url=result.download_url,
+    )
+
+    if action is None:
+        logger.verbose("STATE", "Pending release unchanged")
+        return
+
+    save_deployment_state(state, state_path)
+    if action == "cleared":
+        logger.info(
+            "STATE",
+            "Pending release cleared (vendor serves the deployed version)",
+        )
+    elif action == "replaced":
+        logger.info(
+            "STATE",
+            f"Pending release replaced with {result.version} (newest wins)",
+        )
+    else:
+        logger.info(
+            "STATE",
+            f"Recorded pending release {result.version} in {state_path}",
+        )

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -61,6 +61,7 @@ from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import DiscoverResult
 from napt.state import (
+    cache_file_path,
     deployment_state_path,
     load_cache,
     load_deployment_state,
@@ -107,10 +108,10 @@ def discover_recipe(
 
     Raises:
         ConfigError: On missing or invalid configuration, including
-            an unknown ``discovery.strategy`` value or a corrupted
-            deployment state file.
+            an unknown ``discovery.strategy`` value.
         NetworkError: On download or version-extraction failures from
             either flow.
+        PackagingError: On a corrupted deployment state file.
 
     """
     logger = get_global_logger()
@@ -120,7 +121,7 @@ def discover_recipe(
     if output_dir is None:
         output_dir = Path(config["directories"]["discover"])
     if cache_file is None:
-        cache_file = Path(config["directories"]["cache"]) / "discovery.json"
+        cache_file = cache_file_path(config)
     if state_dir is None:
         state_dir = Path(config["directories"]["state"]) / "deployment"
 
@@ -252,13 +253,7 @@ def _record_pending_release(
     result: StrategyResult,
     logger: Any,
 ) -> None:
-    """Records the discovered release in the app's deployment state.
-
-    Updates the pending publication candidate when the discovered release
-    differs from the deployed version (single slot, newest wins). Unlike
-    the discovery cache, deployment state failures are not swallowed —
-    a corrupted authoritative file must surface to the caller.
-    """
+    """Records the discovered release as the app's pending candidate."""
     state_path = deployment_state_path(state_dir, app_id)
     state = load_deployment_state(state_path)
 

--- a/napt/state/__init__.py
+++ b/napt/state/__init__.py
@@ -52,7 +52,13 @@ Example:
 
 """
 
-from .cache import DiscoveryCache, create_default_cache, load_cache, save_cache
+from .cache import (
+    DiscoveryCache,
+    cache_file_path,
+    create_default_cache,
+    load_cache,
+    save_cache,
+)
 from .deployment import (
     create_default_deployment_state,
     deployment_state_path,
@@ -63,6 +69,7 @@ from .deployment import (
 
 __all__ = [
     "DiscoveryCache",
+    "cache_file_path",
     "create_default_cache",
     "create_default_deployment_state",
     "deployment_state_path",

--- a/napt/state/__init__.py
+++ b/napt/state/__init__.py
@@ -12,47 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""State tracking and version management for NAPT.
+"""State persistence for NAPT.
 
-This module provides state persistence for tracking discovered application
-versions, ETags, and file metadata between runs. This enables:
+This package holds two kinds of state with opposite philosophies:
 
-- Efficient conditional downloads (HTTP 304 Not Modified)
-- Version change detection
-- Bandwidth optimization for scheduled workflows
+- **Discovery cache** ([napt.state.cache][]): A disposable optimization
+    file (default ``cache/discovery.json``) tracking discovered versions,
+    ETags, and download metadata between runs. It enables conditional
+    downloads (HTTP 304) and version-change detection. Deleting it costs
+    one full re-download per app and nothing else.
+- **Deployment state** ([napt.state.deployment][]): Authoritative per-app
+    records (``state/deployment/<recipe-id>.json``) of what NAPT has
+    published to Intune and what is awaiting publication. Not regenerable.
+    Serialized deterministically so unchanged state produces byte-identical
+    files and clean diffs.
 
-The state file is a JSON file that stores:
-
-- Discovered versions from vendors
-- HTTP ETags and Last-Modified headers for conditional requests
-- File paths and SHA-256 hashes for cached installers
-- Last checked timestamps for monitoring
-
-State tracking is enabled by default and can be disabled with --stateless flag.
+Cache tracking is enabled by default and can be disabled with the
+--stateless flag, which also disables deployment state writes.
 
 Example:
-    Basic usage:
+    Reading the discovery cache:
         ```python
         from pathlib import Path
-        from napt.state import load_state, save_state
+        from napt.state import load_cache
 
-        state = load_state(Path("state/versions.json"))
+        data = load_cache(Path("cache/discovery.json"))
+        entry = data.get("apps", {}).get("napt-chrome")
+        ```
 
-        app_id = "napt-chrome"
-        cache = state.get("apps", {}).get(app_id)
+    Reading deployment state:
+        ```python
+        from pathlib import Path
+        from napt.state import deployment_state_path, load_deployment_state
 
-        state["apps"][app_id] = {
-            "url": "https://dl.google.com/chrome.msi",
-            "etag": 'W/"abc123"',
-            "sha256": "abc123...",
-            "known_version": "130.0.0"
-        }
-
-        save_state(state, Path("state/versions.json"))
+        path = deployment_state_path(Path("state/deployment"), "napt-chrome")
+        state = load_deployment_state(path)
+        pending = state.get("pending")
         ```
 
 """
 
-from .tracker import StateTracker, load_state, save_state
+from .cache import DiscoveryCache, create_default_cache, load_cache, save_cache
+from .deployment import (
+    create_default_deployment_state,
+    deployment_state_path,
+    load_deployment_state,
+    record_pending,
+    save_deployment_state,
+)
 
-__all__ = ["StateTracker", "load_state", "save_state"]
+__all__ = [
+    "DiscoveryCache",
+    "create_default_cache",
+    "create_default_deployment_state",
+    "deployment_state_path",
+    "load_cache",
+    "load_deployment_state",
+    "record_pending",
+    "save_cache",
+    "save_deployment_state",
+]

--- a/napt/state/cache.py
+++ b/napt/state/cache.py
@@ -73,6 +73,19 @@ from napt import __version__
 from napt.exceptions import PackagingError
 
 
+def cache_file_path(config: dict[str, Any]) -> Path:
+    """Returns the discovery cache file path from merged configuration.
+
+    Args:
+        config: Merged configuration containing ``directories.cache``.
+
+    Returns:
+        Path to the discovery cache file (``<directories.cache>/discovery.json``).
+
+    """
+    return Path(config["directories"]["cache"]) / "discovery.json"
+
+
 class DiscoveryCache:
     """Manages the discovery cache with automatic persistence.
 

--- a/napt/state/cache.py
+++ b/napt/state/cache.py
@@ -12,49 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""State tracking implementation for NAPT.
+"""Discovery cache persistence for NAPT.
 
-This module implements the state persistence layer for tracking discovered
-application versions, ETags, and download metadata between runs.
+This module implements the discovery cache: a disposable optimization file
+(default ``cache/discovery.json``) that tracks discovered versions, ETags,
+and download metadata between runs. Deleting it costs one full re-download
+per app and nothing else — the filesystem and deployment state remain the
+source of truth.
 
-The state file supports two optimization approaches:
+The cache supports two optimization approaches:
 
 - VERSION-FIRST (url_pattern, api_github, api_json): Uses known_version for comparison
 - FILE-FIRST (url_download): Uses etag/last_modified for HTTP conditional requests
 
 Key Features:
 
-- JSON-based state storage (fast parsing, standard library)
+- JSON-based cache storage (fast parsing, standard library)
 - Automatic ETag/Last-Modified tracking for conditional requests
 - Version change detection for version-first strategies
 - Robust error handling (corrupted files, missing data)
-- Auto-creation of state files and directories
+- Auto-creation of cache files and directories
 
 Example:
-    High-level API with StateTracker:
+    High-level API with DiscoveryCache:
         ```python
         from pathlib import Path
-        from napt.state import StateTracker
+        from napt.state import DiscoveryCache
 
-        tracker = StateTracker(Path("state/versions.json"))
-        tracker.load()
+        cache = DiscoveryCache(Path("cache/discovery.json"))
+        cache.load()
 
-        # Get cache for conditional requests
-        cache = tracker.get_cache("napt-chrome")
+        # Get entry for conditional requests
+        entry = cache.get_cache("napt-chrome")
 
         # Update after discovery
-        tracker.update_cache("napt-chrome", version="130.0.0", ...)
-        tracker.save()
+        cache.update_cache("napt-chrome", version="130.0.0", ...)
+        cache.save()
         ```
 
     Low-level API with functions:
         ```python
         from pathlib import Path
-        from napt.state import load_state, save_state
+        from napt.state import load_cache, save_cache
 
-        state = load_state(Path("state/versions.json"))
-        # ... modify state dict ...
-        save_state(state, Path("state/versions.json"))
+        data = load_cache(Path("cache/discovery.json"))
+        # ... modify cache dict ...
+        save_cache(data, Path("cache/discovery.json"))
         ```
 
 """
@@ -70,81 +73,81 @@ from napt import __version__
 from napt.exceptions import PackagingError
 
 
-class StateTracker:
-    """Manages application state tracking with automatic persistence.
+class DiscoveryCache:
+    """Manages the discovery cache with automatic persistence.
 
     This class provides a high-level interface for loading, querying, and
-    updating the state file. It handles file I/O, error recovery, and
+    updating the cache file. It handles file I/O, error recovery, and
     provides convenience methods for common operations.
 
     Attributes:
-        state_file: Path to the JSON state file.
-        state: In-memory state dictionary.
+        cache_file: Path to the JSON cache file.
+        data: In-memory cache dictionary.
 
     Example:
         Basic usage:
             ```python
             from pathlib import Path
 
-            tracker = StateTracker(Path("state/versions.json"))
-            tracker.load()
-            cache = tracker.get_cache("napt-chrome")
-            tracker.update_cache(
+            cache = DiscoveryCache(Path("cache/discovery.json"))
+            cache.load()
+            entry = cache.get_cache("napt-chrome")
+            cache.update_cache(
                 "napt-chrome",
                 url="https://...",
                 sha256="...",
                 known_version="130.0.0"
             )
-            tracker.save()
+            cache.save()
             ```
 
     """
 
-    def __init__(self, state_file: Path):
-        """Initialize state tracker.
+    def __init__(self, cache_file: Path):
+        """Initialize discovery cache.
 
         Args:
-            state_file: Path to JSON state file. Created if doesn't exist.
+            cache_file: Path to JSON cache file. Created if doesn't exist.
 
         """
-        self.state_file = state_file
-        self.state: dict[str, Any] = {}
+        self.cache_file = cache_file
+        self.data: dict[str, Any] = {}
 
     def load(self) -> dict[str, Any]:
-        """Load state from file.
+        """Load cache from file.
 
-        Creates default state structure if file doesn't exist.
+        Creates default cache structure if file doesn't exist.
         Handles corrupted files by creating backup and starting fresh.
 
         Returns:
-            Loaded state dictionary.
+            Loaded cache dictionary.
 
         Raises:
             OSError: If file permissions prevent reading.
 
         """
         try:
-            self.state = load_state(self.state_file)
+            self.data = load_cache(self.cache_file)
         except FileNotFoundError:
-            # First run, create default state
-            self.state = create_default_state()
-            self.state_file.parent.mkdir(parents=True, exist_ok=True)
+            # First run, create default cache
+            self.data = create_default_cache()
+            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
             self.save()
         except json.JSONDecodeError as err:
             # Corrupted file, backup and create new
-            backup = self.state_file.with_suffix(".json.backup")
-            self.state_file.rename(backup)
-            self.state = create_default_state()
+            backup = self.cache_file.with_suffix(".json.backup")
+            self.cache_file.rename(backup)
+            self.data = create_default_cache()
             self.save()
             raise PackagingError(
-                f"Corrupted state file backed up to {backup}. "
-                f"Created fresh state file."
+                f"Corrupted cache file backed up to {backup}. "
+                f"Created fresh cache file."
             ) from err
 
-        return self.state
+        return self.data
 
     def save(self) -> None:
-        """Save current state to file.
+        """Save current cache to file.
 
         Updates metadata.last_updated timestamp automatically.
         Creates parent directories if needed.
@@ -154,13 +157,13 @@ class StateTracker:
 
         """
         # Update metadata
-        self.state.setdefault("metadata", {})
-        self.state["metadata"]["last_updated"] = datetime.now(UTC).isoformat()
+        self.data.setdefault("metadata", {})
+        self.data["metadata"]["last_updated"] = datetime.now(UTC).isoformat()
 
         # Ensure parent directory exists
-        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        self.cache_file.parent.mkdir(parents=True, exist_ok=True)
 
-        save_state(self.state, self.state_file)
+        save_cache(self.data, self.cache_file)
 
     def get_cache(self, recipe_id: str) -> dict[str, Any] | None:
         """Get cached information for a recipe.
@@ -174,14 +177,14 @@ class StateTracker:
         Example:
             Retrieve cached information:
                 ```python
-                cache = tracker.get_cache("napt-chrome")
-                if cache:
-                    etag = cache.get('etag')
-                    known_version = cache.get('known_version')
+                entry = cache.get_cache("napt-chrome")
+                if entry:
+                    etag = entry.get('etag')
+                    known_version = entry.get('known_version')
                 ```
 
         """
-        return self.state.get("apps", {}).get(recipe_id)
+        return self.data.get("apps", {}).get(recipe_id)
 
     def update_cache(
         self,
@@ -214,7 +217,7 @@ class StateTracker:
         Example:
             Update cache entry:
                 ```python
-                tracker.update_cache(
+                cache.update_cache(
                     "napt-chrome",
                     url="https://dl.google.com/chrome.msi",
                     sha256="abc123...",
@@ -234,11 +237,12 @@ class StateTracker:
             - File-first: etag/last_modified are PRIMARY cache keys,
                 known_version informational
 
-            Filesystem is the source of truth; state is for optimization only.
+            The cache is for optimization only; the filesystem and
+            deployment state are the source of truth.
 
         """
-        if "apps" not in self.state:
-            self.state["apps"] = {}
+        if "apps" not in self.data:
+            self.data["apps"] = {}
 
         cache_entry = {
             "url": url,
@@ -253,7 +257,7 @@ class StateTracker:
         if strategy is not None:
             cache_entry["strategy"] = strategy
 
-        self.state["apps"][recipe_id] = cache_entry
+        self.data["apps"][recipe_id] = cache_entry
 
     def has_version_changed(self, recipe_id: str, new_version: str) -> bool:
         """Check if discovered version differs from cached known_version.
@@ -268,7 +272,7 @@ class StateTracker:
         Example:
             Check if version has changed:
                 ```python
-                if tracker.has_version_changed("napt-chrome", "130.0.0"):
+                if cache.has_version_changed("napt-chrome", "130.0.0"):
                     print("New version available!")
                 ```
 
@@ -277,24 +281,24 @@ class StateTracker:
             Real version should be extracted from filesystem during build.
 
         """
-        cache = self.get_cache(recipe_id)
-        if not cache:
+        entry = self.get_cache(recipe_id)
+        if not entry:
             return True  # No cache, treat as changed
 
-        return cache.get("known_version") != new_version
+        return entry.get("known_version") != new_version
 
 
-def create_default_state() -> dict[str, Any]:
-    """Create a default empty state structure.
+def create_default_cache() -> dict[str, Any]:
+    """Create a default empty cache structure.
 
     Returns:
-        Empty state with metadata section.
+        Empty cache with metadata section.
 
     Example:
-        Create default state structure:
+        Create default cache structure:
             ```python
-            state = create_default_state()
-            state["apps"] = {}
+            data = create_default_cache()
+            data["apps"] = {}
             ```
 
     """
@@ -308,54 +312,54 @@ def create_default_state() -> dict[str, Any]:
     }
 
 
-def load_state(state_file: Path) -> dict[str, Any]:
-    """Load state from JSON file.
+def load_cache(cache_file: Path) -> dict[str, Any]:
+    """Load cache from JSON file.
 
     Args:
-        state_file: Path to JSON state file.
+        cache_file: Path to JSON cache file.
 
     Returns:
-        Loaded state dictionary.
+        Loaded cache dictionary.
 
     Raises:
-        FileNotFoundError: If state file doesn't exist.
+        FileNotFoundError: If cache file doesn't exist.
         json.JSONDecodeError: If file contains invalid JSON.
         OSError: If file cannot be read due to permissions.
 
     Example:
-        Load state from file:
+        Load cache from file:
             ```python
             from pathlib import Path
 
-            state = load_state(Path("state/versions.json"))
-            apps = state.get("apps", {})
+            data = load_cache(Path("cache/discovery.json"))
+            apps = data.get("apps", {})
             ```
 
     """
-    with open(state_file, encoding="utf-8") as f:
+    with open(cache_file, encoding="utf-8") as f:
         return json.load(f)
 
 
-def save_state(state: dict[str, Any], state_file: Path) -> None:
-    """Save state to JSON file with pretty-printing.
+def save_cache(data: dict[str, Any], cache_file: Path) -> None:
+    """Save cache to JSON file with pretty-printing.
 
     Creates parent directories if needed. Uses 2-space indentation
     and sorted keys for consistent diffs in version control.
 
     Args:
-        state: State dictionary to save.
-        state_file: Path to JSON state file.
+        data: Cache dictionary to save.
+        cache_file: Path to JSON cache file.
 
     Raises:
         OSError: If file cannot be written due to permissions.
 
     Example:
-        Save state to file:
+        Save cache to file:
             ```python
             from pathlib import Path
 
-            state = {"metadata": {}, "apps": {}}
-            save_state(state, Path("state/versions.json"))
+            data = {"metadata": {}, "apps": {}}
+            save_cache(data, Path("cache/discovery.json"))
             ```
 
     Note:
@@ -364,8 +368,8 @@ def save_state(state: dict[str, Any], state_file: Path) -> None:
         - Adds trailing newline for git compatibility
 
     """
-    state_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(state_file, "w", encoding="utf-8") as f:
-        json.dump(state, f, indent=2, sort_keys=True)
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
         f.write("\n")  # Trailing newline for git

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -1,0 +1,203 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployment state persistence for NAPT.
+
+This module implements per-app deployment state: authoritative records of
+what NAPT has published to Intune and what is awaiting publication. Unlike
+the discovery cache, deployment state is not regenerable.
+
+Each app gets its own file, ``state/deployment/<recipe-id>.json``, so that
+concurrent changes to different apps never conflict and each file's diff
+is scoped to one app. A file holds four sections:
+
+- ``deployed``: The version currently published to Intune, with its
+    SHA-256 hash and Intune app IDs. Null until the first upload.
+- ``pending``: The discovered release awaiting publication, with version,
+    SHA-256 hash, and download URL. A single slot — a newer discovery
+    replaces an unpublished candidate (newest wins). Null when nothing is
+    awaiting publication.
+- ``rings``: Which version currently holds each deployment ring. Written
+    by ``napt promote``.
+- ``retained``: Superseded versions kept in Intune for rollback.
+
+Serialization is deterministic (sorted keys, fixed indentation, no
+timestamps), so re-running a command that produces no logical change
+produces a byte-identical file and a clean git diff.
+
+Example:
+    Recording a discovered release:
+        ```python
+        from pathlib import Path
+        from napt.state import (
+            deployment_state_path,
+            load_deployment_state,
+            record_pending,
+            save_deployment_state,
+        )
+
+        path = deployment_state_path(Path("state/deployment"), "napt-chrome")
+        state = load_deployment_state(path)
+        action = record_pending(
+            state,
+            version="130.0.0",
+            sha256="abc123...",
+            url="https://dl.google.com/chrome.msi",
+        )
+        if action:
+            save_deployment_state(state, path)
+        ```
+
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from napt.exceptions import ConfigError
+
+
+def deployment_state_path(state_dir: Path, recipe_id: str) -> Path:
+    """Returns the deployment state file path for a recipe.
+
+    Args:
+        state_dir: Directory holding per-app deployment state files
+            (typically ``state/deployment``).
+        recipe_id: Recipe identifier (from recipe's 'id' field).
+
+    Returns:
+        Path to the app's deployment state file.
+
+    """
+    return state_dir / f"{recipe_id}.json"
+
+
+def create_default_deployment_state() -> dict[str, Any]:
+    """Creates an empty deployment state structure.
+
+    Returns:
+        Deployment state with no deployed version, no pending release,
+        no ring assignments, and no retained versions.
+
+    """
+    return {
+        "deployed": None,
+        "pending": None,
+        "rings": {},
+        "retained": [],
+    }
+
+
+def load_deployment_state(state_path: Path) -> dict[str, Any]:
+    """Loads deployment state for one app.
+
+    Returns a default empty structure when the file does not exist. Does
+    not create the file — deployment state is only written when there is
+    something to record.
+
+    Args:
+        state_path: Path to the app's deployment state file.
+
+    Returns:
+        Deployment state dictionary.
+
+    Raises:
+        ConfigError: If the file exists but contains invalid JSON.
+            Deployment state is authoritative, so a corrupted file is
+            never silently replaced.
+
+    """
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return create_default_deployment_state()
+    except json.JSONDecodeError as err:
+        raise ConfigError(
+            f"Corrupted deployment state file: {state_path}. "
+            "Deployment state is authoritative and is not auto-replaced. "
+            "Fix the JSON or restore the file from a backup."
+        ) from err
+
+
+def save_deployment_state(state: dict[str, Any], state_path: Path) -> None:
+    """Saves deployment state for one app deterministically.
+
+    Creates parent directories if needed. Output is byte-identical for
+    logically identical state: keys are sorted, indentation is fixed at
+    2 spaces, and no timestamps or run-specific values are written.
+
+    Args:
+        state: Deployment state dictionary to save.
+        state_path: Path to the app's deployment state file.
+
+    Raises:
+        OSError: If the file cannot be written due to permissions.
+
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(state_path, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+        f.write("\n")  # Trailing newline for git
+
+
+def record_pending(
+    state: dict[str, Any],
+    version: str,
+    sha256: str,
+    url: str,
+) -> str | None:
+    """Records a discovered release as the pending publication candidate.
+
+    The pending slot holds exactly one candidate and the newest discovery
+    wins: a release that differs from both the deployed version and the
+    current pending candidate replaces the pending candidate. Identity is
+    the SHA-256 hash, not the version string, so a vendor re-release of
+    the same version with a different binary is treated as new.
+
+    Args:
+        state: Deployment state dictionary to update in place.
+        version: Discovered version string.
+        sha256: SHA-256 hash of the discovered installer.
+        url: Download URL of the discovered installer.
+
+    Returns:
+        A string naming the change made ("recorded" for a first candidate,
+            "replaced" when a candidate was overwritten, "cleared" when the
+            vendor serves the already-deployed release), or
+            None when the state did not change.
+
+    """
+    deployed = state.get("deployed")
+    pending = state.get("pending")
+
+    if deployed and deployed.get("sha256") == sha256:
+        # Vendor serves exactly what is deployed; nothing awaits publication.
+        if pending is not None:
+            state["pending"] = None
+            return "cleared"
+        return None
+
+    if pending and pending.get("sha256") == sha256:
+        return None
+
+    state["pending"] = {
+        "version": version,
+        "sha256": sha256,
+        "url": url,
+    }
+    return "replaced" if pending else "recorded"

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -67,7 +67,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt.exceptions import ConfigError
+from napt.exceptions import PackagingError
 
 
 def deployment_state_path(state_dir: Path, recipe_id: str) -> Path:
@@ -115,7 +115,7 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
         Deployment state dictionary.
 
     Raises:
-        ConfigError: If the file exists but contains invalid JSON.
+        PackagingError: If the file exists but contains invalid JSON.
             Deployment state is authoritative, so a corrupted file is
             never silently replaced.
 
@@ -126,7 +126,7 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
     except FileNotFoundError:
         return create_default_deployment_state()
     except json.JSONDecodeError as err:
-        raise ConfigError(
+        raise PackagingError(
             f"Corrupted deployment state file: {state_path}. "
             "Deployment state is authoritative and is not auto-replaced. "
             "Fix the JSON or restore the file from a backup."

--- a/state/.gitignore
+++ b/state/.gitignore
@@ -1,4 +1,4 @@
-# This directory stores state files for NAPT version tracking
-# State files are machine-managed and regenerated from discovery
-# They are gitignored by default but can be version controlled for audit trails
-
+# This directory holds per-app deployment state (state/deployment/<id>.json):
+# authoritative records of what NAPT has published to Intune and what is
+# awaiting publication. Ignored here to keep local test artifacts out of
+# NAPT's own repository.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import os
-from pathlib import Path
 import time
 from unittest.mock import MagicMock, patch
 
@@ -131,7 +130,8 @@ class TestCmdDiscover:
             _args(
                 recipe=str(tmp_path / "nonexistent.yaml"),
                 output_dir=None,
-                state_file=Path("state/versions.json"),
+                cache_file=None,
+                state_dir=None,
                 stateless=False,
             )
         )
@@ -157,7 +157,8 @@ class TestCmdDiscover:
                 _args(
                     recipe=str(recipe),
                     output_dir=None,
-                    state_file=Path("state/versions.json"),
+                    cache_file=None,
+                    state_dir=None,
                     stateless=False,
                 )
             )
@@ -176,7 +177,8 @@ class TestCmdDiscover:
                 _args(
                     recipe=str(recipe),
                     output_dir=None,
-                    state_file=Path("state/versions.json"),
+                    cache_file=None,
+                    state_dir=None,
                     stateless=False,
                 )
             )
@@ -193,15 +195,16 @@ class TestCmdDiscover:
                     _args(
                         recipe=str(recipe),
                         output_dir=None,
-                        state_file=Path("state/versions.json"),
+                        cache_file=None,
+                        state_dir=None,
                         stateless=False,
                     )
                 )
                 == 1
             )
 
-    def test_stateless_passes_none_state_file(self, tmp_path):
-        """Tests that --stateless causes state_file=None to be passed."""
+    def test_stateless_flag_passed_through(self, tmp_path):
+        """Tests that --stateless is passed to discover_recipe."""
         recipe = tmp_path / "recipe.yaml"
         recipe.touch()
         mock_result = _mock_result(
@@ -219,12 +222,15 @@ class TestCmdDiscover:
                 _args(
                     recipe=str(recipe),
                     output_dir=None,
-                    state_file=Path("state/versions.json"),
+                    cache_file=None,
+                    state_dir=None,
                     stateless=True,
                 )
             )
         _, kwargs = mock.call_args
-        assert kwargs["state_file"] is None
+        assert kwargs["stateless"] is True
+        assert kwargs["cache_file"] is None
+        assert kwargs["state_dir"] is None
 
     def test_output_dir_passed_through(self, tmp_path):
         """Tests that --output-dir is resolved and passed to discover_recipe."""
@@ -246,7 +252,8 @@ class TestCmdDiscover:
                 _args(
                     recipe=str(recipe),
                     output_dir=str(custom_output),
-                    state_file=Path("state/versions.json"),
+                    cache_file=None,
+                    state_dir=None,
                     stateless=False,
                 )
             )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,13 +153,16 @@ class TestVersionFirstFastPath:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download.html", text=html_content)
 
-            with patch("napt.discovery.manager.load_state") as mock_load_state:
-                mock_load_state.return_value = state
+            with patch("napt.discovery.manager.load_cache") as mock_load_cache:
+                mock_load_cache.return_value = state
 
-                with patch("napt.discovery.manager.save_state"):
+                with patch("napt.discovery.manager.save_cache"):
                     with patch("napt.discovery.base.download_file") as mock_download:
                         result = discover_recipe(
-                            recipe_path, tmp_test_dir, state_file=Path("state.json")
+                            recipe_path,
+                            tmp_test_dir,
+                            cache_file=Path("state.json"),
+                            state_dir=tmp_test_dir / "state",
                         )
 
                         # Verify download was NOT called (fast path)
@@ -211,10 +214,10 @@ class TestVersionFirstFastPath:
         with requests_mock.Mocker() as m:
             m.get("https://example.com/download.html", text=html_content)
 
-            with patch("napt.discovery.manager.load_state") as mock_load_state:
-                mock_load_state.return_value = state
+            with patch("napt.discovery.manager.load_cache") as mock_load_cache:
+                mock_load_cache.return_value = state
 
-                with patch("napt.discovery.manager.save_state"):
+                with patch("napt.discovery.manager.save_cache"):
                     with patch("napt.discovery.base.download_file") as mock_download:
                         from napt.results import DownloadResult
 
@@ -225,7 +228,10 @@ class TestVersionFirstFastPath:
                         )
 
                         result = discover_recipe(
-                            recipe_path, tmp_test_dir, state_file=Path("state.json")
+                            recipe_path,
+                            tmp_test_dir,
+                            cache_file=Path("state.json"),
+                            state_dir=tmp_test_dir / "state",
                         )
 
                         # Verify download WAS called (version changed)
@@ -284,12 +290,15 @@ class TestVersionFirstFastPath:
                 headers={"Content-Length": str(len(fake_content))},
             )
 
-            with patch("napt.discovery.manager.load_state") as mock_load_state:
-                mock_load_state.return_value = state
+            with patch("napt.discovery.manager.load_cache") as mock_load_cache:
+                mock_load_cache.return_value = state
 
-                with patch("napt.discovery.manager.save_state"):
+                with patch("napt.discovery.manager.save_cache"):
                     result = discover_recipe(
-                        recipe_path, tmp_test_dir, state_file=Path("state.json")
+                        recipe_path,
+                        tmp_test_dir,
+                        cache_file=Path("state.json"),
+                        state_dir=tmp_test_dir / "state",
                     )
 
         # Verify result and that file was downloaded into app-scoped subdirectory

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,10 +1,12 @@
 """
 Tests for napt.state module.
 
-Tests state management including:
-- Loading and saving state files
+Tests state persistence including:
+- Loading and saving discovery cache files
 - Cache operations
-- State file creation and error handling
+- Cache file creation and error handling
+- Deployment state loading, saving, and determinism
+- Pending release recording (newest wins)
 """
 
 from __future__ import annotations
@@ -13,28 +15,37 @@ import json
 
 import pytest
 
-from napt.exceptions import PackagingError
-from napt.state import StateTracker, load_state, save_state
-from napt.state.tracker import create_default_state
+from napt.exceptions import ConfigError, PackagingError
+from napt.state import (
+    DiscoveryCache,
+    create_default_deployment_state,
+    deployment_state_path,
+    load_cache,
+    load_deployment_state,
+    record_pending,
+    save_cache,
+    save_deployment_state,
+)
+from napt.state.cache import create_default_cache
 
 
-class TestStateFileOperations:
-    """Tests for loading and saving state files."""
+class TestCacheFileOperations:
+    """Tests for loading and saving discovery cache files."""
 
-    def test_create_default_state(self):
-        """Test creating default empty state structure."""
-        state = create_default_state()
+    def test_create_default_cache(self):
+        """Tests that the default cache structure is empty with metadata."""
+        data = create_default_cache()
 
-        assert "metadata" in state
-        assert "apps" in state
-        assert state["metadata"]["schema_version"] == "2"
-        assert isinstance(state["apps"], dict)
-        assert len(state["apps"]) == 0
+        assert "metadata" in data
+        assert "apps" in data
+        assert data["metadata"]["schema_version"] == "2"
+        assert isinstance(data["apps"], dict)
+        assert len(data["apps"]) == 0
 
-    def test_save_and_load_state(self, tmp_path):
-        """Test round-trip save and load."""
-        state_file = tmp_path / "test_state.json"
-        state = {
+    def test_save_and_load_cache(self, tmp_path):
+        """Tests round-trip save and load."""
+        cache_file = tmp_path / "discovery.json"
+        data = {
             "metadata": {"napt_version": "0.1.0"},
             "apps": {
                 "test-app": {
@@ -47,80 +58,80 @@ class TestStateFileOperations:
         }
 
         # Save
-        save_state(state, state_file)
-        assert state_file.exists()
+        save_cache(data, cache_file)
+        assert cache_file.exists()
 
         # Load
-        loaded = load_state(state_file)
+        loaded = load_cache(cache_file)
         assert loaded["apps"]["test-app"]["known_version"] == "1.2.3"
         assert loaded["apps"]["test-app"]["etag"] == 'W/"abc123"'
         assert loaded["apps"]["test-app"]["url"] == "https://vendor.com/app.msi"
 
     def test_load_missing_file_raises(self, tmp_path):
-        """Test that loading nonexistent file raises FileNotFoundError."""
-        state_file = tmp_path / "nonexistent.json"
+        """Tests that loading nonexistent file raises FileNotFoundError."""
+        cache_file = tmp_path / "nonexistent.json"
 
         with pytest.raises(FileNotFoundError):
-            load_state(state_file)
+            load_cache(cache_file)
 
     def test_load_invalid_json_raises(self, tmp_path):
-        """Test that loading invalid JSON raises JSONDecodeError."""
-        state_file = tmp_path / "invalid.json"
-        state_file.write_text("This is not JSON", encoding="utf-8")
+        """Tests that loading invalid JSON raises JSONDecodeError."""
+        cache_file = tmp_path / "invalid.json"
+        cache_file.write_text("This is not JSON", encoding="utf-8")
 
         with pytest.raises(json.JSONDecodeError):
-            load_state(state_file)
+            load_cache(cache_file)
 
     def test_save_creates_parent_directory(self, tmp_path):
-        """Test that save creates parent directories if needed."""
-        state_file = tmp_path / "nested" / "dir" / "state.json"
-        state = create_default_state()
+        """Tests that save creates parent directories if needed."""
+        cache_file = tmp_path / "nested" / "dir" / "discovery.json"
+        data = create_default_cache()
 
-        save_state(state, state_file)
+        save_cache(data, cache_file)
 
-        assert state_file.exists()
-        assert state_file.parent.exists()
+        assert cache_file.exists()
+        assert cache_file.parent.exists()
 
     def test_save_pretty_prints_json(self, tmp_path):
-        """Test that saved JSON is pretty-printed."""
-        state_file = tmp_path / "state.json"
-        state = {"metadata": {}, "apps": {"test": {"version": "1.0"}}}
+        """Tests that saved JSON is pretty-printed."""
+        cache_file = tmp_path / "discovery.json"
+        data = {"metadata": {}, "apps": {"test": {"version": "1.0"}}}
 
-        save_state(state, state_file)
+        save_cache(data, cache_file)
 
-        content = state_file.read_text(encoding="utf-8")
+        content = cache_file.read_text(encoding="utf-8")
         # Should have indentation (pretty-printed)
         assert "  " in content
         # Should have trailing newline
         assert content.endswith("\n")
 
 
-class TestStateTracker:
-    """Tests for StateTracker class."""
+class TestDiscoveryCache:
+    """Tests for DiscoveryCache class."""
 
     def test_init(self, tmp_path):
-        """Test StateTracker initialization."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
+        """Tests DiscoveryCache initialization."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
 
-        assert tracker.state_file == state_file
-        assert isinstance(tracker.state, dict)
+        assert cache.cache_file == cache_file
+        assert isinstance(cache.data, dict)
 
     def test_load_creates_default_if_missing(self, tmp_path):
-        """Test that load creates default state if file doesn't exist."""
-        state_file = tmp_path / "new_state.json"
-        tracker = StateTracker(state_file)
+        """Tests that load creates default cache if file doesn't exist."""
+        cache_file = tmp_path / "new_discovery.json"
+        cache = DiscoveryCache(cache_file)
 
-        state = tracker.load()
+        data = cache.load()
 
-        assert state_file.exists()
-        assert "metadata" in state
-        assert "apps" in state
+        assert cache_file.exists()
+        assert "metadata" in data
+        assert "apps" in data
 
     def test_load_existing_file(self, tmp_path):
-        """Test loading existing state file."""
-        state_file = tmp_path / "state.json"
-        initial_state = {
+        """Tests loading existing cache file."""
+        cache_file = tmp_path / "discovery.json"
+        initial_data = {
             "metadata": {"napt_version": "0.1.0"},
             "apps": {
                 "test-app": {
@@ -130,49 +141,49 @@ class TestStateTracker:
                 }
             },
         }
-        save_state(initial_state, state_file)
+        save_cache(initial_data, cache_file)
 
-        tracker = StateTracker(state_file)
-        state = tracker.load()
+        cache = DiscoveryCache(cache_file)
+        data = cache.load()
 
-        assert state["apps"]["test-app"]["known_version"] == "1.2.3"
+        assert data["apps"]["test-app"]["known_version"] == "1.2.3"
 
     def test_load_corrupted_file_creates_backup(self, tmp_path):
-        """Test that corrupted file is backed up and replaced."""
-        state_file = tmp_path / "state.json"
-        state_file.write_text("corrupted JSON{{{", encoding="utf-8")
+        """Tests that corrupted file is backed up and replaced."""
+        cache_file = tmp_path / "discovery.json"
+        cache_file.write_text("corrupted JSON{{{", encoding="utf-8")
 
-        tracker = StateTracker(state_file)
+        cache = DiscoveryCache(cache_file)
 
-        with pytest.raises(PackagingError, match="Corrupted state file"):
-            tracker.load()
+        with pytest.raises(PackagingError, match="Corrupted cache file"):
+            cache.load()
 
         # Should create backup
-        backup_file = tmp_path / "state.json.backup"
+        backup_file = tmp_path / "discovery.json.backup"
         assert backup_file.exists()
         assert backup_file.read_text(encoding="utf-8") == "corrupted JSON{{{"
 
-        # Should create new clean state file
-        assert state_file.exists()
-        new_state = load_state(state_file)
-        assert "apps" in new_state
+        # Should create new clean cache file
+        assert cache_file.exists()
+        new_data = load_cache(cache_file)
+        assert "apps" in new_data
 
     def test_save_updates_timestamp(self, tmp_path):
-        """Test that save updates last_updated timestamp."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = create_default_state()
+        """Tests that save updates last_updated timestamp."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = create_default_cache()
 
-        tracker.save()
+        cache.save()
 
-        loaded = load_state(state_file)
+        loaded = load_cache(cache_file)
         assert "last_updated" in loaded["metadata"]
 
     def test_get_cache_existing(self, tmp_path):
-        """Test getting cache for existing recipe."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = {
+        """Tests getting cache entry for existing recipe."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = {
             "metadata": {},
             "apps": {
                 "test-app": {
@@ -184,30 +195,30 @@ class TestStateTracker:
             },
         }
 
-        cache = tracker.get_cache("test-app")
+        entry = cache.get_cache("test-app")
 
-        assert cache is not None
-        assert cache["known_version"] == "1.2.3"
-        assert cache["etag"] == 'W/"abc123"'
-        assert cache["url"] == "https://vendor.com/app.msi"
+        assert entry is not None
+        assert entry["known_version"] == "1.2.3"
+        assert entry["etag"] == 'W/"abc123"'
+        assert entry["url"] == "https://vendor.com/app.msi"
 
     def test_get_cache_missing(self, tmp_path):
-        """Test getting cache for non-existent recipe returns None."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = {"metadata": {}, "apps": {}}
+        """Tests getting cache entry for non-existent recipe returns None."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = {"metadata": {}, "apps": {}}
 
-        cache = tracker.get_cache("nonexistent-app")
+        entry = cache.get_cache("nonexistent-app")
 
-        assert cache is None
+        assert entry is None
 
     def test_update_cache(self, tmp_path):
-        """Test updating cache for a recipe."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = create_default_state()
+        """Tests updating cache entry for a recipe."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = create_default_cache()
 
-        tracker.update_cache(
+        cache.update_cache(
             recipe_id="test-app",
             url="https://vendor.com/file.msi",
             sha256="abc123",
@@ -217,41 +228,233 @@ class TestStateTracker:
             strategy="url_download",
         )
 
-        cache = tracker.get_cache("test-app")
-        assert cache["known_version"] == "2.0.0"
-        assert cache["url"] == "https://vendor.com/file.msi"
-        assert cache["etag"] == 'W/"xyz789"'
-        assert cache["last_modified"] == "Mon, 28 Oct 2024 10:00:00 GMT"
-        assert cache["sha256"] == "abc123"
-        assert cache["strategy"] == "url_download"
+        entry = cache.get_cache("test-app")
+        assert entry["known_version"] == "2.0.0"
+        assert entry["url"] == "https://vendor.com/file.msi"
+        assert entry["etag"] == 'W/"xyz789"'
+        assert entry["last_modified"] == "Mon, 28 Oct 2024 10:00:00 GMT"
+        assert entry["sha256"] == "abc123"
+        assert entry["strategy"] == "url_download"
 
     def test_has_version_changed_true(self, tmp_path):
-        """Test version change detection when version differs."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = {
+        """Tests version change detection when version differs."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = {
             "metadata": {},
             "apps": {"test-app": {"known_version": "1.0.0"}},
         }
 
-        assert tracker.has_version_changed("test-app", "2.0.0") is True
+        assert cache.has_version_changed("test-app", "2.0.0") is True
 
     def test_has_version_changed_false(self, tmp_path):
-        """Test version change detection when version same."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = {
+        """Tests version change detection when version same."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = {
             "metadata": {},
             "apps": {"test-app": {"known_version": "1.0.0"}},
         }
 
-        assert tracker.has_version_changed("test-app", "1.0.0") is False
+        assert cache.has_version_changed("test-app", "1.0.0") is False
 
     def test_has_version_changed_no_cache(self, tmp_path):
-        """Test version change detection with no cached version."""
-        state_file = tmp_path / "state.json"
-        tracker = StateTracker(state_file)
-        tracker.state = {"metadata": {}, "apps": {}}
+        """Tests version change detection with no cached version."""
+        cache_file = tmp_path / "discovery.json"
+        cache = DiscoveryCache(cache_file)
+        cache.data = {"metadata": {}, "apps": {}}
 
         # No cache means version changed
-        assert tracker.has_version_changed("test-app", "1.0.0") is True
+        assert cache.has_version_changed("test-app", "1.0.0") is True
+
+
+class TestDeploymentStateFiles:
+    """Tests for per-app deployment state persistence."""
+
+    def test_deployment_state_path(self, tmp_path):
+        """Tests that the state path is derived from the recipe id."""
+        path = deployment_state_path(tmp_path / "deployment", "napt-chrome")
+
+        assert path == tmp_path / "deployment" / "napt-chrome.json"
+
+    def test_create_default_deployment_state(self):
+        """Tests that the default structure has all empty sections."""
+        state = create_default_deployment_state()
+
+        assert state["deployed"] is None
+        assert state["pending"] is None
+        assert state["rings"] == {}
+        assert state["retained"] == []
+
+    def test_load_missing_file_returns_default(self, tmp_path):
+        """Tests that a missing file loads as default state without creating it."""
+        state_path = tmp_path / "deployment" / "napt-chrome.json"
+
+        state = load_deployment_state(state_path)
+
+        assert state == create_default_deployment_state()
+        assert not state_path.exists()
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        """Tests round-trip save and load."""
+        state_path = tmp_path / "deployment" / "napt-chrome.json"
+        state = create_default_deployment_state()
+        state["pending"] = {
+            "version": "130.0.0",
+            "sha256": "abc123",
+            "url": "https://dl.google.com/chrome.msi",
+        }
+
+        save_deployment_state(state, state_path)
+        loaded = load_deployment_state(state_path)
+
+        assert loaded == state
+
+    def test_load_corrupted_file_raises_config_error(self, tmp_path):
+        """Tests that a corrupted file raises instead of being replaced."""
+        state_path = tmp_path / "napt-chrome.json"
+        state_path.write_text("not JSON{{{", encoding="utf-8")
+
+        with pytest.raises(ConfigError, match="Corrupted deployment state"):
+            load_deployment_state(state_path)
+
+        # The corrupted file must be left untouched (never silently replaced).
+        assert state_path.read_text(encoding="utf-8") == "not JSON{{{"
+
+    def test_save_is_deterministic(self, tmp_path):
+        """Tests that logically identical state produces byte-identical files."""
+        path_a = tmp_path / "a.json"
+        path_b = tmp_path / "b.json"
+
+        state_a = create_default_deployment_state()
+        state_a["pending"] = {
+            "version": "1.0.0",
+            "sha256": "abc",
+            "url": "https://vendor.com/app.msi",
+        }
+        # Same logical content, different key insertion order.
+        state_b = {
+            "retained": [],
+            "rings": {},
+            "pending": {
+                "url": "https://vendor.com/app.msi",
+                "sha256": "abc",
+                "version": "1.0.0",
+            },
+            "deployed": None,
+        }
+
+        save_deployment_state(state_a, path_a)
+        save_deployment_state(state_b, path_b)
+
+        assert path_a.read_bytes() == path_b.read_bytes()
+
+    def test_save_twice_is_byte_identical(self, tmp_path):
+        """Tests that re-saving unchanged state does not alter the file."""
+        state_path = tmp_path / "napt-chrome.json"
+        state = create_default_deployment_state()
+        state["pending"] = {"version": "1.0.0", "sha256": "abc", "url": "https://x"}
+
+        save_deployment_state(state, state_path)
+        first = state_path.read_bytes()
+        save_deployment_state(state, state_path)
+
+        assert state_path.read_bytes() == first
+
+
+class TestRecordPending:
+    """Tests for pending release recording (single slot, newest wins)."""
+
+    def test_first_discovery_is_recorded(self):
+        """Tests that a release is recorded when nothing is deployed or pending."""
+        state = create_default_deployment_state()
+
+        action = record_pending(
+            state, version="1.0.0", sha256="aaa", url="https://vendor.com/1.msi"
+        )
+
+        assert action == "recorded"
+        assert state["pending"] == {
+            "version": "1.0.0",
+            "sha256": "aaa",
+            "url": "https://vendor.com/1.msi",
+        }
+
+    def test_rerun_with_same_release_is_noop(self):
+        """Tests that re-discovering the pending release changes nothing."""
+        state = create_default_deployment_state()
+        record_pending(state, version="1.0.0", sha256="aaa", url="https://x/1.msi")
+
+        action = record_pending(
+            state, version="1.0.0", sha256="aaa", url="https://x/1.msi"
+        )
+
+        assert action is None
+        assert state["pending"]["version"] == "1.0.0"
+
+    def test_newer_release_replaces_pending(self):
+        """Tests that a newer discovery replaces an unpublished candidate."""
+        state = create_default_deployment_state()
+        record_pending(state, version="1.0.0", sha256="aaa", url="https://x/1.msi")
+
+        action = record_pending(
+            state, version="2.0.0", sha256="bbb", url="https://x/2.msi"
+        )
+
+        assert action == "replaced"
+        assert state["pending"] == {
+            "version": "2.0.0",
+            "sha256": "bbb",
+            "url": "https://x/2.msi",
+        }
+
+    def test_deployed_release_is_not_recorded(self):
+        """Tests that discovering the deployed release records nothing."""
+        state = create_default_deployment_state()
+        state["deployed"] = {"version": "1.0.0", "sha256": "aaa"}
+
+        action = record_pending(
+            state, version="1.0.0", sha256="aaa", url="https://x/1.msi"
+        )
+
+        assert action is None
+        assert state["pending"] is None
+
+    def test_rollback_to_deployed_clears_pending(self):
+        """Tests that pending is cleared when the vendor serves the deployed release."""
+        state = create_default_deployment_state()
+        state["deployed"] = {"version": "1.0.0", "sha256": "aaa"}
+        record_pending(state, version="2.0.0", sha256="bbb", url="https://x/2.msi")
+
+        action = record_pending(
+            state, version="1.0.0", sha256="aaa", url="https://x/1.msi"
+        )
+
+        assert action == "cleared"
+        assert state["pending"] is None
+
+    def test_same_version_different_binary_is_new(self):
+        """Tests that identity is the hash, not the version string."""
+        state = create_default_deployment_state()
+        state["deployed"] = {"version": "1.0.0", "sha256": "aaa"}
+
+        action = record_pending(
+            state, version="1.0.0", sha256="zzz", url="https://x/1.msi"
+        )
+
+        assert action == "recorded"
+        assert state["pending"]["sha256"] == "zzz"
+
+    def test_newer_release_supersedes_pending_over_deployed(self):
+        """Tests the full flow: deployed, pending, then an even newer release."""
+        state = create_default_deployment_state()
+        state["deployed"] = {"version": "1.0.0", "sha256": "aaa"}
+        record_pending(state, version="2.0.0", sha256="bbb", url="https://x/2.msi")
+
+        action = record_pending(
+            state, version="3.0.0", sha256="ccc", url="https://x/3.msi"
+        )
+
+        assert action == "replaced"
+        assert state["pending"]["version"] == "3.0.0"
+        assert state["deployed"]["version"] == "1.0.0"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from napt.exceptions import ConfigError, PackagingError
+from napt.exceptions import PackagingError
 from napt.state import (
     DiscoveryCache,
     create_default_deployment_state,
@@ -310,12 +310,12 @@ class TestDeploymentStateFiles:
 
         assert loaded == state
 
-    def test_load_corrupted_file_raises_config_error(self, tmp_path):
+    def test_load_corrupted_file_raises(self, tmp_path):
         """Tests that a corrupted file raises instead of being replaced."""
         state_path = tmp_path / "napt-chrome.json"
         state_path.write_text("not JSON{{{", encoding="utf-8")
 
-        with pytest.raises(ConfigError, match="Corrupted deployment state"):
+        with pytest.raises(PackagingError, match="Corrupted deployment state"):
             load_deployment_state(state_path)
 
         # The corrupted file must be left untouched (never silently replaced).


### PR DESCRIPTION
## Description

Splits NAPT state into a disposable discovery cache (`cache/discovery.json`, moved from `state/versions.json`) and authoritative per-app deployment state (`state/deployment/<id>.json`). `napt discover` now records each discovered release as the pending publication candidate — one slot, newest wins, identity by SHA-256.

## Motivation

Upcoming deployment promotion needs an authoritative, non-regenerable record of what NAPT published and what awaits publication. That record can''t share a file or philosophy with the disposable cache. Design captured in the roadmap commit.

## Changes

- `napt/state/tracker.py` -> `cache.py` (`DiscoveryCache`, `load_cache`/`save_cache`); new `napt/state/deployment.py` with `record_pending`
- `napt discover` writes the pending candidate; corrupted deployment state raises instead of auto-replacing
- New `directories.cache` / `directories.state` settings; `napt init` scaffolds `state/deployment/`
- **BREAKING:** `--state-file` renamed to `--cache-file`; new `--state-dir`; `--stateless` also skips deployment state; no fallback for the old cache path

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

563 unit tests pass; new coverage for determinism and all `record_pending` transitions. Smoke-tested init + discover end-to-end with mocked HTTP.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors