### PR TITLE
feat: Add deployment config and assignment client

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Deployment configuration** - New `deployment:` recipe section:
+    `require_pending` makes `napt upload` fail unless the release was
+    recorded at discovery (for review-gated publish workflows);
+    `rings`, `install`, and `retain_versions` define update promotion
+    policy for the upcoming `napt promote` command. Group name resolution
+    requires the `Group.Read.All` application permission
+
 - **Deployment state files** - `napt discover` records each discovered
     release in `state/deployment/{id}.json` as a pending publication
     candidate. One file per app; the newest discovery wins

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -656,6 +656,23 @@ intune:
 See [recipe-reference.md](recipe-reference.md#intune-configuration) for all
 allowed values.
 
+### Require recorded releases before upload
+
+For review-gated publish workflows, make `napt upload` refuse anything that
+was not recorded at discovery.
+Set once in `defaults/org.yaml`:
+
+```yaml
+deployment:
+  require_pending: true
+```
+
+With this enabled, an upload fails unless the app's deployment state has a
+pending release matching the package's installer hash.
+For a legitimate manual upload under this policy, run `napt discover` first,
+or add a pending entry (version, sha256, url) to
+`state/deployment/<id>.json`.
+
 ### Set a custom app icon
 
 `napt build` extracts an icon from the installer to `icons/{id}.png`

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -1000,6 +1000,82 @@ it does not exist and verifying write access). If that fails (e.g., permissions)
 to `C:\ProgramData\NAPT\` (system) or `%LOCALAPPDATA%\NAPT\` (user). If both fail, a warning is
 written to stderr and the script runs without a log file.
 
+## Deployment Configuration
+
+The `deployment` section controls upload strictness and deployment promotion.
+These settings are org policy — configure them in `defaults/org.yaml` and
+override per-recipe only when an app needs different treatment.
+
+```yaml
+deployment:
+  require_pending: false        # Optional: require a recorded pending release
+  rings:                        # Optional: rings for update promotion
+    - name: "pilot"
+      groups: ["sg-intune-pilot"]
+      promote_after_days: 2
+    - name: "production"
+      groups: ["sg-intune-all-workstations"]
+  install:                      # Optional: install entry assignment
+    intent: "available"
+    groups: ["All Users"]
+  retain_versions: 1            # Optional: superseded versions kept for rollback
+```
+
+Groups may be Entra ID display names or object IDs.
+Display names are resolved via the Graph API, which requires the
+`Group.Read.All` application permission (see
+[App Registration Setup](user-guide.md#app-registration-setup)).
+
+### require_pending
+
+**Type:** `boolean`
+**Required:** No
+**Default:** `false`
+
+When enabled, `napt upload` fails if the app's deployment state has no
+pending release matching the package — nothing reaches Intune without a
+recorded release.
+Enable this when publishes are gated through review of committed deployment
+state.
+For a manual upload under this policy, run `napt discover` first or add a
+pending entry (version, sha256, url) to the app's deployment state file.
+
+### rings
+
+**Type:** `list`
+**Required:** No
+**Default:** `[]`
+
+Ordered deployment rings for update promotion.
+Each ring requires a unique `name` and a non-empty `groups` list;
+`promote_after_days` (optional) sets how many days a version holds the ring
+before becoming eligible for the next one.
+
+**Note:** Rings are consumed by the upcoming `napt promote` command and have
+no effect yet.
+
+### install
+
+**Type:** `dict`
+**Required:** No
+**Default:** `intent: "available"`, `groups: []`
+
+Assignment for the install entry (net-new installs).
+`intent` is `"available"` (Company Portal) or `"required"`.
+
+**Note:** Consumed by the upcoming `napt promote` command; no effect yet.
+
+### retain_versions
+
+**Type:** `integer`
+**Required:** No
+**Default:** `1`
+
+How many superseded versions stay in Intune for rollback before deletion.
+`0` deletes a version as soon as it holds no rings.
+
+**Note:** Consumed by the upcoming `napt promote` command; no effect yet.
+
 ## Variable Substitution
 
 Recipes use two distinct substitution mechanisms with different syntax.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -245,7 +245,8 @@ Graph API. Run `napt package` before uploading.
    Verifies the package's installer hash (from the build manifest) against the
    pending release in the app's deployment state — a mismatch aborts the upload,
    so what was recorded at discovery is byte-for-byte what ships.
-   When no pending release is recorded, the upload proceeds with a warning
+   When no pending release is recorded, the upload proceeds with a warning,
+   or fails when `deployment.require_pending` is enabled
 2. **Authenticate** - Tries three credential methods in order (see [Authentication](#authentication) below)
 3. **Parse Package Metadata** - Reads encryption metadata from `Detection.xml` inside the `.intunewin` ZIP
 4–6. **Create, Upload, Commit (install entry)** - Creates the Win32 app record
@@ -308,10 +309,12 @@ Create the app registration once per organization:
 4. Go to **API permissions** → **Add a permission** →
    **Microsoft Graph** → **Application permissions**
 5. Search for and add `DeviceManagementApps.ReadWrite.All`
-6. Also add the **Delegated** version of `DeviceManagementApps.ReadWrite.All`
+6. Also add `Group.Read.All` (application permission) — used to resolve
+   Entra ID group names in `deployment:` configuration to object IDs
+7. Also add the **Delegated** versions of both permissions
    (for interactive device code auth)
-7. Click **Grant admin consent**
-8. Go to **Authentication** → **Advanced settings** →
+8. Click **Grant admin consent**
+9. Go to **Authentication** → **Advanced settings** →
    set **Allow public client flows** to **Yes** → click **Save**
    (required for device code flow)
 

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -108,6 +108,17 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "intunewin": {
         "release": "latest",
     },
+    # Deployment promotion settings.
+    # Rings, install-entry assignment, retention, and upload strictness.
+    "deployment": {
+        "rings": [],
+        "install": {
+            "intent": "available",
+            "groups": [],
+        },
+        "retain_versions": 1,
+        "require_pending": False,
+    },
 }
 
 
@@ -205,4 +216,31 @@ apiVersion: napt/v1
 # intunewin:
 #   # IntuneWinAppUtil.exe release: "latest" or specific version (e.g., "1.8.6")
 #   release: "latest"
+
+# deployment:
+#   # Require a recorded pending release before upload.
+#   # When true, 'napt upload' fails unless deployment state has a pending
+#   # entry matching the package (records what review approved).
+#   require_pending: false
+#
+#   # Deployment rings for update promotion (used by upcoming napt promote).
+#   # Each ring assigns the [Update] entry to Entra ID groups; a version
+#   # becomes eligible for the next ring after promote_after_days.
+#   rings:
+#     - name: "pilot"
+#       groups: ["sg-intune-pilot"]
+#       promote_after_days: 2
+#     - name: "broad"
+#       groups: ["sg-intune-broad"]
+#       promote_after_days: 5
+#     - name: "production"
+#       groups: ["sg-intune-all-workstations"]
+#
+#   # Install entry assignment (used by upcoming napt promote).
+#   install:
+#     intent: "available"  # available or required
+#     groups: ["All Users"]
+#
+#   # Superseded versions kept in Intune for rollback before deletion.
+#   retain_versions: 1
 """

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -23,6 +23,11 @@ Implements the full upload flow for a Win32 LOB app:
     5. Commit the uploaded file with encryption metadata (POST commit + polling)
     6. Set the committed content version on the app (PATCH mobileApps)
 
+Also provides app queries used for reconciliation (list_mobile_apps,
+get_mobile_app, update_win32_app) and group-based assignment plumbing
+(resolve_group_id, get_app_assignments, build_group_assignment,
+assign_app) used by deployment promotion.
+
 All functions take an access_token as the first argument. Obtain one via
 napt.upload.auth.get_access_token().
 
@@ -54,6 +59,7 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
+import re
 import time
 
 import requests
@@ -62,11 +68,15 @@ from napt.exceptions import AuthError, ConfigError, NetworkError
 from napt.upload.intunewin import IntunewinMetadata
 
 __all__ = [
+    "assign_app",
+    "build_group_assignment",
     "create_win32_app",
     "create_content_version",
     "create_content_version_file",
+    "get_app_assignments",
     "get_mobile_app",
     "list_mobile_apps",
+    "resolve_group_id",
     "update_win32_app",
     "upload_to_azure_blob",
     "commit_content_version_file",
@@ -178,6 +188,125 @@ def _poll(
         f"{context}: timed out after {POLL_MAX_SECONDS}s "
         f"waiting for state '{success_state}'"
     )
+
+
+_GUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def resolve_group_id(access_token: str, group: str) -> str:
+    """Resolve an Entra ID group name or object ID to an object ID.
+
+    Values that already look like object IDs (GUIDs) pass through without
+    a Graph call. Names are looked up by exact displayName match, which
+    requires the Group.Read.All application permission.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        group: Group displayName or object ID (GUID).
+
+    Returns:
+        The group's object ID.
+
+    Raises:
+        AuthError: On 401 or 403 (check Group.Read.All permission).
+        ConfigError: If no group or more than one group matches the name.
+        NetworkError: On 5xx or connection error.
+
+    """
+    if _GUID_RE.match(group):
+        return group
+
+    escaped = group.replace("'", "''")
+    url = (
+        f"{GRAPH_BASE}/groups"
+        f"?$filter=displayName eq '{escaped}'&$select=id,displayName"
+    )
+    resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
+    body = _check_response(resp, "resolve_group_id")
+    matches: list[dict] = body.get("value", [])
+
+    if not matches:
+        raise ConfigError(
+            f"No Entra ID group found with displayName '{group}'. "
+            "Check the name, or use the group's object ID instead."
+        )
+    if len(matches) > 1:
+        ids = ", ".join(m["id"] for m in matches)
+        raise ConfigError(
+            f"Multiple Entra ID groups share the displayName '{group}' "
+            f"({ids}). Use the object ID of the intended group instead."
+        )
+    return matches[0]["id"]
+
+
+def get_app_assignments(access_token: str, app_id: str) -> list[dict]:
+    """Get the current assignments of a mobile app.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app.
+
+    Returns:
+        A list of mobileAppAssignment dicts (empty when unassigned).
+
+    Raises:
+        AuthError: On 401 or 403.
+        NetworkError: On 5xx or connection error.
+
+    """
+    url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}/assignments"
+    resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
+    body = _check_response(resp, "get_app_assignments")
+    return body.get("value", [])
+
+
+def build_group_assignment(group_id: str, intent: str) -> dict:
+    """Build a mobileAppAssignment payload targeting one Entra ID group.
+
+    Args:
+        group_id: Object ID of the target group.
+        intent: Assignment intent, "available" or "required".
+
+    Returns:
+        A mobileAppAssignment dict for use with assign_app.
+
+    """
+    return {
+        "@odata.type": "#microsoft.graph.mobileAppAssignment",
+        "intent": intent,
+        "target": {
+            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+            "groupId": group_id,
+        },
+    }
+
+
+def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:
+    """Set a mobile app's assignments.
+
+    The assign action replaces the app's entire assignment set. Callers
+    that intend to preserve existing assignments must read them first with
+    get_app_assignments and include them in the new list.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app.
+        assignments: Complete list of mobileAppAssignment dicts to apply.
+
+    Raises:
+        AuthError: On 401 or 403.
+        ConfigError: On 400 (invalid assignment payload).
+        NetworkError: On 5xx or connection error.
+
+    """
+    url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}/assign"
+    body = {"mobileAppAssignments": assignments}
+    resp = requests.post(
+        url, headers=_json_headers(access_token), json=body, timeout=30
+    )
+    _check_response(resp, "assign_app")
 
 
 def list_mobile_apps(access_token: str) -> list[dict]:

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -704,9 +704,10 @@ def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
     manifest) is verified against the pending release recorded in the app's
     deployment state, so what was recorded at discovery is byte-for-byte
     what ships. A hash mismatch aborts the upload. When no pending release
-    is recorded, the upload proceeds with a warning. On success, the
-    deployment state records the published version, hash, and Intune app
-    IDs, and a matching pending slot is cleared.
+    is recorded, the upload proceeds with a warning — or fails when
+    deployment.require_pending is enabled. On success, the deployment
+    state records the published version, hash, and Intune app IDs, and a
+    matching pending slot is cleared.
 
     Re-running an upload is safe: existing NAPT-stamped apps matching this
     publish instance (recipe id, entry type, installer hash) are adopted —
@@ -733,9 +734,10 @@ def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
             Run 'napt package' to create or recreate the package.
         AuthError: If all Azure credential methods fail.
         NetworkError: If Graph API or Azure Blob Storage calls fail.
-        PackagingError: If the .intunewin file is malformed, or the
+        PackagingError: If the .intunewin file is malformed, the
             package's installer hash does not match the pending release
-            in deployment state.
+            in deployment state, or no pending release is recorded while
+            deployment.require_pending is enabled.
 
     Example:
         Upload and print the resulting Intune app IDs:
@@ -794,6 +796,13 @@ def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
             )
         logger.info(
             "UPLOAD", f"Package matches pending release (sha256 {installer_sha256})"
+        )
+    elif config["deployment"]["require_pending"]:
+        raise PackagingError(
+            f"No pending release recorded for '{app_id}' and "
+            "deployment.require_pending is enabled.\n"
+            "Run 'napt discover' to record the release, or add a pending "
+            f"entry (version, sha256, url) to {state_path}."
         )
     else:
         logger.warning(

--- a/napt/validation.py
+++ b/napt/validation.py
@@ -108,6 +108,27 @@ _LOGGING_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
     "log_rotation_mb": (int, None, "log rotation size in MB"),
 }
 
+# Schema for the deployment: section
+_DEPLOYMENT_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
+    "rings": (list, None, "deployment rings for update promotion"),
+    "install": (dict, None, "install entry assignment"),
+    "retain_versions": (int, None, "superseded versions kept for rollback"),
+    "require_pending": (bool, None, "require a recorded pending release"),
+}
+
+# Schema for the deployment.install subsection
+_DEPLOYMENT_INSTALL_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
+    "intent": (str, ["available", "required"], "assignment intent"),
+    "groups": (list, None, "Entra ID groups for the install entry"),
+}
+
+# Schema for one deployment.rings entry
+_DEPLOYMENT_RING_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
+    "name": (str, None, "ring name"),
+    "groups": (list, None, "Entra ID groups assigned by this ring"),
+    "promote_after_days": (int, None, "days before eligible for the next ring"),
+}
+
 # Allowed keys for psadt.app_vars.
 # NAPT-managed keys (AppArch, DeployAppScriptVersion, DeployAppScriptFriendlyName,
 # DeployAppScriptParameters) are excluded — setting them in recipes is an error.
@@ -404,6 +425,106 @@ def _validate_logging_section(
     _validate_section(logging_config, _LOGGING_FIELDS, "logging", errors, warnings)
 
 
+def _validate_group_list(
+    groups: list,
+    field_path: str,
+    errors: list[str],
+) -> None:
+    """Validate the entries of an Entra ID group list.
+
+    Callers are responsible for the list type check (via
+    [_validate_section][napt.validation._validate_section]); this only
+    checks the entries.
+
+    Args:
+        groups: The groups list to check.
+        field_path: Full path to the field for error messages.
+        errors: List to append errors to.
+
+    """
+    for index, group in enumerate(groups):
+        if not isinstance(group, str) or not group:
+            errors.append(f"{field_path}[{index}]: Must be a non-empty string")
+
+
+def _validate_deployment_section(
+    recipe: dict,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    """Validate the top-level deployment: section.
+
+    Validates ring entries, the install subsection, retention, and the
+    require_pending flag.
+
+    Args:
+        recipe: The full recipe dictionary.
+        errors: List to append errors to.
+        warnings: List to append warnings to.
+
+    """
+    deployment = recipe.get("deployment")
+    if deployment is None:
+        return
+
+    if not isinstance(deployment, dict):
+        errors.append("deployment: Must be a dictionary")
+        return
+
+    _validate_section(deployment, _DEPLOYMENT_FIELDS, "deployment", errors, warnings)
+
+    rings = deployment.get("rings")
+    if isinstance(rings, list):
+        ring_names: set[str] = set()
+        for index, ring in enumerate(rings):
+            ring_path = f"deployment.rings[{index}]"
+            if not isinstance(ring, dict):
+                errors.append(f"{ring_path}: Must be a dictionary")
+                continue
+            _validate_section(
+                ring, _DEPLOYMENT_RING_FIELDS, ring_path, errors, warnings
+            )
+            # Wrong-typed fields are already reported by _validate_section;
+            # the checks below only cover absence and value constraints.
+            name = ring.get("name")
+            if "name" not in ring or name == "":
+                errors.append(f"{ring_path}: Missing required field: name")
+            elif isinstance(name, str):
+                if name in ring_names:
+                    errors.append(f"{ring_path}: Duplicate ring name '{name}'")
+                else:
+                    ring_names.add(name)
+            groups = ring.get("groups")
+            if "groups" not in ring or groups == []:
+                errors.append(f"{ring_path}: Missing required field: groups")
+            elif isinstance(groups, list):
+                _validate_group_list(groups, f"{ring_path}.groups", errors)
+            days = ring.get("promote_after_days")
+            if isinstance(days, int) and days < 0:
+                errors.append(f"{ring_path}.promote_after_days: Must be >= 0")
+
+    install = deployment.get("install")
+    if install is not None:
+        if not isinstance(install, dict):
+            errors.append("deployment.install: Must be a dictionary")
+        else:
+            _validate_section(
+                install,
+                _DEPLOYMENT_INSTALL_FIELDS,
+                "deployment.install",
+                errors,
+                warnings,
+            )
+            if isinstance(install.get("groups"), list):
+                _validate_group_list(
+                    install["groups"], "deployment.install.groups", errors
+                )
+
+    retain = deployment.get("retain_versions")
+    if isinstance(retain, int) and retain < 0:
+        errors.append("deployment.retain_versions: Must be >= 0")
+
+
 def validate_config(
     config: dict[str, Any],
     recipe_path: str = "",
@@ -503,6 +624,7 @@ def validate_config(
     _validate_psadt_section(config, errors)
     _validate_intune_section(config, errors, warnings)
     _validate_logging_section(config, errors, warnings)
+    _validate_deployment_section(config, errors, warnings)
 
     # Determine final status
     status = "valid" if len(errors) == 0 else "invalid"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -818,3 +818,176 @@ logging: "not a dict"
 
         assert result.status == "invalid"
         assert any("logging" in err and "dictionary" in err for err in result.errors)
+
+
+_DEPLOYMENT_RECIPE_HEADER = """
+apiVersion: napt/v1
+name: "Test App"
+id: "test-app"
+discovery:
+  strategy: url_download
+  url: "https://example.com/app.msi"
+"""
+
+
+class TestDeploymentValidation:
+    """Tests for deployment: section validation."""
+
+    def test_valid_deployment_section(self, tmp_path):
+        """Tests that a full valid deployment config passes validation."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  require_pending: true
+  retain_versions: 2
+  rings:
+    - name: "pilot"
+      groups: ["sg-pilot"]
+      promote_after_days: 2
+    - name: "production"
+      groups: ["sg-prod-a", "sg-prod-b"]
+  install:
+    intent: "available"
+    groups: ["All Users"]
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "valid"
+        assert len(result.errors) == 0
+
+    def test_ring_missing_name_error(self, tmp_path):
+        """Tests that a ring without a name is detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  rings:
+    - groups: ["sg-pilot"]
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any("rings[0]" in err and "name" in err for err in result.errors)
+
+    def test_ring_missing_groups_error(self, tmp_path):
+        """Tests that a ring without groups is detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  rings:
+    - name: "pilot"
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any("rings[0]" in err and "groups" in err for err in result.errors)
+
+    def test_duplicate_ring_name_error(self, tmp_path):
+        """Tests that duplicate ring names are detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  rings:
+    - name: "pilot"
+      groups: ["sg-a"]
+    - name: "pilot"
+      groups: ["sg-b"]
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any("Duplicate ring name" in err for err in result.errors)
+
+    def test_negative_promote_after_days_error(self, tmp_path):
+        """Tests that a negative promote_after_days is detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  rings:
+    - name: "pilot"
+      groups: ["sg-a"]
+      promote_after_days: -1
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any("promote_after_days" in err for err in result.errors)
+
+    def test_invalid_install_intent_error(self, tmp_path):
+        """Tests that an unknown install intent is detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  install:
+    intent: "mandatory"
+    groups: ["All Users"]
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any(
+            "deployment.install.intent" in err and "Invalid value" in err
+            for err in result.errors
+        )
+
+    def test_wrong_typed_ring_field_reports_one_error(self, tmp_path):
+        """Tests that a wrong-typed ring field produces exactly one error."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  rings:
+    - name: "pilot"
+      groups: "sg-a"
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        groups_errors = [e for e in result.errors if "groups" in e]
+        assert len(groups_errors) == 1
+        assert "Must be list" in groups_errors[0]
+
+    def test_non_string_group_error(self, tmp_path):
+        """Tests that a non-string group entry is detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  install:
+    groups: ["ok", 42]
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any("groups[1]" in err for err in result.errors)
+
+    def test_negative_retain_versions_error(self, tmp_path):
+        """Tests that a negative retain_versions is detected."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  retain_versions: -1
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "invalid"
+        assert any("retain_versions" in err for err in result.errors)
+
+    def test_unknown_deployment_field_warns(self, tmp_path):
+        """Tests that an unknown deployment field produces a warning."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  bake_days: 3
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "valid"
+        assert any("Unknown field 'bake_days'" in w for w in result.warnings)

--- a/tests/upload/test_graph.py
+++ b/tests/upload/test_graph.py
@@ -11,13 +11,17 @@ import requests_mock as req_mock
 from napt.exceptions import ConfigError, NetworkError
 from napt.upload.graph import (
     GRAPH_BASE,
+    assign_app,
+    build_group_assignment,
     commit_content_version,
     commit_content_version_file,
     create_content_version,
     create_content_version_file,
     create_win32_app,
+    get_app_assignments,
     get_mobile_app,
     list_mobile_apps,
+    resolve_group_id,
     upload_to_azure_blob,
 )
 
@@ -244,3 +248,83 @@ def test_get_mobile_app_returns_full_object() -> None:
         result = get_mobile_app(TOKEN, APP_ID)
 
     assert result == body
+
+
+# --- resolve_group_id / assignments ---
+
+GROUP_ID = "12345678-abcd-4bed-b834-2a9ef5879619"
+_GROUPS_URL = f"{GRAPH_BASE}/groups"
+_ASSIGNMENTS_URL = f"{_APP_URL}/assignments"
+_ASSIGN_URL = f"{_APP_URL}/assign"
+
+
+def test_resolve_group_id_guid_passes_through() -> None:
+    """Tests that an object ID is returned without a Graph call."""
+    assert resolve_group_id(TOKEN, GROUP_ID) == GROUP_ID
+
+
+def test_resolve_group_id_looks_up_name() -> None:
+    """Tests that a single displayName match resolves to its object ID."""
+    with req_mock.Mocker() as m:
+        m.get(_GROUPS_URL, json={"value": [{"id": GROUP_ID, "displayName": "Pilot"}]})
+        assert resolve_group_id(TOKEN, "Pilot") == GROUP_ID
+
+
+def test_resolve_group_id_no_match_raises() -> None:
+    """Tests that an unknown group name raises ConfigError."""
+    with req_mock.Mocker() as m:
+        m.get(_GROUPS_URL, json={"value": []})
+        with pytest.raises(ConfigError, match="No Entra ID group found"):
+            resolve_group_id(TOKEN, "Nope")
+
+
+def test_resolve_group_id_ambiguous_raises() -> None:
+    """Tests that multiple matches raise ConfigError."""
+    with req_mock.Mocker() as m:
+        m.get(
+            _GROUPS_URL,
+            json={"value": [{"id": "a"}, {"id": "b"}]},
+        )
+        with pytest.raises(ConfigError, match="Multiple Entra ID groups"):
+            resolve_group_id(TOKEN, "Pilot")
+
+
+def test_resolve_group_id_escapes_quotes() -> None:
+    """Tests that single quotes in group names are escaped in the filter."""
+    with req_mock.Mocker() as m:
+        m.get(_GROUPS_URL, json={"value": [{"id": GROUP_ID}]})
+        resolve_group_id(TOKEN, "O'Brien's Group")
+        # OData escapes each ' as '' in the filter expression
+        assert "O''Brien''s" in m.request_history[0].url
+
+
+def test_get_app_assignments_returns_value() -> None:
+    """Tests that assignments are returned from the value array."""
+    assignments = [{"id": "a1", "intent": "required"}]
+    with req_mock.Mocker() as m:
+        m.get(_ASSIGNMENTS_URL, json={"value": assignments})
+        assert get_app_assignments(TOKEN, APP_ID) == assignments
+
+
+def test_assign_app_posts_full_set() -> None:
+    """Tests that assign_app posts the complete assignment list."""
+    assignments = [build_group_assignment(GROUP_ID, "required")]
+    with req_mock.Mocker() as m:
+        m.post(_ASSIGN_URL, status_code=200)
+        assign_app(TOKEN, APP_ID, assignments)
+        body = m.request_history[0].json()
+    assert body == {"mobileAppAssignments": assignments}
+
+
+def test_build_group_assignment_shape() -> None:
+    """Tests the mobileAppAssignment payload structure."""
+    result = build_group_assignment(GROUP_ID, "available")
+
+    assert result == {
+        "@odata.type": "#microsoft.graph.mobileAppAssignment",
+        "intent": "available",
+        "target": {
+            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+            "groupId": GROUP_ID,
+        },
+    }

--- a/tests/upload/test_manager.py
+++ b/tests/upload/test_manager.py
@@ -28,8 +28,9 @@ def _fake_config(
     app_id: str = "test-app",
     app_name: str = "Test App",
     build_types: str = "both",
+    overrides: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return _deep_merge_dicts(
+    config = _deep_merge_dicts(
         copy.deepcopy(DEFAULT_CONFIG),
         {
             "id": app_id,
@@ -37,6 +38,9 @@ def _fake_config(
             "intune": {"build_types": build_types},
         },
     )
+    if overrides:
+        config = _deep_merge_dicts(config, overrides)
+    return config
 
 
 def _patch_graph(
@@ -439,6 +443,7 @@ def _run_upload(
     existing_apps: list[dict[str, Any]] | None = None,
     full_app: dict[str, Any] | None = None,
     force: bool = False,
+    config_overrides: dict[str, Any] | None = None,
 ) -> tuple[Any, dict[str, MagicMock]]:
     """Run upload_package with all Graph calls mocked.
 
@@ -450,6 +455,7 @@ def _run_upload(
         full_app: Return value for get_mobile_app (used when a stamped
             app matches).
         force: Passed through to upload_package.
+        config_overrides: Extra config merged over the fake defaults.
 
     Returns:
         A tuple of (UploadResult, mocks) where mocks holds the
@@ -474,7 +480,9 @@ def _run_upload(
         stack.enter_context(
             patch(
                 "napt.upload.manager.load_effective_config",
-                return_value=_fake_config(build_types=build_types),
+                return_value=_fake_config(
+                    build_types=build_types, overrides=config_overrides
+                ),
             )
         )
         stack.enter_context(
@@ -759,3 +767,35 @@ def test_upload_force_without_match_creates_normally(
     assert mocks["create_app"].call_count == 2
     mocks["update_app"].assert_not_called()
     assert result.intune_app_id == "intune-app-123"
+
+
+def test_upload_require_pending_blocks_without_pending(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that require_pending fails the upload when nothing is pending."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    with pytest.raises(PackagingError, match="require_pending"):
+        _run_upload(
+            tmp_path,
+            fake_metadata,
+            config_overrides={"deployment": {"require_pending": True}},
+        )
+
+
+def test_upload_require_pending_passes_with_matching_pending(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that require_pending allows upload of the recorded release."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+    _seed_pending(tmp_path, sha256="a" * 64)
+
+    result, _ = _run_upload(
+        tmp_path,
+        fake_metadata,
+        config_overrides={"deployment": {"require_pending": True}},
+    )
+
+    assert result.status == "success"


### PR DESCRIPTION
## Description

Adds the `deployment:` org-policy config section — `rings` (name, `groups` list, `promote_after_days`), `install` (intent/groups), `retain_versions`, and `require_pending` — with full validation, plus the Graph assignment client (`resolve_group_id`, `get_app_assignments`, `build_group_assignment`, `assign_app`) that `napt promote` will drive.

## Motivation

Prerequisites for ring-based promotion: the config defines what a ring is, the client defines how one is assigned. `require_pending` is live immediately — it closes the hash gate''s escape hatch for review-gated orgs (upload fails without a recorded pending release instead of warning).

## Changes

- `deployment:` section in the four-layer config with validation (duplicate ring names, negative values, group entry types)
- `deployment.require_pending` enforced in `napt upload`
- Graph: group displayName-to-ID resolution (GUID passthrough, OData quote escaping, ambiguity errors; needs `Group.Read.All`), assignment read, and full-replace `assign` with documented read-modify-write contract
- `rings`/`install`/`retain_versions` are validated but inert until `napt promote` (documented as such)
- Docs: recipe-reference section, app-registration permission step, common-tasks require_pending workflow

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

624 tests pass; new coverage for deployment validation (including single-error-per-problem), group resolution, and require_pending gate behavior. napt-reviewer verdict: ship (findings addressed). Group resolution and assign are mocked only — live Graph testing lands with `napt promote`.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors