### PR TITLE
feat: Add upload provenance and hash gate

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,9 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deployment state files** - `napt discover` records each discovered
     release in `state/deployment/{id}.json` as a pending publication
     candidate. One file per app; the newest discovery wins
+- **Upload provenance** - `napt upload` stamps each Intune app entry's
+    notes field with `napt/v1 id=<recipe-id> sha256=<hash>` and records
+    the published version, hash, and Intune app IDs in deployment state
+- **Installer hash verification** - `napt upload` refuses to publish a
+    package whose installer hash does not match the pending release
+    recorded at discovery, so what was approved is exactly what ships
 
 ### Changed
 
+- **BREAKING: `intune.notes` removed** - The Intune notes field is
+    reserved for NAPT's provenance stamp. Move any notes content to
+    `intune.description` or `intune.owner`
 - **BREAKING: Discovery cache moved** - `state/versions.json` is now
     `cache/discovery.json`, and `napt discover --state-file` was renamed
     to `--cache-file`. Delete the old file; the cache rebuilds on the

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -517,7 +517,6 @@ intune:
   logo_path: "brand-packs/logos/app.png"             # Optional: path to app icon
   developer: "Developer Name"                        # Optional: developer field
   owner: "IT Team"                                   # Optional: business owner field
-  notes: "Free-text notes shown in Intune portal"    # Optional: notes field
   detection:                                         # Optional: detection configuration
     display_name: "Application Name"
     architecture: "x64"
@@ -759,14 +758,6 @@ Developer or maintainer name. Shown in the Intune portal's app details.
 **Default:** None
 
 Business owner of the application. Shown in the Intune portal's app details.
-
-### notes
-
-**Type:** `string`
-**Required:** No
-**Default:** None
-
-Free-text notes shown in the Intune portal. Useful for internal documentation.
 
 ### detection
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,10 +113,10 @@ Agreed design:
 
 - Requires Graph API assignment endpoints and `Group.Read.All` for group
   name resolution
-- Delivered across eight PRs: state split, upload provenance and hash gate,
-  idempotent upload, deployment config and assignment client, `promote plan`
-  and `napt status`, `promote apply` with retention, drift detection, GitOps
-  docs and schema versioning
+- Delivered across eight PRs: state split (shipped), upload provenance and
+  hash gate (shipped), idempotent upload, deployment config and assignment
+  client, `promote plan` and `napt status`, `promote apply` with retention,
+  drift detection, GitOps docs and schema versioning
 
 **Related**: Health-gated promotion (block on install failure rates) and
 native Intune supersedence are deliberate follow-ups, not part of this

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -241,7 +241,11 @@ The upload process publishes a packaged app to Microsoft Intune via the
 Graph API. Run `napt package` before uploading.
 
 1. **Locate Package** - Scans `packages/{app_id}/` for the versioned subdirectory
-   created by `napt package` and reads `Invoke-AppDeployToolkit.intunewin` from it
+   created by `napt package` and reads `Invoke-AppDeployToolkit.intunewin` from it.
+   Verifies the package's installer hash (from the build manifest) against the
+   pending release in the app's deployment state — a mismatch aborts the upload,
+   so what was recorded at discovery is byte-for-byte what ships.
+   When no pending release is recorded, the upload proceeds with a warning
 2. **Authenticate** - Tries three credential methods in order (see [Authentication](#authentication) below)
 3. **Parse Package Metadata** - Reads encryption metadata from `Detection.xml` inside the `.intunewin` ZIP
 4–6. **Create, Upload, Commit (install entry)** - Creates the Win32 app record
@@ -254,6 +258,13 @@ Graph API. Run `napt package` before uploading.
    Skipped when `build_types` is `"app_only"`.
    When `build_types` is `"both"` (default), this runs after the install entry
    is fully committed
+
+Each created app entry carries a provenance stamp in its Intune notes field:
+`napt/v1 id=<recipe-id> sha256=<installer-hash>`.
+The stamp marks the app as NAPT-managed and ties it to the exact binary it was
+built from; the notes field is reserved for NAPT and is not recipe-configurable.
+On success, the app's deployment state records the published version, hash,
+and both Intune app IDs, and a matching pending slot is cleared.
 
 **Output**: Intune Win32 App ID (install entry), Intune Win32 Update ID (update
 entry), app name, version, and package path. Each ID is omitted when its

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -41,6 +41,7 @@ Example:
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import re
@@ -810,6 +811,23 @@ def _generate_requirements_script(
     return requirements_script_path
 
 
+def _sha256_file(path: Path) -> str:
+    """Computes the SHA-256 hex digest of a file with chunked reads.
+
+    Args:
+        path: File to hash.
+
+    Returns:
+        SHA-256 hex digest string.
+
+    """
+    sha = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
 def _write_build_manifest(
     build_dir: Path,
     app_id: str,
@@ -817,6 +835,7 @@ def _write_build_manifest(
     version: str,
     build_types: str,
     architecture: str,
+    installer_sha256: str,
     detection_script_path: Path | None,
     requirements_script_path: Path | None,
 ) -> Path:
@@ -835,6 +854,8 @@ def _write_build_manifest(
         architecture: Resolved installer architecture ("x86", "x64", "arm64", "any").
             Auto-detected from MSI Template for MSI installers; from recipe config
             for non-MSI installers.
+        installer_sha256: SHA-256 hex digest of the source installer file,
+            carried through so 'napt upload' can verify provenance.
         detection_script_path: Path to detection script, or None if not generated.
         requirements_script_path: Path to requirements script, or None if not generated.
 
@@ -856,6 +877,7 @@ def _write_build_manifest(
         "version": version,
         "win32_build_types": build_types,
         "architecture": architecture,
+        "installer_sha256": installer_sha256,
     }
 
     # Add script paths (relative to version directory for portability)
@@ -1393,6 +1415,7 @@ def build_package(
         version=version,
         build_types=build_types,
         architecture=architecture,
+        installer_sha256=_sha256_file(installer_file),
         detection_script_path=detection_script_path,
         requirements_script_path=requirements_script_path,
     )

--- a/napt/state/__init__.py
+++ b/napt/state/__init__.py
@@ -63,6 +63,7 @@ from .deployment import (
     create_default_deployment_state,
     deployment_state_path,
     load_deployment_state,
+    record_deployed,
     record_pending,
     save_deployment_state,
 )
@@ -75,6 +76,7 @@ __all__ = [
     "deployment_state_path",
     "load_cache",
     "load_deployment_state",
+    "record_deployed",
     "record_pending",
     "save_cache",
     "save_deployment_state",

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -201,3 +201,38 @@ def record_pending(
         "url": url,
     }
     return "replaced" if pending else "recorded"
+
+
+def record_deployed(
+    state: dict[str, Any],
+    version: str,
+    sha256: str,
+    intune_app_id: str | None,
+    intune_update_app_id: str | None,
+) -> None:
+    """Records a successful publication as the deployed release.
+
+    Replaces the ``deployed`` section and clears the pending slot when the
+    pending candidate is the release that was just published. A pending
+    candidate with a different hash (a newer discovery) is left in place.
+
+    Args:
+        state: Deployment state dictionary to update in place.
+        version: Published version string.
+        sha256: SHA-256 hash of the published release's installer.
+        intune_app_id: Graph API object ID of the install entry, or None
+            when build_types is "update_only".
+        intune_update_app_id: Graph API object ID of the update entry, or
+            None when build_types is "app_only".
+
+    """
+    state["deployed"] = {
+        "version": version,
+        "sha256": sha256,
+        "intune_app_id": intune_app_id,
+        "intune_update_app_id": intune_update_app_id,
+    }
+
+    pending = state.get("pending")
+    if pending and pending.get("sha256") == sha256:
+        state["pending"] = None

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -41,9 +41,15 @@ from typing import Any
 
 from napt.build.icons import MAX_ICON_BYTES
 from napt.config import load_effective_config
-from napt.exceptions import ConfigError
+from napt.exceptions import ConfigError, PackagingError
 from napt.logging import get_global_logger
 from napt.results import UploadResult
+from napt.state import (
+    deployment_state_path,
+    load_deployment_state,
+    record_deployed,
+    save_deployment_state,
+)
 from napt.upload.auth import get_access_token
 from napt.upload.graph import (
     commit_content_version,
@@ -261,12 +267,59 @@ def _resolve_large_icon(config: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _read_build_manifest(package_dir: Path) -> dict[str, Any]:
+    """Reads and validates the build manifest from a package directory.
+
+    Args:
+        package_dir: Versioned package directory containing
+            build-manifest.json (copied there by 'napt package').
+
+    Returns:
+        The parsed build manifest.
+
+    Raises:
+        ConfigError: If the manifest is missing, or its architecture or
+            installer_sha256 fields are absent or unrecognized. Run
+            'napt build' and 'napt package' to recreate the package.
+
+    """
+    manifest_path = package_dir / "build-manifest.json"
+    if not manifest_path.exists():
+        raise ConfigError(
+            f"Build manifest not found in {package_dir}. "
+            "Run 'napt package' to recreate the package."
+        )
+    manifest: dict[str, Any] = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    arch_raw: str = manifest.get("architecture") or ""
+    if not arch_raw:
+        raise ConfigError(
+            f"Architecture not found in build manifest {manifest_path}. "
+            "Run 'napt build' and 'napt package' to recreate the package."
+        )
+    if arch_raw not in _ARCH_MAP:
+        raise ConfigError(
+            f"Unrecognized architecture '{arch_raw}' in build manifest. "
+            f"Expected one of: {', '.join(_ARCH_MAP)}. "
+            "Run 'napt build' and 'napt package' to recreate the package."
+        )
+
+    if not manifest.get("installer_sha256"):
+        raise ConfigError(
+            f"installer_sha256 not found in build manifest {manifest_path}. "
+            "Run 'napt build' and 'napt package' to recreate the package."
+        )
+
+    return manifest
+
+
 def _build_app_metadata(
     config: dict[str, Any],
     recipe_path: Path,
     version: str,
     package_path: Path,
     build_types: str,
+    manifest: dict[str, Any],
     large_icon: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the Win32LobApp JSON payload for the Graph API.
@@ -276,6 +329,11 @@ def _build_app_metadata(
     Scripts are read from the package directory (copied there by 'napt package'),
     so this function does not access the builds directory.
 
+    The payload's notes field carries the NAPT provenance stamp
+    (``napt/v1 id=<recipe-id> sha256=<installer-hash>``), which marks the
+    app as NAPT-managed and ties it to the exact binary it was built from.
+    The field is reserved for NAPT and is not recipe-configurable.
+
     Args:
         config: Effective configuration dict from load_effective_config.
         recipe_path: Path to the recipe file (used to infer vendor/publisher).
@@ -284,6 +342,8 @@ def _build_app_metadata(
             (e.g., packages/napt-chrome/144.0.7559.110/Invoke-AppDeployToolkit.intunewin).
         build_types: Either "app_only" (install entry, detection script only) or
             "update_only" (update entry, detection + requirements scripts).
+        manifest: Parsed build manifest from
+            [_read_build_manifest][napt.upload.manager._read_build_manifest].
         large_icon: Resolved largeIcon mimeContent from
             [_resolve_large_icon][napt.upload.manager._resolve_large_icon],
             or None to omit the icon.
@@ -292,10 +352,9 @@ def _build_app_metadata(
         Dict ready to POST to the Graph API mobileApps endpoint.
 
     Raises:
-        ConfigError: If the build manifest is missing, the architecture field
-            is absent or unrecognized, the detection script is missing, or the
-            requirements script is missing when build_types is "update_only".
-            Run 'napt build' and 'napt package' to recreate the package.
+        ConfigError: If the detection script is missing, or the requirements
+            script is missing when build_types is "update_only". Run
+            'napt build' and 'napt package' to recreate the package.
 
     """
     logger = get_global_logger()
@@ -314,27 +373,7 @@ def _build_app_metadata(
     privacy_url: str = intune.get("privacy_url", "")
     info_url: str = intune.get("info_url", "")
 
-    # Read architecture from build manifest (written by napt build)
-    manifest_path = package_dir / "build-manifest.json"
-    if not manifest_path.exists():
-        raise ConfigError(
-            f"Build manifest not found in {package_dir}. "
-            "Run 'napt package' to recreate the package."
-        )
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    arch_raw: str = manifest.get("architecture") or ""
-    if not arch_raw:
-        raise ConfigError(
-            f"Architecture not found in build manifest {manifest_path}. "
-            "Run 'napt build' and 'napt package' to recreate the package."
-        )
-    if arch_raw not in _ARCH_MAP:
-        raise ConfigError(
-            f"Unrecognized architecture '{arch_raw}' in build manifest. "
-            f"Expected one of: {', '.join(_ARCH_MAP)}. "
-            "Run 'napt build' and 'napt package' to recreate the package."
-        )
-    allowed_architectures: str | None = _ARCH_MAP[arch_raw]
+    allowed_architectures: str | None = _ARCH_MAP[manifest["architecture"]]
 
     # Detection script (always required)
     detection_scripts = sorted(package_dir.glob("*-Detection.ps1"))
@@ -423,13 +462,17 @@ def _build_app_metadata(
         "uninstallCommandLine": uninstall_command,
     }
 
-    # Optional fields: developer, owner, notes
+    # Optional fields: developer, owner
     if intune.get("developer"):
         payload["developer"] = intune["developer"]
     if intune.get("owner"):
         payload["owner"] = intune["owner"]
-    if intune.get("notes"):
-        payload["notes"] = intune["notes"]
+
+    # Provenance stamp: marks the app as NAPT-managed and ties it to the
+    # exact binary it was built from. The notes field is reserved for NAPT.
+    payload["notes"] = (
+        f"napt/v1 id={config['id']} sha256={manifest['installer_sha256']}"
+    )
 
     # Optional: app icon (largeIcon), resolved once per upload
     if large_icon is not None:
@@ -524,6 +567,14 @@ def upload_package(recipe_path: Path) -> UploadResult:
     - CI/CD: set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID
     - Azure-hosted runners: assign a managed identity to the resource
 
+    Before any Graph call, the package's installer hash (from the build
+    manifest) is verified against the pending release recorded in the app's
+    deployment state, so what was recorded at discovery is byte-for-byte
+    what ships. A hash mismatch aborts the upload. When no pending release
+    is recorded, the upload proceeds with a warning. On success, the
+    deployment state records the published version, hash, and Intune app
+    IDs, and a matching pending slot is cleared.
+
     Args:
         recipe_path: Path to the recipe YAML file.
 
@@ -538,7 +589,9 @@ def upload_package(recipe_path: Path) -> UploadResult:
             Run 'napt package' to create or recreate the package.
         AuthError: If all Azure credential methods fail.
         NetworkError: If Graph API or Azure Blob Storage calls fail.
-        PackagingError: If the .intunewin file is malformed.
+        PackagingError: If the .intunewin file is malformed, or the
+            package's installer hash does not match the pending release
+            in deployment state.
 
     Example:
         Upload and print the resulting Intune app IDs:
@@ -573,6 +626,38 @@ def upload_package(recipe_path: Path) -> UploadResult:
     logger.verbose("UPLOAD", f"Package: {package_path}")
     logger.verbose("UPLOAD", f"Version: {version}")
 
+    manifest = _read_build_manifest(package_path.parent)
+    installer_sha256: str = manifest["installer_sha256"]
+
+    # Verify provenance against deployment state before any Graph call:
+    # what was recorded at discovery must be byte-for-byte what ships.
+    state_path = deployment_state_path(
+        Path(config["directories"]["state"]) / "deployment", app_id
+    )
+    state = load_deployment_state(state_path)
+    pending = state.get("pending")
+    if pending:
+        if pending.get("sha256") != installer_sha256:
+            raise PackagingError(
+                f"Installer hash mismatch for '{app_id}': the package was "
+                f"built from a different binary than the pending release "
+                f"recorded in {state_path}.\n"
+                f"  pending:  {pending.get('version')} "
+                f"(sha256 {pending.get('sha256')})\n"
+                f"  package:  {version} (sha256 {installer_sha256})\n"
+                "Re-run 'napt discover', 'napt build', and 'napt package' "
+                "so the package matches the recorded release."
+            )
+        logger.info(
+            "UPLOAD", f"Package matches pending release (sha256 {installer_sha256})"
+        )
+    else:
+        logger.warning(
+            "UPLOAD",
+            f"No pending release recorded for '{app_id}'; uploading "
+            "without provenance verification.",
+        )
+
     # Step 2: Authenticate
     logger.step(2, total_steps, "Authenticating with Azure...")
     access_token = get_access_token()
@@ -587,7 +672,7 @@ def upload_package(recipe_path: Path) -> UploadResult:
     if build_types in ("app_only", "both"):
         # Install entry: steps 4-6
         install_metadata = _build_app_metadata(
-            config, recipe_path, version, package_path, "app_only", large_icon
+            config, recipe_path, version, package_path, "app_only", manifest, large_icon
         )
         intune_app_id = _upload_single_app(
             access_token,
@@ -604,7 +689,13 @@ def upload_package(recipe_path: Path) -> UploadResult:
         # Update entry: steps 4-6 (single) or 7-9 (both)
         step_offset = 6 if build_types == "both" else 3
         update_metadata = _build_app_metadata(
-            config, recipe_path, version, package_path, "update_only", large_icon
+            config,
+            recipe_path,
+            version,
+            package_path,
+            "update_only",
+            manifest,
+            large_icon,
         )
         intune_update_app_id = _upload_single_app(
             access_token,
@@ -616,6 +707,18 @@ def upload_package(recipe_path: Path) -> UploadResult:
             step_commit=step_offset + 3,
             total_steps=total_steps,
         )
+
+    # Record the publication in deployment state: deployed version, hash,
+    # and Intune app IDs; a matching pending slot is cleared.
+    record_deployed(
+        state,
+        version=version,
+        sha256=installer_sha256,
+        intune_app_id=intune_app_id,
+        intune_update_app_id=intune_update_app_id,
+    )
+    save_deployment_state(state, state_path)
+    logger.info("STATE", f"Recorded deployed release {version} in {state_path}")
 
     logger.verbose("UPLOAD", "Upload complete")
 

--- a/napt/validation.py
+++ b/napt/validation.py
@@ -98,7 +98,6 @@ _INTUNE_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
     "logo_path": (str, None, "path to app icon file"),
     "developer": (str, None, "app developer or maintainer"),
     "owner": (str, None, "business owner of the app"),
-    "notes": (str, None, "free-text notes shown in Intune portal"),
     "detection": (dict, None, "detection configuration"),
 }
 

--- a/tests/build/test_manager.py
+++ b/tests/build/test_manager.py
@@ -279,6 +279,7 @@ class TestWriteBuildManifest:
             version="1.0.0",
             build_types="both",
             architecture="x64",
+            installer_sha256="a" * 64,
             detection_script_path=detection_path,
             requirements_script_path=requirements_path,
         )
@@ -293,6 +294,7 @@ class TestWriteBuildManifest:
         assert manifest["version"] == "1.0.0"
         assert manifest["win32_build_types"] == "both"
         assert manifest["architecture"] == "x64"
+        assert manifest["installer_sha256"] == "a" * 64
         assert manifest["detection_script_path"] == "Test-App_1.0.0-Detection.ps1"
         assert manifest["requirements_script_path"] == "Test-App_1.0.0-Requirements.ps1"
 
@@ -312,6 +314,7 @@ class TestWriteBuildManifest:
             version="1.0.0",
             build_types="app_only",
             architecture="x64",
+            installer_sha256="a" * 64,
             detection_script_path=detection_path,
             requirements_script_path=None,  # No requirements script for app_only
         )
@@ -340,6 +343,7 @@ class TestWriteBuildManifest:
             version="1.0.0",
             build_types="update_only",
             architecture="x64",
+            installer_sha256="a" * 64,
             detection_script_path=detection_path,  # Detection always generated
             requirements_script_path=requirements_path,
         )
@@ -366,6 +370,7 @@ class TestWriteBuildManifest:
             version="131.0.0",
             build_types="app_only",
             architecture="x64",
+            installer_sha256="a" * 64,
             detection_script_path=detection_path,
             requirements_script_path=None,
         )
@@ -392,6 +397,7 @@ class TestWriteBuildManifest:
             version="1.0.0",
             build_types="both",
             architecture="x64",
+            installer_sha256="a" * 64,
             detection_script_path=None,
             requirements_script_path=None,
         )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,6 +22,7 @@ from napt.state import (
     deployment_state_path,
     load_cache,
     load_deployment_state,
+    record_deployed,
     record_pending,
     save_cache,
     save_deployment_state,
@@ -458,3 +459,66 @@ class TestRecordPending:
         assert action == "replaced"
         assert state["pending"]["version"] == "3.0.0"
         assert state["deployed"]["version"] == "1.0.0"
+
+
+class TestRecordDeployed:
+    """Tests for deployed release recording."""
+
+    def test_records_deployed_and_clears_matching_pending(self):
+        """Tests that publishing the pending release clears the slot."""
+        state = create_default_deployment_state()
+        record_pending(state, version="2.0.0", sha256="bbb", url="https://x/2.msi")
+
+        record_deployed(
+            state,
+            version="2.0.0",
+            sha256="bbb",
+            intune_app_id="app-1",
+            intune_update_app_id="update-1",
+        )
+
+        assert state["deployed"] == {
+            "version": "2.0.0",
+            "sha256": "bbb",
+            "intune_app_id": "app-1",
+            "intune_update_app_id": "update-1",
+        }
+        assert state["pending"] is None
+
+    def test_preserves_newer_pending(self):
+        """Tests that a pending release with a different hash is kept."""
+        state = create_default_deployment_state()
+        record_pending(state, version="3.0.0", sha256="ccc", url="https://x/3.msi")
+
+        record_deployed(
+            state,
+            version="2.0.0",
+            sha256="bbb",
+            intune_app_id="app-1",
+            intune_update_app_id=None,
+        )
+
+        assert state["deployed"]["version"] == "2.0.0"
+        assert state["pending"]["version"] == "3.0.0"
+
+    def test_replaces_previous_deployed(self):
+        """Tests that a new publication replaces the deployed section."""
+        state = create_default_deployment_state()
+        record_deployed(
+            state,
+            version="1.0.0",
+            sha256="aaa",
+            intune_app_id="a",
+            intune_update_app_id="b",
+        )
+
+        record_deployed(
+            state,
+            version="2.0.0",
+            sha256="bbb",
+            intune_app_id="c",
+            intune_update_app_id="d",
+        )
+
+        assert state["deployed"]["version"] == "2.0.0"
+        assert state["deployed"]["intune_app_id"] == "c"

--- a/tests/upload/conftest.py
+++ b/tests/upload/conftest.py
@@ -55,6 +55,7 @@ def make_package_dir(
     tmp_path: Path,
     app_id: str = "test-app",
     version: str = "1.0.0",
+    installer_sha256: str = "a" * 64,
 ) -> Path:
     """Create a minimal fake package directory for upload tests.
 
@@ -62,6 +63,7 @@ def make_package_dir(
         tmp_path: Base directory (typically pytest's tmp_path).
         app_id: App identifier used in the directory path.
         version: Version string used in the directory path.
+        installer_sha256: Installer hash written to the build manifest.
 
     Returns:
         Path to the version directory (packages/{app_id}/{version}/).
@@ -71,7 +73,8 @@ def make_package_dir(
     pkg_dir.mkdir(parents=True)
     (pkg_dir / "Invoke-AppDeployToolkit.intunewin").write_bytes(make_intunewin_bytes())
     (pkg_dir / "build-manifest.json").write_text(
-        json.dumps({"architecture": "x64"}), encoding="utf-8"
+        json.dumps({"architecture": "x64", "installer_sha256": installer_sha256}),
+        encoding="utf-8",
     )
     (pkg_dir / f"{app_id}-Detection.ps1").write_text("# detection", encoding="utf-8")
     (pkg_dir / f"{app_id}-Requirements.ps1").write_text(

--- a/tests/upload/test_manager.py
+++ b/tests/upload/test_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from contextlib import ExitStack
 import copy
 from pathlib import Path
 from typing import Any
@@ -12,7 +13,13 @@ import pytest
 
 from napt.config.defaults import DEFAULT_CONFIG
 from napt.config.loader import _deep_merge_dicts
-from napt.exceptions import NetworkError
+from napt.exceptions import NetworkError, PackagingError
+from napt.state import (
+    create_default_deployment_state,
+    deployment_state_path,
+    load_deployment_state,
+    save_deployment_state,
+)
 from napt.upload.manager import _resolve_large_icon, upload_package
 from tests.upload.conftest import make_package_dir
 
@@ -413,3 +420,160 @@ def test_upload_package_both_shares_icon_across_entries(
     for call in create_app_mock.call_args_list:
         payload = call.args[1]
         assert payload["largeIcon"] == expected_icon
+
+
+# =============================================================================
+# Provenance stamp, hash gate, and deployment state recording
+# =============================================================================
+
+
+def _run_upload(
+    tmp_path: Path,
+    fake_metadata: Any,
+    build_types: str = "both",
+) -> tuple[Any, MagicMock]:
+    """Run upload_package with all Graph calls mocked.
+
+    Returns:
+        A tuple of (UploadResult, create_win32_app mock).
+
+    """
+    recipe_path = tmp_path / "recipes" / "Vendor" / "test-app.yaml"
+    if not recipe_path.exists():
+        recipe_path.parent.mkdir(parents=True)
+        recipe_path.touch()
+
+    patches = _patch_graph()
+    create_app_mock = MagicMock(side_effect=patches["create_win32_app"])
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "napt.upload.manager.load_effective_config",
+                return_value=_fake_config(build_types=build_types),
+            )
+        )
+        stack.enter_context(
+            patch("napt.upload.manager.get_access_token", return_value="fake-token")
+        )
+        stack.enter_context(
+            patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata)
+        )
+        stack.enter_context(
+            patch(
+                "napt.upload.manager.extract_encrypted_payload",
+                return_value=tmp_path / "payload",
+            )
+        )
+        stack.enter_context(
+            patch("napt.upload.manager.create_win32_app", create_app_mock)
+        )
+        stack.enter_context(
+            patch(
+                "napt.upload.manager.create_content_version",
+                side_effect=patches["create_content_version"],
+            )
+        )
+        stack.enter_context(
+            patch(
+                "napt.upload.manager.create_content_version_file",
+                side_effect=patches["create_content_version_file"],
+            )
+        )
+        stack.enter_context(patch("napt.upload.manager.upload_to_azure_blob"))
+        stack.enter_context(patch("napt.upload.manager.commit_content_version_file"))
+        stack.enter_context(patch("napt.upload.manager.commit_content_version"))
+        result = upload_package(recipe_path)
+
+    return result, create_app_mock
+
+
+def _seed_pending(tmp_path: Path, sha256: str, version: str = "1.0.0") -> Path:
+    """Writes a deployment state file with a pending release for test-app."""
+    state_path = deployment_state_path(tmp_path / "state" / "deployment", "test-app")
+    state = create_default_deployment_state()
+    state["pending"] = {
+        "version": version,
+        "sha256": sha256,
+        "url": "https://vendor.com/app.msi",
+    }
+    save_deployment_state(state, state_path)
+    return state_path
+
+
+def test_upload_stamps_provenance_notes(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that both app entries carry the napt/v1 provenance stamp."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="c" * 64)
+
+    _, create_app_mock = _run_upload(tmp_path, fake_metadata)
+
+    expected = f"napt/v1 id=test-app sha256={'c' * 64}"
+    assert create_app_mock.call_count == 2
+    for call in create_app_mock.call_args_list:
+        assert call.args[1]["notes"] == expected
+
+
+def test_upload_hash_mismatch_aborts_before_graph(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that a pending/package hash mismatch aborts before any Graph call."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+    _seed_pending(tmp_path, sha256="b" * 64, version="2.0.0")
+
+    with pytest.raises(PackagingError, match="hash mismatch"):
+        _run_upload(tmp_path, fake_metadata)
+
+
+def test_upload_matching_pending_records_deployed(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that a matching pending release transitions to deployed."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+    state_path = _seed_pending(tmp_path, sha256="a" * 64)
+
+    _run_upload(tmp_path, fake_metadata)
+
+    state = load_deployment_state(state_path)
+    assert state["pending"] is None
+    assert state["deployed"] == {
+        "version": "1.0.0",
+        "sha256": "a" * 64,
+        "intune_app_id": "intune-app-123",
+        "intune_update_app_id": "intune-update-456",
+    }
+
+
+def test_upload_without_pending_warns_and_records(
+    tmp_path: Path, monkeypatch, fake_metadata, capsys
+) -> None:
+    """Tests that upload without a pending release warns but still records."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    _run_upload(tmp_path, fake_metadata)
+
+    assert "No pending release recorded" in capsys.readouterr().out
+    state_path = deployment_state_path(tmp_path / "state" / "deployment", "test-app")
+    state = load_deployment_state(state_path)
+    assert state["deployed"]["intune_app_id"] == "intune-app-123"
+    assert state["pending"] is None
+
+
+def test_upload_app_only_records_null_update_id(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that app_only records a null update entry ID in deployed state."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    _run_upload(tmp_path, fake_metadata, build_types="app_only")
+
+    state_path = deployment_state_path(tmp_path / "state" / "deployment", "test-app")
+    state = load_deployment_state(state_path)
+    assert state["deployed"]["intune_app_id"] == "intune-app-123"
+    assert state["deployed"]["intune_update_app_id"] is None


### PR DESCRIPTION
## Description

`napt upload` now stamps each Intune app entry''s notes field with `napt/v1 id=<recipe-id> sha256=<hash>`, verifies the package''s installer hash against the pending release in deployment state before any Graph call, and records the published version, hash, and Intune app IDs on success (matching pending slot cleared). `napt build` records `installer_sha256` in the build manifest to carry provenance through the pipeline.

## Motivation

The stamp marks apps as NAPT-managed and ties each to the exact binary it was built from (identity key: `recipe_id + sha256`). The hash gate binds uploads to the release recorded at discovery — in a PR-gated workflow, what the reviewer approved is byte-for-byte what ships. Recorded app IDs are the prerequisite for idempotent upload and `napt promote`.

## Changes

- `napt/v1` provenance stamp on both app entries; notes field now reserved for NAPT
- **BREAKING:** `intune.notes` recipe field removed (move content to `intune.description` or `intune.owner`)
- Hash gate: pending mismatch fails before authentication; no pending recorded warns and proceeds (a strict org-policy flag lands with the `deployment:` config block)
- New `record_deployed` state transition; `installer_sha256` in build-manifest.json

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

586 tests pass; new coverage for the stamp on both entries, gate abort-before-Graph, pending-to-deployed transition, no-pending warning, and `record_deployed` semantics. napt-reviewer verdict: ship (findings addressed).

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors