### PR TITLE
feat: Make upload idempotent via reconcile

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,9 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deployment state files** - `napt discover` records each discovered
     release in `state/deployment/{id}.json` as a pending publication
     candidate. One file per app; the newest discovery wins
+- **Idempotent upload** - Re-running `napt upload` adopts the existing
+    NAPT-stamped Intune apps for a release instead of creating duplicates,
+    and resumes the content upload when a previous run crashed mid-publish.
+    Pass `--force` to re-send metadata and content to the existing apps
+    (e.g., after changing PSADT commands without a new installer release)
 - **Upload provenance** - `napt upload` stamps each Intune app entry's
-    notes field with `napt/v1 id=<recipe-id> sha256=<hash>` and records
-    the published version, hash, and Intune app IDs in deployment state
+    notes field with `napt/v1 id=<recipe-id> entry=<install|update>
+    sha256=<hash>` and records the published version, hash, and Intune
+    app IDs in deployment state
 - **Installer hash verification** - `napt upload` refuses to publish a
     package whose installer hash does not match the pending release
     recorded at discovery, so what was approved is exactly what ships

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -692,6 +692,54 @@ The icons directory is a machine-local output (gitignored), so this fix
 does not travel with the repo.
 Delete the file and rebuild to force re-extraction.
 
+### Fix a broken published app
+
+You published an app, installs are failing — a bad install command, wrong
+detection settings, a missing PSADT step.
+You fixed the recipe, and now Intune needs to match.
+
+**The fix: delete the broken app and publish fresh.**
+
+Intune throttles retries after repeated failures (the Global Retry
+Schedule), and republishing content to the same app does not reliably
+reset it.
+A fresh app object gets a clean evaluation on every device:
+
+1. Delete the broken app entries (install and `[Update]`) in the Intune
+   portal.
+   Deleting first matters: NAPT recognizes its own apps by their
+   provenance stamp, so re-running upload against the existing broken app
+   would adopt it instead of creating a new one.
+2. Rebuild and upload:
+   ```bash
+   napt build recipes/Vendor/app.yaml
+   napt package recipes/Vendor/app.yaml
+   napt upload recipes/Vendor/app.yaml
+   ```
+   Upload finds no stamped apps, creates fresh entries, and records the
+   new app IDs in deployment state automatically.
+3. Recreate the assignments the old app had.
+
+If the vendor has shipped a newer version since the broken publish, you
+can also just run the normal pipeline — the new release creates new app
+entries anyway, and the broken version's entries can be deleted.
+
+**Exception: no device has attempted the install yet.**
+
+If you caught the problem before any assignment took effect — the app is
+still unassigned, or you spotted a wrong command during portal review —
+there is no retry throttling to escape, and an in-place fix is faster:
+
+```bash
+napt build recipes/Vendor/app.yaml
+napt package recipes/Vendor/app.yaml
+napt upload recipes/Vendor/app.yaml --force
+```
+
+`--force` updates the existing app entries in place — metadata and a fresh
+content version together — and keeps the app IDs.
+It never creates duplicates.
+
 ## Update Existing Recipes
 
 When a recipe needs changes (new version format, different download URL, etc.).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,8 +82,8 @@ Agreed design:
   `state/deployment/<recipe-id>.json` (deployed, pending, rings, retained),
   serialized deterministically for clean diffs.
 - **Identity and ownership**: Uploads stamp `napt/v1 id=<recipe>
-  sha256=<hash>` into the Intune notes field; `recipe_id + sha256` is the
-  identity key.
+  entry=<install|update> sha256=<hash>` into the Intune notes field;
+  `recipe_id + sha256` is the identity key.
   The `intune.notes` recipe field is removed — the field is reserved for
   NAPT.
 - **Approval binding**: Upload verifies the installer hash against the
@@ -114,9 +114,9 @@ Agreed design:
 - Requires Graph API assignment endpoints and `Group.Read.All` for group
   name resolution
 - Delivered across eight PRs: state split (shipped), upload provenance and
-  hash gate (shipped), idempotent upload, deployment config and assignment
-  client, `promote plan` and `napt status`, `promote apply` with retention,
-  drift detection, GitOps docs and schema versioning
+  hash gate (shipped), idempotent upload (shipped), deployment config and
+  assignment client, `promote plan` and `napt status`, `promote apply` with
+  retention, drift detection, GitOps docs and schema versioning
 
 **Related**: Health-gated promotion (block on install failure rates) and
 native Intune supersedence are deliberate follow-ups, not part of this

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -260,11 +260,25 @@ Graph API. Run `napt package` before uploading.
    is fully committed
 
 Each created app entry carries a provenance stamp in its Intune notes field:
-`napt/v1 id=<recipe-id> sha256=<installer-hash>`.
+`napt/v1 id=<recipe-id> entry=<install|update> sha256=<installer-hash>`.
 The stamp marks the app as NAPT-managed and ties it to the exact binary it was
 built from; the notes field is reserved for NAPT and is not recipe-configurable.
 On success, the app's deployment state records the published version, hash,
 and both Intune app IDs, and a matching pending slot is cleared.
+
+Re-running an upload is safe.
+Before creating anything, NAPT lists the tenant's apps and looks for stamps
+matching this release: a fully published match is adopted as-is, a match whose
+content was never committed (a crashed previous run) gets a fresh content
+upload, and only missing entries are created.
+Apps without a NAPT stamp are never touched.
+
+Adoption keeps the matched app exactly as it is — it does not re-send
+metadata or package content, since the match key is the installer binary.
+If you changed the recipe or package without a new installer release
+(PSADT commands, detection settings, icon), pass `--force` to update the
+matched apps' metadata and upload a fresh content version.
+`--force` never creates duplicates.
 
 **Output**: Intune Win32 App ID (install entry), Intune Win32 Update ID (update
 entry), app name, version, and package path. Each ID is omitted when its

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -559,6 +559,8 @@ def cmd_upload(args: argparse.Namespace) -> int:
 
     Note:
         Run 'napt package' before this command to create the .intunewin file.
+        Re-running an upload adopts existing NAPT-stamped apps instead of
+        creating duplicates; --force re-sends metadata and content to them.
         Developers: set AZURE_CLIENT_ID and AZURE_TENANT_ID, then complete
         the device code flow when prompted.
         Set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID for CI/CD.
@@ -578,7 +580,7 @@ def cmd_upload(args: argparse.Namespace) -> int:
     print()
 
     try:
-        result = upload_package(recipe_path)
+        result = upload_package(recipe_path, force=args.force)
     except ConfigError as err:
         print(f"Error: {err}")
         if args.verbose or args.debug:
@@ -1059,6 +1061,15 @@ def main() -> None:
         "--tenant-id",
         default=None,
         help="Azure AD tenant ID (overrides defaults/org.yaml)",
+    )
+    parser_upload.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Re-upload metadata and content to existing NAPT-managed apps "
+            "for this release instead of adopting them as-is "
+            "(never creates duplicates)"
+        ),
     )
     parser_upload.add_argument(
         "-v",

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -65,6 +65,9 @@ __all__ = [
     "create_win32_app",
     "create_content_version",
     "create_content_version_file",
+    "get_mobile_app",
+    "list_mobile_apps",
+    "update_win32_app",
     "upload_to_azure_blob",
     "commit_content_version_file",
     "commit_content_version",
@@ -177,6 +180,58 @@ def _poll(
     )
 
 
+def list_mobile_apps(access_token: str) -> list[dict]:
+    """List all mobile apps in the tenant with id, displayName, and notes.
+
+    Follows @odata.nextLink pagination until the collection is exhausted.
+
+    Args:
+        access_token: Bearer token for Graph API.
+
+    Returns:
+        A list of app dicts, each with at least "id", "displayName", and
+            "notes" keys.
+
+    Raises:
+        AuthError: On 401 or 403.
+        NetworkError: On 5xx or connection error.
+
+    """
+    url: str | None = (
+        f"{GRAPH_BASE}/deviceAppManagement/mobileApps" "?$select=id,displayName,notes"
+    )
+    apps: list[dict] = []
+    while url:
+        resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
+        body = _check_response(resp, "list_mobile_apps")
+        apps.extend(body.get("value", []))
+        url = body.get("@odata.nextLink")
+    return apps
+
+
+def get_mobile_app(access_token: str, app_id: str) -> dict:
+    """Get one mobile app's full object by Graph API ID.
+
+    Used to read subtype fields that $select on the collection cannot
+    reliably return, such as win32LobApp.committedContentVersion.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app.
+
+    Returns:
+        The full app object dict.
+
+    Raises:
+        AuthError: On 401 or 403.
+        NetworkError: On 5xx or connection error.
+
+    """
+    url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
+    resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
+    return _check_response(resp, "get_mobile_app")
+
+
 def create_win32_app(access_token: str, app_metadata: dict) -> str:
     """Create a new Win32 LOB app record in Intune.
 
@@ -200,6 +255,27 @@ def create_win32_app(access_token: str, app_metadata: dict) -> str:
     )
     body = _check_response(resp, "create_win32_app")
     return body["id"]
+
+
+def update_win32_app(access_token: str, app_id: str, app_metadata: dict) -> None:
+    """Update an existing Win32 LOB app record's metadata in Intune.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app to update.
+        app_metadata: Win32LobApp JSON payload to apply.
+
+    Raises:
+        AuthError: On 401 or 403.
+        ConfigError: On 400 (invalid metadata).
+        NetworkError: On 5xx or connection error.
+
+    """
+    url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
+    resp = requests.patch(
+        url, headers=_json_headers(access_token), json=app_metadata, timeout=30
+    )
+    _check_response(resp, "update_win32_app")
 
 
 def create_content_version(access_token: str, app_id: str) -> str:

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -57,9 +57,13 @@ from napt.upload.graph import (
     create_content_version,
     create_content_version_file,
     create_win32_app,
+    get_mobile_app,
+    list_mobile_apps,
+    update_win32_app,
     upload_to_azure_blob,
 )
 from napt.upload.intunewin import extract_encrypted_payload, parse_intunewin
+from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, build_stamp, parse_stamp
 
 __all__ = ["upload_package"]
 
@@ -330,9 +334,10 @@ def _build_app_metadata(
     so this function does not access the builds directory.
 
     The payload's notes field carries the NAPT provenance stamp
-    (``napt/v1 id=<recipe-id> sha256=<installer-hash>``), which marks the
-    app as NAPT-managed and ties it to the exact binary it was built from.
-    The field is reserved for NAPT and is not recipe-configurable.
+    (``napt/v1 id=<recipe-id> entry=<install|update> sha256=<installer-hash>``),
+    which marks the app as NAPT-managed and ties it to the exact binary it
+    was built from. The field is reserved for NAPT and is not
+    recipe-configurable.
 
     Args:
         config: Effective configuration dict from load_effective_config.
@@ -470,9 +475,8 @@ def _build_app_metadata(
 
     # Provenance stamp: marks the app as NAPT-managed and ties it to the
     # exact binary it was built from. The notes field is reserved for NAPT.
-    payload["notes"] = (
-        f"napt/v1 id={config['id']} sha256={manifest['installer_sha256']}"
-    )
+    entry = ENTRY_UPDATE if build_types == "update_only" else ENTRY_INSTALL
+    payload["notes"] = build_stamp(config["id"], entry, manifest["installer_sha256"])
 
     # Optional: app icon (largeIcon), resolved once per upload
     if large_icon is not None:
@@ -485,44 +489,58 @@ def _build_app_metadata(
     return payload
 
 
-def _upload_single_app(
+def _find_stamped_app(
+    apps: list[dict[str, Any]],
+    recipe_id: str,
+    entry: str,
+    sha256: str,
+) -> dict[str, Any] | None:
+    """Finds the app whose provenance stamp matches a publish instance.
+
+    Args:
+        apps: Mobile app dicts from list_mobile_apps.
+        recipe_id: Recipe identifier to match.
+        entry: Entry type to match ("install" or "update").
+        sha256: Installer hash to match.
+
+    Returns:
+        The matching app dict, or None when no stamped app matches.
+
+    """
+    for app in apps:
+        stamp = parse_stamp(app.get("notes"))
+        if (
+            stamp
+            and stamp["id"] == recipe_id
+            and stamp["entry"] == entry
+            and stamp["sha256"] == sha256
+        ):
+            return app
+    return None
+
+
+def _upload_app_content(
     access_token: str,
-    app_metadata: dict[str, Any],
+    intune_app_id: str,
     package_path: Path,
     intunewin_metadata: Any,
-    step_create: int,
     step_upload: int,
     step_commit: int,
     total_steps: int,
-) -> str:
-    """Create, upload, and commit one Intune Win32 app entry.
-
-    Executes the full Graph API upload flow for a single app entry: creates
-    the app record and content version, uploads the encrypted payload to Azure
-    Blob Storage, and commits the content version.
+) -> None:
+    """Uploads and commits the encrypted payload for one app record.
 
     Args:
         access_token: Azure AD bearer token for Graph API calls.
-        app_metadata: Win32LobApp JSON payload from _build_app_metadata.
+        intune_app_id: Graph API object ID of the app record.
         package_path: Path to the .intunewin file.
         intunewin_metadata: Parsed encryption metadata from parse_intunewin.
-        step_create: Step number to display when creating the app record.
         step_upload: Step number to display when uploading to Blob Storage.
         step_commit: Step number to display when committing.
         total_steps: Total step count for progress display.
 
-    Returns:
-        The Graph API object ID of the created Intune Win32 app.
-
     """
     logger = get_global_logger()
-    display_name: str = app_metadata["displayName"]
-
-    logger.step(
-        step_create, total_steps, f"Creating app record for '{display_name}'..."
-    )
-    intune_app_id = create_win32_app(access_token, app_metadata)
-    logger.info("UPLOAD", f"Created Intune app: {intune_app_id}")
 
     cv_id = create_content_version(access_token, intune_app_id)
     logger.verbose("UPLOAD", f"Content version: {cv_id}")
@@ -543,10 +561,118 @@ def _upload_single_app(
     )
     commit_content_version(access_token, intune_app_id, cv_id)
 
+
+def _upload_single_app(
+    access_token: str,
+    app_metadata: dict[str, Any],
+    package_path: Path,
+    intunewin_metadata: Any,
+    existing_apps: list[dict[str, Any]],
+    recipe_id: str,
+    entry: str,
+    installer_sha256: str,
+    step_create: int,
+    step_upload: int,
+    step_commit: int,
+    total_steps: int,
+    force: bool = False,
+) -> str:
+    """Publish one Intune Win32 app entry, reusing an existing stamped app.
+
+    Reconcile-before-act: when a NAPT-stamped app already matches this
+    publish instance (recipe id, entry type, installer hash), the app is
+    adopted instead of duplicated — skipped entirely if its content is
+    committed, or resumed with a fresh content upload if a previous run
+    crashed between app creation and commit. Otherwise the app record is
+    created and its content uploaded and committed.
+
+    Adoption does not re-send app metadata or content: a matched app keeps
+    whatever it already has, even if the recipe or package changed since it
+    was published (the match key is the installer binary, not the package).
+    Pass force=True to update the matched app's metadata and upload a fresh
+    content version instead of adopting.
+
+    Args:
+        access_token: Azure AD bearer token for Graph API calls.
+        app_metadata: Win32LobApp JSON payload from _build_app_metadata.
+        package_path: Path to the .intunewin file.
+        intunewin_metadata: Parsed encryption metadata from parse_intunewin.
+        existing_apps: Mobile app dicts from list_mobile_apps.
+        recipe_id: Recipe identifier for stamp matching.
+        entry: Entry type for stamp matching ("install" or "update").
+        installer_sha256: Installer hash for stamp matching.
+        step_create: Step number to display when creating the app record.
+        step_upload: Step number to display when uploading to Blob Storage.
+        step_commit: Step number to display when committing.
+        total_steps: Total step count for progress display.
+        force: When True, a matched app gets its metadata updated and a
+            fresh content version uploaded instead of being adopted as-is.
+
+    Returns:
+        The Graph API object ID of the created or adopted Intune Win32 app.
+
+    """
+    logger = get_global_logger()
+    display_name: str = app_metadata["displayName"]
+
+    match = _find_stamped_app(existing_apps, recipe_id, entry, installer_sha256)
+    if match is not None:
+        intune_app_id: str = match["id"]
+        if force:
+            logger.step(
+                step_create,
+                total_steps,
+                f"Re-uploading existing app record for '{display_name}'...",
+            )
+            update_win32_app(access_token, intune_app_id, app_metadata)
+            logger.info(
+                "UPLOAD",
+                f"Updated Intune app metadata: {intune_app_id} (--force)",
+            )
+        else:
+            full_app = get_mobile_app(access_token, intune_app_id)
+            if full_app.get("committedContentVersion"):
+                logger.step(
+                    step_create,
+                    total_steps,
+                    f"Adopting existing app record for '{display_name}'...",
+                )
+                logger.info(
+                    "UPLOAD",
+                    f"Adopted Intune app: {intune_app_id} (content already committed)",
+                )
+                return intune_app_id
+
+            logger.step(
+                step_create,
+                total_steps,
+                f"Resuming upload for existing app record '{display_name}'...",
+            )
+            logger.info(
+                "UPLOAD",
+                f"Reusing Intune app: {intune_app_id} (content was never committed)",
+            )
+    else:
+        logger.step(
+            step_create, total_steps, f"Creating app record for '{display_name}'..."
+        )
+        intune_app_id = create_win32_app(access_token, app_metadata)
+        logger.info("UPLOAD", f"Created Intune app: {intune_app_id}")
+
+    _upload_app_content(
+        access_token,
+        intune_app_id,
+        package_path,
+        intunewin_metadata,
+        step_upload,
+        step_commit,
+        total_steps,
+    )
+
     return intune_app_id
 
 
-def upload_package(recipe_path: Path) -> UploadResult:
+def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
     """Upload a packaged app to Microsoft Intune via the Graph API.
 
     Loads the recipe config, infers the .intunewin package path, authenticates
@@ -575,8 +701,19 @@ def upload_package(recipe_path: Path) -> UploadResult:
     deployment state records the published version, hash, and Intune app
     IDs, and a matching pending slot is cleared.
 
+    Re-running an upload is safe: existing NAPT-stamped apps matching this
+    publish instance (recipe id, entry type, installer hash) are adopted —
+    or their interrupted content upload resumed — instead of duplicated.
+    Adoption keeps the app as it is; it does not re-send metadata or
+    content. Pass force=True to update matched apps' metadata and upload a
+    fresh content version (e.g., after changing PSADT commands or detection
+    settings without a new installer release).
+
     Args:
         recipe_path: Path to the recipe YAML file.
+        force: When True, matched stamped apps are re-uploaded (metadata
+            and content) instead of adopted as-is. Never creates
+            duplicates.
 
     Returns:
         Upload result including the Intune app ID(s), app name, version, and
@@ -666,6 +803,11 @@ def upload_package(recipe_path: Path) -> UploadResult:
     logger.step(3, total_steps, "Parsing package metadata...")
     intunewin_metadata = parse_intunewin(package_path)
 
+    # Reconcile-before-act: list existing apps once so stamped apps from a
+    # previous (possibly crashed) run are adopted instead of duplicated.
+    existing_apps = list_mobile_apps(access_token)
+    logger.verbose("UPLOAD", f"Tenant has {len(existing_apps)} mobile apps")
+
     intune_app_id: str | None = None
     intune_update_app_id: str | None = None
 
@@ -679,10 +821,15 @@ def upload_package(recipe_path: Path) -> UploadResult:
             install_metadata,
             package_path,
             intunewin_metadata,
+            existing_apps,
+            recipe_id=app_id,
+            entry=ENTRY_INSTALL,
+            installer_sha256=installer_sha256,
             step_create=4,
             step_upload=5,
             step_commit=6,
             total_steps=total_steps,
+            force=force,
         )
 
     if build_types in ("update_only", "both"):
@@ -702,10 +849,15 @@ def upload_package(recipe_path: Path) -> UploadResult:
             update_metadata,
             package_path,
             intunewin_metadata,
+            existing_apps,
+            recipe_id=app_id,
+            entry=ENTRY_UPDATE,
+            installer_sha256=installer_sha256,
             step_create=step_offset + 1,
             step_upload=step_offset + 2,
             step_commit=step_offset + 3,
             total_steps=total_steps,
+            force=force,
         )
 
     # Record the publication in deployment state: deployed version, hash,

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -589,8 +589,8 @@ def _upload_single_app(
     Adoption does not re-send app metadata or content: a matched app keeps
     whatever it already has, even if the recipe or package changed since it
     was published (the match key is the installer binary, not the package).
-    Pass force=True to update the matched app's metadata and upload a fresh
-    content version instead of adopting.
+    Pass force=True to upload a fresh content version and then update the
+    matched app's metadata instead of adopting.
 
     Args:
         access_token: Azure AD bearer token for Graph API calls.
@@ -616,6 +616,7 @@ def _upload_single_app(
     display_name: str = app_metadata["displayName"]
 
     match = _find_stamped_app(existing_apps, recipe_id, entry, installer_sha256)
+    patch_metadata_after_content = False
     if match is not None:
         intune_app_id: str = match["id"]
         if force:
@@ -624,11 +625,10 @@ def _upload_single_app(
                 total_steps,
                 f"Re-uploading existing app record for '{display_name}'...",
             )
-            update_win32_app(access_token, intune_app_id, app_metadata)
-            logger.info(
-                "UPLOAD",
-                f"Updated Intune app metadata: {intune_app_id} (--force)",
-            )
+            # The metadata PATCH must come after the content upload: Intune
+            # rejects a contentVersions POST that closely follows an app
+            # PATCH with HTTP 412 ConditionNotMet (stale internal ETag).
+            patch_metadata_after_content = True
         else:
             full_app = get_mobile_app(access_token, intune_app_id)
             if full_app.get("committedContentVersion"):
@@ -668,6 +668,13 @@ def _upload_single_app(
         step_commit,
         total_steps,
     )
+
+    if patch_metadata_after_content:
+        update_win32_app(access_token, intune_app_id, app_metadata)
+        logger.info(
+            "UPLOAD",
+            f"Updated Intune app metadata: {intune_app_id} (--force)",
+        )
 
     return intune_app_id
 

--- a/napt/upload/stamp.py
+++ b/napt/upload/stamp.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provenance stamp for NAPT-managed Intune apps.
+
+The stamp is a single machine-parseable line written to the Intune notes
+field of every app NAPT publishes:
+
+    napt/v1 id=<recipe-id> entry=<install|update> sha256=<installer-hash>
+
+It serves two purposes: ownership (presence of the stamp marks an app as
+NAPT-managed; unstamped apps are never touched) and identity (the recipe
+id, entry type, and installer hash tie the Intune object to a specific
+publish instance recorded in deployment state). The notes field is
+reserved for NAPT and is not recipe-configurable.
+"""
+
+from __future__ import annotations
+
+from napt.exceptions import ConfigError
+
+# Maximum length Intune accepts for the mobileApp notes field.
+NOTES_MAX_LENGTH = 1024
+
+STAMP_PREFIX = "napt/v1"
+
+# Intune app entry types NAPT publishes per recipe.
+ENTRY_INSTALL = "install"
+ENTRY_UPDATE = "update"
+
+_REQUIRED_KEYS = ("id", "entry", "sha256")
+
+
+def build_stamp(recipe_id: str, entry: str, sha256: str) -> str:
+    """Builds the provenance stamp for one Intune app entry.
+
+    Args:
+        recipe_id: Recipe identifier (from recipe's 'id' field).
+        entry: Entry type, either "install" or "update".
+        sha256: SHA-256 hex digest of the source installer.
+
+    Returns:
+        The stamp line to write to the Intune notes field.
+
+    Raises:
+        ConfigError: If the stamp would exceed Intune's notes field length
+            limit (only possible with an extremely long recipe id).
+
+    """
+    stamp = f"{STAMP_PREFIX} id={recipe_id} entry={entry} sha256={sha256}"
+    if len(stamp) > NOTES_MAX_LENGTH:
+        raise ConfigError(
+            f"Provenance stamp for '{recipe_id}' is {len(stamp)} characters, "
+            f"over Intune's {NOTES_MAX_LENGTH}-character notes field limit. "
+            "Shorten the recipe id."
+        )
+    return stamp
+
+
+def parse_stamp(notes: str | None) -> dict[str, str] | None:
+    """Parses a provenance stamp from an Intune notes field value.
+
+    Args:
+        notes: The notes field content, or None.
+
+    Returns:
+        A dict with "id", "entry", and "sha256" keys, or None when the
+            notes do not carry a complete NAPT stamp.
+
+    """
+    if not notes or not notes.startswith(f"{STAMP_PREFIX} "):
+        return None
+
+    fields: dict[str, str] = {}
+    for token in notes.split()[1:]:
+        key, sep, value = token.partition("=")
+        if sep and value:
+            fields[key] = value
+
+    if any(key not in fields for key in _REQUIRED_KEYS):
+        return None
+    return {key: fields[key] for key in _REQUIRED_KEYS}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -503,7 +503,7 @@ class TestCmdUpload:
 
     def test_missing_recipe_returns_one(self, tmp_path, capsys):
         """Tests that a missing recipe file exits with code 1."""
-        code = cmd_upload(_args(recipe=str(tmp_path / "nonexistent.yaml")))
+        code = cmd_upload(_args(recipe=str(tmp_path / "nonexistent.yaml"), force=False))
         assert code == 1
 
     def test_success_prints_results_returns_zero(self, tmp_path, capsys):
@@ -519,7 +519,7 @@ class TestCmdUpload:
             status="success",
         )
         with patch("napt.cli.upload_package", return_value=mock_result):
-            code = cmd_upload(_args(recipe=str(recipe)))
+            code = cmd_upload(_args(recipe=str(recipe), force=False))
         assert code == 0
         out = capsys.readouterr().out
         assert "[SUCCESS]" in out
@@ -534,7 +534,7 @@ class TestCmdUpload:
             "napt.cli.upload_package",
             side_effect=AuthError("credential chain exhausted"),
         ):
-            code = cmd_upload(_args(recipe=str(recipe)))
+            code = cmd_upload(_args(recipe=str(recipe), force=False))
         assert code == 1
         out = capsys.readouterr().out
         assert "Authentication error" in out
@@ -545,14 +545,14 @@ class TestCmdUpload:
         recipe = tmp_path / "recipe.yaml"
         recipe.touch()
         with patch("napt.cli.upload_package", side_effect=ConfigError("bad")):
-            assert cmd_upload(_args(recipe=str(recipe))) == 1
+            assert cmd_upload(_args(recipe=str(recipe), force=False)) == 1
 
     def test_network_error_returns_one(self, tmp_path):
         """Tests that NetworkError returns 1."""
         recipe = tmp_path / "recipe.yaml"
         recipe.touch()
         with patch("napt.cli.upload_package", side_effect=NetworkError("net")):
-            assert cmd_upload(_args(recipe=str(recipe))) == 1
+            assert cmd_upload(_args(recipe=str(recipe), force=False)) == 1
 
 
 # =============================================================================

--- a/tests/upload/test_graph.py
+++ b/tests/upload/test_graph.py
@@ -16,6 +16,8 @@ from napt.upload.graph import (
     create_content_version,
     create_content_version_file,
     create_win32_app,
+    get_mobile_app,
+    list_mobile_apps,
     upload_to_azure_blob,
 )
 
@@ -205,3 +207,40 @@ def test_commit_content_version_500_raises_network_error() -> None:
         m.patch(_APP_URL, json={}, status_code=500)
         with pytest.raises(NetworkError):
             commit_content_version(TOKEN, APP_ID, CV_ID)
+
+
+# --- list_mobile_apps / get_mobile_app ---
+
+
+def test_list_mobile_apps_single_page() -> None:
+    """Tests that a single page of apps is returned."""
+    apps = [{"id": "1", "displayName": "A", "notes": None}]
+    with req_mock.Mocker() as m:
+        m.get(_APPS_URL, json={"value": apps})
+        result = list_mobile_apps(TOKEN)
+
+    assert result == apps
+
+
+def test_list_mobile_apps_follows_pagination() -> None:
+    """Tests that @odata.nextLink pages are followed and merged."""
+    page1 = {
+        "value": [{"id": "1"}],
+        "@odata.nextLink": f"{_APPS_URL}?$skiptoken=abc",
+    }
+    page2 = {"value": [{"id": "2"}]}
+    with req_mock.Mocker() as m:
+        m.get(_APPS_URL, [{"json": page1}, {"json": page2}])
+        result = list_mobile_apps(TOKEN)
+
+    assert [a["id"] for a in result] == ["1", "2"]
+
+
+def test_get_mobile_app_returns_full_object() -> None:
+    """Tests that get_mobile_app returns the app body."""
+    body = {"id": APP_ID, "committedContentVersion": "1"}
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, json=body)
+        result = get_mobile_app(TOKEN, APP_ID)
+
+    assert result == body

--- a/tests/upload/test_manager.py
+++ b/tests/upload/test_manager.py
@@ -74,6 +74,7 @@ def test_upload_package_both_creates_two_apps(
         ),
         patch("napt.upload.manager.get_access_token", return_value="fake-token"),
         patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch("napt.upload.manager.list_mobile_apps", return_value=[]),
         patch(
             "napt.upload.manager.extract_encrypted_payload",
             return_value=tmp_path / "payload",
@@ -122,6 +123,7 @@ def test_upload_package_app_only_creates_one_app(
         ),
         patch("napt.upload.manager.get_access_token", return_value="fake-token"),
         patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch("napt.upload.manager.list_mobile_apps", return_value=[]),
         patch(
             "napt.upload.manager.extract_encrypted_payload",
             return_value=tmp_path / "payload",
@@ -161,6 +163,7 @@ def test_upload_package_update_only_creates_one_app(
         ),
         patch("napt.upload.manager.get_access_token", return_value="fake-token"),
         patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch("napt.upload.manager.list_mobile_apps", return_value=[]),
         patch(
             "napt.upload.manager.extract_encrypted_payload",
             return_value=tmp_path / "payload",
@@ -200,6 +203,7 @@ def test_upload_package_propagates_network_error(
         ),
         patch("napt.upload.manager.get_access_token", return_value="fake-token"),
         patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch("napt.upload.manager.list_mobile_apps", return_value=[]),
         patch(
             "napt.upload.manager.create_win32_app",
             side_effect=NetworkError("Graph API down"),
@@ -393,6 +397,7 @@ def test_upload_package_both_shares_icon_across_entries(
         ),
         patch("napt.upload.manager.get_access_token", return_value="fake-token"),
         patch("napt.upload.manager.parse_intunewin", return_value=fake_metadata),
+        patch("napt.upload.manager.list_mobile_apps", return_value=[]),
         patch(
             "napt.upload.manager.extract_encrypted_payload",
             return_value=tmp_path / "payload",
@@ -431,11 +436,24 @@ def _run_upload(
     tmp_path: Path,
     fake_metadata: Any,
     build_types: str = "both",
-) -> tuple[Any, MagicMock]:
+    existing_apps: list[dict[str, Any]] | None = None,
+    full_app: dict[str, Any] | None = None,
+    force: bool = False,
+) -> tuple[Any, dict[str, MagicMock]]:
     """Run upload_package with all Graph calls mocked.
 
+    Args:
+        tmp_path: Test directory (cwd for the run).
+        fake_metadata: IntunewinMetadata fixture value.
+        build_types: build_types config value for the run.
+        existing_apps: Return value for list_mobile_apps (default empty).
+        full_app: Return value for get_mobile_app (used when a stamped
+            app matches).
+        force: Passed through to upload_package.
+
     Returns:
-        A tuple of (UploadResult, create_win32_app mock).
+        A tuple of (UploadResult, mocks) where mocks holds the
+            "create_app", "create_cv", and "update_app" MagicMocks.
 
     """
     recipe_path = tmp_path / "recipes" / "Vendor" / "test-app.yaml"
@@ -444,7 +462,13 @@ def _run_upload(
         recipe_path.touch()
 
     patches = _patch_graph()
-    create_app_mock = MagicMock(side_effect=patches["create_win32_app"])
+    mocks = {
+        "create_app": MagicMock(side_effect=patches["create_win32_app"]),
+        "create_cv": MagicMock(side_effect=patches["create_content_version"]),
+        "update_app": MagicMock(),
+    }
+    create_app_mock = mocks["create_app"]
+    create_cv_mock = mocks["create_cv"]
 
     with ExitStack() as stack:
         stack.enter_context(
@@ -461,6 +485,18 @@ def _run_upload(
         )
         stack.enter_context(
             patch(
+                "napt.upload.manager.list_mobile_apps",
+                return_value=existing_apps or [],
+            )
+        )
+        stack.enter_context(
+            patch(
+                "napt.upload.manager.get_mobile_app",
+                return_value=full_app or {},
+            )
+        )
+        stack.enter_context(
+            patch(
                 "napt.upload.manager.extract_encrypted_payload",
                 return_value=tmp_path / "payload",
             )
@@ -469,10 +505,7 @@ def _run_upload(
             patch("napt.upload.manager.create_win32_app", create_app_mock)
         )
         stack.enter_context(
-            patch(
-                "napt.upload.manager.create_content_version",
-                side_effect=patches["create_content_version"],
-            )
+            patch("napt.upload.manager.create_content_version", create_cv_mock)
         )
         stack.enter_context(
             patch(
@@ -480,12 +513,15 @@ def _run_upload(
                 side_effect=patches["create_content_version_file"],
             )
         )
+        stack.enter_context(
+            patch("napt.upload.manager.update_win32_app", mocks["update_app"])
+        )
         stack.enter_context(patch("napt.upload.manager.upload_to_azure_blob"))
         stack.enter_context(patch("napt.upload.manager.commit_content_version_file"))
         stack.enter_context(patch("napt.upload.manager.commit_content_version"))
-        result = upload_package(recipe_path)
+        result = upload_package(recipe_path, force=force)
 
-    return result, create_app_mock
+    return result, mocks
 
 
 def _seed_pending(tmp_path: Path, sha256: str, version: str = "1.0.0") -> Path:
@@ -504,16 +540,18 @@ def _seed_pending(tmp_path: Path, sha256: str, version: str = "1.0.0") -> Path:
 def test_upload_stamps_provenance_notes(
     tmp_path: Path, monkeypatch, fake_metadata
 ) -> None:
-    """Tests that both app entries carry the napt/v1 provenance stamp."""
+    """Tests that both app entries carry entry-specific napt/v1 stamps."""
     monkeypatch.chdir(tmp_path)
     make_package_dir(tmp_path, installer_sha256="c" * 64)
 
-    _, create_app_mock = _run_upload(tmp_path, fake_metadata)
+    _, mocks = _run_upload(tmp_path, fake_metadata)
 
-    expected = f"napt/v1 id=test-app sha256={'c' * 64}"
+    create_app_mock = mocks["create_app"]
     assert create_app_mock.call_count == 2
-    for call in create_app_mock.call_args_list:
-        assert call.args[1]["notes"] == expected
+    install_notes = create_app_mock.call_args_list[0].args[1]["notes"]
+    update_notes = create_app_mock.call_args_list[1].args[1]["notes"]
+    assert install_notes == f"napt/v1 id=test-app entry=install sha256={'c' * 64}"
+    assert update_notes == f"napt/v1 id=test-app entry=update sha256={'c' * 64}"
 
 
 def test_upload_hash_mismatch_aborts_before_graph(
@@ -577,3 +615,147 @@ def test_upload_app_only_records_null_update_id(
     state = load_deployment_state(state_path)
     assert state["deployed"]["intune_app_id"] == "intune-app-123"
     assert state["deployed"]["intune_update_app_id"] is None
+
+
+# =============================================================================
+# Reconcile-before-act (idempotent upload)
+# =============================================================================
+
+
+def _stamped_apps(sha256: str) -> list[dict[str, Any]]:
+    """Returns fake list_mobile_apps output with both entries stamped."""
+    return [
+        {
+            "id": "existing-install",
+            "displayName": "Test App",
+            "notes": f"napt/v1 id=test-app entry=install sha256={sha256}",
+        },
+        {
+            "id": "existing-update",
+            "displayName": "[Update] Test App",
+            "notes": f"napt/v1 id=test-app entry=update sha256={sha256}",
+        },
+        {
+            "id": "unrelated",
+            "displayName": "Hand-made app",
+            "notes": "made by an admin",
+        },
+    ]
+
+
+def test_upload_adopts_committed_stamped_apps(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that committed stamped apps are adopted without any creation."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    result, mocks = _run_upload(
+        tmp_path,
+        fake_metadata,
+        existing_apps=_stamped_apps("a" * 64),
+        full_app={"committedContentVersion": "1"},
+    )
+
+    mocks["create_app"].assert_not_called()
+    mocks["create_cv"].assert_not_called()
+    assert result.intune_app_id == "existing-install"
+    assert result.intune_update_app_id == "existing-update"
+
+    # Adoption still records the deployed release in state
+    state_path = deployment_state_path(tmp_path / "state" / "deployment", "test-app")
+    state = load_deployment_state(state_path)
+    assert state["deployed"]["intune_app_id"] == "existing-install"
+
+
+def test_upload_resumes_uncommitted_stamped_app(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that an uncommitted stamped app gets content without recreation."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    result, mocks = _run_upload(
+        tmp_path,
+        fake_metadata,
+        existing_apps=_stamped_apps("a" * 64),
+        full_app={"committedContentVersion": None},
+    )
+
+    mocks["create_app"].assert_not_called()
+    assert mocks["create_cv"].call_count == 2  # content uploaded to both entries
+    assert result.intune_app_id == "existing-install"
+    assert result.intune_update_app_id == "existing-update"
+
+
+def test_upload_different_hash_creates_new_apps(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that stamped apps for a different binary are not adopted."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    result, mocks = _run_upload(
+        tmp_path,
+        fake_metadata,
+        existing_apps=_stamped_apps("f" * 64),  # older release's apps
+    )
+
+    assert mocks["create_app"].call_count == 2
+    assert result.intune_app_id == "intune-app-123"
+    assert result.intune_update_app_id == "intune-update-456"
+
+
+def test_upload_partial_match_creates_only_missing_entry(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that only the missing entry is created when one already exists."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+    install_only = [_stamped_apps("a" * 64)[0]]
+
+    result, mocks = _run_upload(
+        tmp_path,
+        fake_metadata,
+        existing_apps=install_only,
+        full_app={"committedContentVersion": "1"},
+    )
+
+    assert mocks["create_app"].call_count == 1
+    assert result.intune_app_id == "existing-install"
+    assert result.intune_update_app_id == "intune-app-123"
+
+
+def test_upload_force_reuploads_matched_apps(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that --force updates metadata and content instead of adopting."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    result, mocks = _run_upload(
+        tmp_path,
+        fake_metadata,
+        existing_apps=_stamped_apps("a" * 64),
+        force=True,
+    )
+
+    mocks["create_app"].assert_not_called()
+    assert mocks["update_app"].call_count == 2
+    assert mocks["create_cv"].call_count == 2  # fresh content for both entries
+    assert result.intune_app_id == "existing-install"
+    assert result.intune_update_app_id == "existing-update"
+
+
+def test_upload_force_without_match_creates_normally(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that --force with no matched apps behaves like a normal upload."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    result, mocks = _run_upload(tmp_path, fake_metadata, force=True)
+
+    assert mocks["create_app"].call_count == 2
+    mocks["update_app"].assert_not_called()
+    assert result.intune_app_id == "intune-app-123"

--- a/tests/upload/test_stamp.py
+++ b/tests/upload/test_stamp.py
@@ -1,0 +1,73 @@
+"""Tests for napt.upload.stamp."""
+
+from __future__ import annotations
+
+import pytest
+
+from napt.exceptions import ConfigError
+from napt.upload.stamp import (
+    NOTES_MAX_LENGTH,
+    build_stamp,
+    parse_stamp,
+)
+
+
+class TestBuildStamp:
+    """Tests for provenance stamp construction."""
+
+    def test_builds_expected_format(self):
+        """Tests that the stamp has the documented format."""
+        stamp = build_stamp("napt-chrome", "install", "a" * 64)
+
+        assert stamp == f"napt/v1 id=napt-chrome entry=install sha256={'a' * 64}"
+
+    def test_round_trips_through_parse(self):
+        """Tests that a built stamp parses back to its fields."""
+        stamp = build_stamp("napt-chrome", "update", "b" * 64)
+
+        assert parse_stamp(stamp) == {
+            "id": "napt-chrome",
+            "entry": "update",
+            "sha256": "b" * 64,
+        }
+
+    def test_over_length_raises(self):
+        """Tests that a stamp over the notes limit raises ConfigError."""
+        long_id = "x" * NOTES_MAX_LENGTH
+
+        with pytest.raises(ConfigError, match="notes field limit"):
+            build_stamp(long_id, "install", "a" * 64)
+
+
+class TestParseStamp:
+    """Tests for provenance stamp parsing."""
+
+    def test_none_returns_none(self):
+        """Tests that None notes parse as no stamp."""
+        assert parse_stamp(None) is None
+
+    def test_empty_returns_none(self):
+        """Tests that empty notes parse as no stamp."""
+        assert parse_stamp("") is None
+
+    def test_admin_text_returns_none(self):
+        """Tests that non-NAPT notes parse as no stamp."""
+        assert parse_stamp("Deployed by the IT team, ticket #42") is None
+
+    def test_missing_field_returns_none(self):
+        """Tests that a stamp without all required fields is rejected."""
+        assert parse_stamp("napt/v1 id=napt-chrome sha256=abc") is None
+
+    def test_prefix_must_match_exactly(self):
+        """Tests that a different stamp version is not parsed as v1."""
+        assert parse_stamp("napt/v2 id=a entry=install sha256=b") is None
+
+    def test_extra_tokens_are_tolerated(self):
+        """Tests that unknown key=value tokens do not break parsing."""
+        stamp = "napt/v1 id=app entry=install sha256=abc future=stuff"
+
+        assert parse_stamp(stamp) == {
+            "id": "app",
+            "entry": "install",
+            "sha256": "abc",
+        }


### PR DESCRIPTION
## Description

`napt upload` now reconciles before acting: it lists the tenant''s apps and matches NAPT provenance stamps against the release being published. Fully published matches are adopted, a match whose content was never committed (crashed run) gets a fresh content upload, and only missing entries are created. Unstamped apps are never touched. New `--force` flag re-sends metadata and a fresh content version to matched apps instead of adopting.

## Motivation

Closes the crash-recovery gap from the provenance work: re-running upload after any failure (or just running it twice) no longer creates duplicate Intune apps. `--force` covers republishing a changed package/recipe when the installer binary is unchanged.

## Changes

- New `napt/upload/stamp.py`: stamp build/parse; stamp now carries `entry=<install|update>` so the two app objects per recipe are distinguishable; enforces Intune''s 1024-char notes limit before upload
- New Graph helpers: `list_mobile_apps` (paginated), `get_mobile_app`, `update_win32_app`
- Reconcile-before-act in `upload_package` + `napt upload --force`
- Note: apps stamped by the previous two-field format are not recognized for adoption (pre-release, no migration)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

604 tests pass; new coverage for stamp build/parse, pagination, adopt/resume/partial-match/force paths. napt-reviewer verdict: ship (findings addressed).

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors