### PR TITLE
feat: Add napt promote plan and napt status

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -163,6 +163,7 @@ All `napt/**/*.py` files require before docstring:
 | `ConfigError` | Recipe/YAML errors, missing fields, invalid config |
 | `NetworkError` | HTTP failures, API errors, download issues |
 | `PackagingError` | PSADT errors, MSI extraction, build failures |
+| `StateError` | Corrupted or invalid persisted state (`state/`, `cache/`) |
 
 **Public API / user-facing:** Use custom exceptions. **Private helpers / bugs:** Use built-in.
 

--- a/defaults/org.yaml
+++ b/defaults/org.yaml
@@ -71,3 +71,16 @@ directories:
   package: "packages"
   # App icons extracted by build and uploaded by upload
   icons: "icons"
+
+deployment:
+  # Update promotion rings (ring 0 -> 1 -> 2). Groups are Entra ID
+  # display names, resolved to object IDs at apply time.
+  rings:
+    - name: "pilot"           # Ring 0
+      groups: ["Pilot Devices"]
+      promote_after_days: 2
+    - name: "broad"           # Ring 1
+      groups: ["Broad Devices"]
+      promote_after_days: 5
+    - name: "production"      # Ring 2 (terminal - never auto-advances)
+      groups: ["Production Devices"]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`napt promote plan`** - Computes which releases enter or advance the
+    configured deployment rings (plus first-time install-entry
+    assignments) and writes a reviewable `state/plan.json`. The plan file
+    exists exactly when there is work — a run that finds nothing removes
+    a stale plan — so its git status drives review workflows. Read-only;
+    applying plans arrives with `napt promote apply`
+- **`napt status`** - Shows deployed version, pending release, and ring
+    positions across all apps; `--format json` for scripting
+
 - **Deployment configuration** - New `deployment:` recipe section:
     `require_pending` makes `napt upload` fail unless the release was
     recorded at discovery (for review-gated publish workflows);

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -1051,8 +1051,8 @@ Each ring requires a unique `name` and a non-empty `groups` list;
 `promote_after_days` (optional) sets how many days a version holds the ring
 before becoming eligible for the next one.
 
-**Note:** Rings are consumed by the upcoming `napt promote` command and have
-no effect yet.
+**Note:** `napt promote plan` evaluates rings to plan promotions;
+assignments are executed by the upcoming `napt promote apply`.
 
 ### install
 
@@ -1063,7 +1063,8 @@ no effect yet.
 Assignment for the install entry (net-new installs).
 `intent` is `"available"` (Company Portal) or `"required"`.
 
-**Note:** Consumed by the upcoming `napt promote` command; no effect yet.
+**Note:** `napt promote plan` plans the install assignment; it is executed
+by the upcoming `napt promote apply`.
 
 ### retain_versions
 
@@ -1074,7 +1075,7 @@ Assignment for the install entry (net-new installs).
 How many superseded versions stay in Intune for rollback before deletion.
 `0` deletes a version as soon as it holds no rings.
 
-**Note:** Consumed by the upcoming `napt promote` command; no effect yet.
+**Note:** Consumed by the upcoming `napt promote apply`; no effect yet.
 
 ## Variable Substitution
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -115,8 +115,9 @@ Agreed design:
   name resolution
 - Delivered across eight PRs: state split (shipped), upload provenance and
   hash gate (shipped), idempotent upload (shipped), deployment config and
-  assignment client, `promote plan` and `napt status`, `promote apply` with
-  retention, drift detection, GitOps docs and schema versioning
+  assignment client (shipped), `promote plan` and `napt status` (shipped),
+  `promote apply` with retention, drift detection, GitOps docs and schema
+  versioning
 
 **Related**: Health-gated promotion (block on install failure rates) and
 native Intune supersedence are deliberate follow-ups, not part of this

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -440,6 +440,27 @@ napt package recipes/Google/chrome.yaml [OPTIONS]
 napt package recipes/Google/chrome.yaml --version 130.0.6723.116
 ```
 
+### napt promote
+
+Plans ring-based promotion of published apps. `promote plan` computes which
+releases enter or advance deployment rings (per `deployment.rings`) and
+writes `state/plan.json` when there is work; a stale plan file is removed
+when nothing is eligible. Read-only: neither Intune nor deployment state is
+modified. Applying plans arrives with `napt promote apply`.
+
+```bash
+napt promote plan [RECIPE_OR_DIR] [OPTIONS]
+```
+
+### napt status
+
+Shows deployment state across all apps: deployed version, pending release,
+and which version holds each ring. `--format json` for scripting.
+
+```bash
+napt status [OPTIONS]
+```
+
 ### napt upload
 
 Uploads the `.intunewin` package to Microsoft Intune via the Graph API.
@@ -602,6 +623,19 @@ A file holds four sections:
 
 `napt discover` records the pending candidate.
 Later pipeline stages consume it.
+
+### Promotion plan file
+
+`napt promote plan` evaluates ring eligibility as a pure function of
+deployment state, configuration, and the clock, and writes the result to
+`state/plan.json`.
+The plan file exists exactly when there are eligible actions: a plan run
+that finds nothing removes a stale plan file.
+Its git status is therefore the CI signal that a promotion review is
+needed — no special exit codes (`napt` always exits 0 on success, 1 on
+error).
+Plan output is deterministic, so re-running plan against unchanged state
+produces a byte-identical file.
 
 ### Default Behavior (Stateful)
 

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -25,6 +25,8 @@ Commands:
     build: Build PSADT package from recipe
     package: Create .intunewin package for Intune (recipe-based)
     upload: Upload .intunewin package to Microsoft Intune
+    promote: Plan (and later apply) deployment ring promotion
+    status: Show deployment state across all apps
 
 Example:
     Validate recipe syntax:
@@ -96,6 +98,8 @@ from napt.exceptions import (
     PackagingError,
 )
 from napt.logging import get_logger, set_global_logger
+from napt.promote import plan_path_for, plan_promotions, write_plan_file
+from napt.state import summarize_deployment_states
 from napt.upload import upload_package
 from napt.validation import validate_recipe
 
@@ -630,6 +634,150 @@ def cmd_upload(args: argparse.Namespace) -> int:
     return 0
 
 
+def _describe_action(action: dict[str, Any]) -> str:
+    """Formats one planned promotion action as a summary line."""
+    groups = ", ".join(action["groups"])
+    if action["type"] == "assign_install":
+        return (
+            f"{action['app_id']}: assign install entry "
+            f"({action['intent']}) -> {groups}"
+        )
+    if action["type"] == "enter_ring":
+        return (
+            f"{action['app_id']}: {action['version']} enters ring "
+            f"'{action['ring']}' -> {groups}"
+        )
+    return (
+        f"{action['app_id']}: {action['version']} advances "
+        f"'{action['from_ring']}' -> '{action['ring']}' -> {groups}"
+    )
+
+
+def cmd_promote_plan(args: argparse.Namespace) -> int:
+    """Handler for 'napt promote plan' command.
+
+    Computes promotion actions for all recipes (or one recipe) as a pure
+    function of deployment state, configuration, and the clock, and
+    writes the plan file when there is work. Read-only with respect to
+    Intune and deployment state; the plan file is the only output. A
+    stale plan file is removed when no actions are eligible.
+
+    Args:
+        args: Parsed command-line arguments containing the recipes path,
+            state directory, and flags.
+
+    Returns:
+        Exit code (0 for success — with or without planned actions,
+        1 for failure).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    recipes = Path(args.recipes)
+    state_dir = Path(args.state_dir)
+    plan_path = plan_path_for(state_dir)
+
+    print(f"Planning promotions for: {recipes}")
+    print()
+
+    try:
+        actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
+        write_plan_file(actions, plan_path)
+    except (ConfigError, PackagingError) as err:
+        print(f"Error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+    except NAPTError as err:
+        print(f"Error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    print("=" * 70)
+    print("PROMOTION PLAN")
+    print("=" * 70)
+    if actions:
+        for action in actions:
+            print(f"  {_describe_action(action)}")
+        print("=" * 70)
+        print()
+        print(f"[OK] Plan written: {plan_path} ({len(actions)} action(s))")
+    else:
+        print("  No promotions eligible.")
+        print("=" * 70)
+        print()
+        print("[OK] Nothing to promote. No plan file needed.")
+
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Handler for 'napt status' command.
+
+    Aggregates all per-app deployment state files into one view: the
+    deployed version, pending release, and which version holds each ring.
+
+    Args:
+        args: Parsed command-line arguments containing the state
+            directory, output format, and flags.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    deployment_dir = Path(args.state_dir) / "deployment"
+
+    try:
+        rows = summarize_deployment_states(deployment_dir)
+    except (ConfigError, PackagingError) as err:
+        print(f"Error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    if args.format == "json":
+        import json
+
+        print(json.dumps(rows, indent=2, sort_keys=True))
+        return 0
+
+    if not rows:
+        print(f"No deployment state found in {deployment_dir}")
+        return 0
+
+    headers = ("App", "Deployed", "Pending", "Rings")
+    table = [
+        (
+            row["app_id"],
+            row["deployed"] or "-",
+            row["pending"] or "-",
+            ", ".join(f"{name}={ver}" for name, ver in row["rings"].items()) or "-",
+        )
+        for row in rows
+    ]
+    widths = [
+        max(len(headers[col]), *(len(line[col]) for line in table))
+        for col in range(len(headers))
+    ]
+    print("  ".join(h.ljust(widths[i]) for i, h in enumerate(headers)))
+    print("  ".join("-" * w for w in widths))
+    for line in table:
+        print("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(line)))
+
+    return 0
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Handler for 'napt init' command.
 
@@ -1084,6 +1232,102 @@ def main() -> None:
         help="Show detailed debugging output (implies --verbose)",
     )
     parser_upload.set_defaults(func=cmd_upload)
+
+    # 'promote' command with subcommands
+    parser_promote = subparsers.add_parser(
+        "promote",
+        help="Plan deployment ring promotion",
+        description=(
+            "Plan (and later apply) ring-based promotion of published apps.\n\n"
+            "Examples:\n"
+            "  napt promote plan\n"
+            "  napt promote plan recipes/Google/chrome.yaml\n"
+            "  napt promote plan --state-dir state\n\n"
+            "See docs for the promotion model and workflows."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    promote_sub = parser_promote.add_subparsers(
+        dest="subcommand",
+        help="Promotion subcommands",
+        required=True,
+    )
+    parser_promote_plan = promote_sub.add_parser(
+        "plan",
+        help="Compute eligible promotions and write the plan file",
+        description=(
+            "Compute which releases enter or advance deployment rings, and "
+            "write state/plan.json when there is work. Read-only: neither "
+            "Intune nor deployment state is modified. A stale plan file is "
+            "removed when nothing is eligible."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser_promote_plan.add_argument(
+        "recipes",
+        nargs="?",
+        default="recipes",
+        help="Recipe file or directory to plan for (default: recipes/)",
+    )
+    parser_promote_plan.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path("state"),
+        help=("State directory holding deployment/ and plan.json " "(default: state)"),
+    )
+    parser_promote_plan.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_promote_plan.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_promote_plan.set_defaults(func=cmd_promote_plan)
+
+    # 'status' command
+    parser_status = subparsers.add_parser(
+        "status",
+        help="Show deployment state across all apps",
+        description=(
+            "Aggregate per-app deployment state into one view: deployed "
+            "version, pending release, and ring positions.\n\n"
+            "Examples:\n"
+            "  napt status\n"
+            "  napt status --format json\n\n"
+            "See docs for more examples and workflows."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser_status.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path("state"),
+        help="State directory holding deployment/ (default: state)",
+    )
+    parser_status.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser_status.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_status.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_status.set_defaults(func=cmd_status)
 
     # Parse and dispatch
     args = parser.parse_args()

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -96,9 +96,15 @@ from napt.exceptions import (
     NAPTError,
     NetworkError,
     PackagingError,
+    StateError,
 )
 from napt.logging import get_logger, set_global_logger
-from napt.promote import plan_path_for, plan_promotions, write_plan_file
+from napt.promote import (
+    plan_path_for,
+    plan_promotions,
+    resolve_state_dir,
+    write_plan_file,
+)
 from napt.state import summarize_deployment_states
 from napt.upload import upload_package
 from napt.validation import validate_recipe
@@ -635,7 +641,14 @@ def cmd_upload(args: argparse.Namespace) -> int:
 
 
 def _describe_action(action: dict[str, Any]) -> str:
-    """Formats one planned promotion action as a summary line."""
+    """Formats one planned promotion action as a summary line.
+
+    Args:
+        action: A planned action dict from plan_promotions.
+
+    Returns:
+        A one-line ASCII description for console output.
+    """
     groups = ", ".join(action["groups"])
     if action["type"] == "assign_install":
         return (
@@ -675,16 +688,20 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
     set_global_logger(logger)
 
     recipes = Path(args.recipes)
-    state_dir = Path(args.state_dir)
-    plan_path = plan_path_for(state_dir)
 
     print(f"Planning promotions for: {recipes}")
     print()
 
     try:
+        state_dir = (
+            Path(args.state_dir)
+            if args.state_dir is not None
+            else resolve_state_dir(recipes)
+        )
+        plan_path = plan_path_for(state_dir)
         actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
         write_plan_file(actions, plan_path)
-    except (ConfigError, PackagingError) as err:
+    except (ConfigError, StateError) as err:
         print(f"Error: {err}")
         if args.verbose or args.debug:
             import traceback
@@ -738,7 +755,7 @@ def cmd_status(args: argparse.Namespace) -> int:
 
     try:
         rows = summarize_deployment_states(deployment_dir)
-    except (ConfigError, PackagingError) as err:
+    except (ConfigError, StateError) as err:
         print(f"Error: {err}")
         if args.verbose or args.debug:
             import traceback
@@ -1272,8 +1289,11 @@ def main() -> None:
     parser_promote_plan.add_argument(
         "--state-dir",
         type=Path,
-        default=Path("state"),
-        help=("State directory holding deployment/ and plan.json " "(default: state)"),
+        default=None,
+        help=(
+            "State directory holding deployment/ and plan.json "
+            "(default: directories.state from config)"
+        ),
     )
     parser_promote_plan.add_argument(
         "-v",

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -111,7 +111,7 @@ def discover_recipe(
             an unknown ``discovery.strategy`` value.
         NetworkError: On download or version-extraction failures from
             either flow.
-        PackagingError: On a corrupted deployment state file.
+        StateError: On a corrupted deployment state file.
 
     """
     logger = get_global_logger()

--- a/napt/exceptions.py
+++ b/napt/exceptions.py
@@ -50,6 +50,7 @@ __all__ = [
     "ConfigError",
     "NetworkError",
     "PackagingError",
+    "StateError",
     "AuthError",
     "NotModifiedError",
 ]
@@ -146,6 +147,37 @@ class PackagingError(NAPTError):
                 build_package(Path("recipe.yaml"), Path("./builds"))
             except PackagingError as e:
                 print(f"Packaging error: {e}")
+            ```
+    """
+
+    pass
+
+
+class StateError(NAPTError):
+    """Raised for persisted-state integrity errors.
+
+    This exception is raised when NAPT's own persisted state — deployment
+    state files under ``state/`` or the discovery cache under ``cache/`` —
+    is unreadable or invalid:
+
+    - Corrupted deployment state files (invalid JSON)
+    - Invalid deployment state fields (e.g., an unparseable ring
+        ``entered_at`` timestamp)
+    - Corrupted discovery cache files (invalid JSON)
+
+    Deployment state is authoritative and never auto-replaced; the error
+    message says how to recover. The discovery cache is disposable and is
+    backed up and recreated before this error is raised.
+
+    Example:
+        Catching state errors:
+            ```python
+            from napt.exceptions import StateError
+
+            try:
+                state = load_deployment_state(path)
+            except StateError as e:
+                print(f"State error: {e}")
             ```
     """
 

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -25,6 +25,16 @@ deployed release into the next ring once it has held its current ring for
 the ring's ``promote_after_days``.
 """
 
-from .planner import plan_path_for, plan_promotions, write_plan_file
+from .planner import (
+    plan_path_for,
+    plan_promotions,
+    resolve_state_dir,
+    write_plan_file,
+)
 
-__all__ = ["plan_path_for", "plan_promotions", "write_plan_file"]
+__all__ = [
+    "plan_path_for",
+    "plan_promotions",
+    "resolve_state_dir",
+    "write_plan_file",
+]

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployment promotion for NAPT.
+
+Implements ring-based promotion of published apps: ``napt promote plan``
+computes which releases should enter or advance through the configured
+deployment rings and writes a reviewable plan file; ``napt promote apply``
+(upcoming) executes a plan against Intune.
+
+The core invariant: each ring holds at most one release of an app's Update
+entry — the newest release that has reached it. Promotion advances the
+deployed release into the next ring once it has held its current ring for
+the ring's ``promote_after_days``.
+"""
+
+from .planner import plan_path_for, plan_promotions, write_plan_file
+
+__all__ = ["plan_path_for", "plan_promotions", "write_plan_file"]

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -47,11 +47,16 @@ from pathlib import Path
 from typing import Any
 
 from napt.config import load_effective_config
-from napt.exceptions import ConfigError
+from napt.exceptions import ConfigError, StateError
 from napt.logging import get_global_logger
 from napt.state import deployment_state_path, load_deployment_state
 
-__all__ = ["plan_path_for", "plan_promotions", "write_plan_file"]
+__all__ = [
+    "plan_path_for",
+    "plan_promotions",
+    "resolve_state_dir",
+    "write_plan_file",
+]
 
 # Deterministic ordering of action types within one app's actions.
 _ACTION_ORDER = {"assign_install": 0, "enter_ring": 1, "advance_ring": 2}
@@ -81,13 +86,13 @@ def _parse_entered_at(value: str, context: str) -> datetime:
         The parsed timezone-aware datetime.
 
     Raises:
-        ConfigError: If the timestamp cannot be parsed.
+        StateError: If the timestamp cannot be parsed.
 
     """
     try:
         parsed = datetime.fromisoformat(value)
     except (TypeError, ValueError) as err:
-        raise ConfigError(
+        raise StateError(
             f"{context}: invalid entered_at timestamp {value!r} in "
             "deployment state. Fix the JSON or restore the file from a backup."
         ) from err
@@ -226,6 +231,29 @@ def _collect_recipe_paths(recipes: Path) -> list[Path]:
     raise ConfigError(f"Recipe path not found: {recipes}")
 
 
+def resolve_state_dir(recipes: Path) -> Path:
+    """Resolves the configured state directory for a plan run.
+
+    ``directories.state`` is org policy — consistent across a project —
+    so the first recipe's effective configuration determines it for a
+    fleet-wide run.
+
+    Args:
+        recipes: A recipe YAML file, or a directory scanned recursively.
+
+    Returns:
+        The configured state directory.
+
+    Raises:
+        ConfigError: If the recipes path is invalid or the first recipe
+            cannot be loaded.
+
+    """
+    first = _collect_recipe_paths(recipes)[0]
+    config = load_effective_config(first)
+    return Path(config["directories"]["state"])
+
+
 def plan_promotions(
     recipes: Path,
     state_dir: Path | None = None,
@@ -249,9 +277,9 @@ def plan_promotions(
         Action dicts sorted by app id and action type.
 
     Raises:
-        ConfigError: On invalid recipes, an invalid recipes path, or a
-            corrupted ring timestamp.
-        PackagingError: On a corrupted deployment state file.
+        ConfigError: On invalid recipes or an invalid recipes path.
+        StateError: On a corrupted deployment state file or an invalid
+            ring timestamp.
 
     """
     logger = get_global_logger()

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -1,0 +1,309 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Promotion planning for NAPT deployment rings.
+
+Computes promotion actions as a pure function of (deployment state,
+configuration, clock) — no Graph calls, no side effects beyond the plan
+file. Re-running plan against unchanged inputs produces byte-identical
+output, so committed plan files diff cleanly and CI can use the plan
+file's change status to decide whether to open a review.
+
+Three action types are planned per app:
+
+- ``assign_install``: The install entry has never been assigned; assign
+    it to the configured ``deployment.install`` groups.
+- ``enter_ring``: The deployed release holds no ring; assign the Update
+    entry to the first ring's groups.
+- ``advance_ring``: The deployed release has held its furthest ring for
+    at least that ring's ``promote_after_days``; assign the next ring.
+
+A ring without ``promote_after_days`` never advances automatically —
+releases hold it until the configuration changes (the natural terminal
+ring, or a deliberate manual gate).
+
+The plan file (default ``state/plan.json``) is written only when actions
+exist; a stale plan file is removed when a plan run finds none. Exit
+codes follow NAPT's uniform contract (0 success, 1 error) — CI detects
+pending work from the plan file's git status, not from exit codes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
+from typing import Any
+
+from napt.config import load_effective_config
+from napt.exceptions import ConfigError
+from napt.logging import get_global_logger
+from napt.state import deployment_state_path, load_deployment_state
+
+__all__ = ["plan_path_for", "plan_promotions", "write_plan_file"]
+
+# Deterministic ordering of action types within one app's actions.
+_ACTION_ORDER = {"assign_install": 0, "enter_ring": 1, "advance_ring": 2}
+
+
+def plan_path_for(state_dir: Path) -> Path:
+    """Returns the plan file path for a state directory.
+
+    Args:
+        state_dir: The configured state directory (``directories.state``).
+
+    Returns:
+        Path to the plan file (``<state_dir>/plan.json``).
+
+    """
+    return state_dir / "plan.json"
+
+
+def _parse_entered_at(value: str, context: str) -> datetime:
+    """Parses a ring entry timestamp from deployment state.
+
+    Args:
+        value: ISO-8601 timestamp string written by promote apply.
+        context: Field description for error messages.
+
+    Returns:
+        The parsed timezone-aware datetime.
+
+    Raises:
+        ConfigError: If the timestamp cannot be parsed.
+
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError) as err:
+        raise ConfigError(
+            f"{context}: invalid entered_at timestamp {value!r} in "
+            "deployment state. Fix the JSON or restore the file from a backup."
+        ) from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _plan_app_actions(
+    config: dict[str, Any],
+    state: dict[str, Any],
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """Computes promotion actions for one app.
+
+    Args:
+        config: Effective configuration for the app's recipe.
+        state: The app's deployment state.
+        now: The evaluation clock (timezone-aware).
+
+    Returns:
+        Action dicts for this app, in deterministic order. Empty when
+            nothing is eligible.
+
+    """
+    app_id: str = config["id"]
+    deployment: dict[str, Any] = config["deployment"]
+    deployed = state.get("deployed")
+
+    if not deployed:
+        return []
+
+    actions: list[dict[str, Any]] = []
+    version: str = deployed["version"]
+    sha256: str = deployed["sha256"]
+
+    # Install entry: assigned once, when groups are configured.
+    install_cfg: dict[str, Any] = deployment["install"]
+    if (
+        deployed.get("intune_app_id")
+        and install_cfg["groups"]
+        and not state.get("install_assigned")
+    ):
+        actions.append(
+            {
+                "type": "assign_install",
+                "app_id": app_id,
+                "version": version,
+                "sha256": sha256,
+                "intent": install_cfg["intent"],
+                "groups": list(install_cfg["groups"]),
+            }
+        )
+
+    # Update entry: rides the rings.
+    rings_cfg: list[dict[str, Any]] = deployment["rings"]
+    if not rings_cfg or not deployed.get("intune_update_app_id"):
+        return actions
+
+    rings_state: dict[str, Any] = state.get("rings", {})
+    ring_names = [ring["name"] for ring in rings_cfg]
+    held_indexes = [
+        index
+        for index, name in enumerate(ring_names)
+        if rings_state.get(name, {}).get("sha256") == sha256
+    ]
+
+    if not held_indexes:
+        first = rings_cfg[0]
+        actions.append(
+            {
+                "type": "enter_ring",
+                "app_id": app_id,
+                "version": version,
+                "sha256": sha256,
+                "ring": first["name"],
+                "groups": list(first["groups"]),
+            }
+        )
+        return actions
+
+    furthest = max(held_indexes)
+    if furthest + 1 >= len(rings_cfg):
+        return actions  # Already at the final ring.
+
+    days = rings_cfg[furthest].get("promote_after_days")
+    if days is None:
+        return actions  # This ring only advances manually.
+
+    held_ring_name = ring_names[furthest]
+    entered_at = _parse_entered_at(
+        rings_state[held_ring_name].get("entered_at"),
+        f"{app_id}: rings.{held_ring_name}",
+    )
+    if now - entered_at < timedelta(days=days):
+        return actions  # Still baking.
+
+    next_ring = rings_cfg[furthest + 1]
+    actions.append(
+        {
+            "type": "advance_ring",
+            "app_id": app_id,
+            "version": version,
+            "sha256": sha256,
+            "from_ring": held_ring_name,
+            "ring": next_ring["name"],
+            "groups": list(next_ring["groups"]),
+        }
+    )
+    return actions
+
+
+def _collect_recipe_paths(recipes: Path) -> list[Path]:
+    """Collects recipe file paths from a file or directory.
+
+    Args:
+        recipes: A recipe YAML file, or a directory scanned recursively
+            for ``*.yaml`` / ``*.yml`` files.
+
+    Returns:
+        Sorted recipe file paths.
+
+    Raises:
+        ConfigError: If the path does not exist or contains no recipes.
+
+    """
+    if recipes.is_file():
+        return [recipes]
+    if recipes.is_dir():
+        found = sorted(
+            path for pattern in ("*.yaml", "*.yml") for path in recipes.rglob(pattern)
+        )
+        if not found:
+            raise ConfigError(f"No recipe files found under {recipes}")
+        return found
+    raise ConfigError(f"Recipe path not found: {recipes}")
+
+
+def plan_promotions(
+    recipes: Path,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Computes promotion actions for a recipe or a directory of recipes.
+
+    Loads each recipe's effective configuration, reads its deployment
+    state, and evaluates ring eligibility against the clock. Read-only:
+    neither Intune nor the state files are modified.
+
+    Args:
+        recipes: A recipe YAML file, or a directory scanned recursively.
+        state_dir: Directory holding per-app deployment state files.
+            When omitted, each recipe's ``directories.state`` setting is
+            used (``<state>/deployment``).
+        now: Evaluation clock. Defaults to the current UTC time; tests
+            pass a fixed value for determinism.
+
+    Returns:
+        Action dicts sorted by app id and action type.
+
+    Raises:
+        ConfigError: On invalid recipes, an invalid recipes path, or a
+            corrupted ring timestamp.
+        PackagingError: On a corrupted deployment state file.
+
+    """
+    logger = get_global_logger()
+    if now is None:
+        now = datetime.now(UTC)
+
+    actions: list[dict[str, Any]] = []
+    for recipe_path in _collect_recipe_paths(recipes):
+        config = load_effective_config(recipe_path)
+        app_state_dir = (
+            state_dir
+            if state_dir is not None
+            else Path(config["directories"]["state"]) / "deployment"
+        )
+        state = load_deployment_state(
+            deployment_state_path(app_state_dir, config["id"])
+        )
+        app_actions = _plan_app_actions(config, state, now)
+        if app_actions:
+            logger.verbose(
+                "PROMOTE",
+                f"{config['id']}: {len(app_actions)} action(s) planned",
+            )
+        actions.extend(app_actions)
+
+    actions.sort(key=lambda a: (a["app_id"], _ACTION_ORDER[a["type"]]))
+    return actions
+
+
+def write_plan_file(actions: list[dict[str, Any]], plan_path: Path) -> bool:
+    """Writes the plan file, or removes a stale one when there is no work.
+
+    The plan file exists exactly when there are planned actions, so its
+    git status is the signal that a promotion review is needed. Output is
+    deterministic (sorted keys, fixed indentation, no timestamps).
+
+    Args:
+        actions: Planned actions from plan_promotions.
+        plan_path: Path to the plan file.
+
+    Returns:
+        True when a plan file exists after the call, False when there
+            was no work (and any stale plan file was removed).
+
+    """
+    if not actions:
+        if plan_path.exists():
+            plan_path.unlink()
+        return False
+
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(plan_path, "w", encoding="utf-8") as f:
+        json.dump({"actions": actions}, f, indent=2, sort_keys=True)
+        f.write("\n")  # Trailing newline for git
+    return True

--- a/napt/state/__init__.py
+++ b/napt/state/__init__.py
@@ -66,6 +66,7 @@ from .deployment import (
     record_deployed,
     record_pending,
     save_deployment_state,
+    summarize_deployment_states,
 )
 
 __all__ = [
@@ -80,4 +81,5 @@ __all__ = [
     "record_pending",
     "save_cache",
     "save_deployment_state",
+    "summarize_deployment_states",
 ]

--- a/napt/state/cache.py
+++ b/napt/state/cache.py
@@ -70,7 +70,7 @@ from pathlib import Path
 from typing import Any
 
 from napt import __version__
-from napt.exceptions import PackagingError
+from napt.exceptions import StateError
 
 
 def cache_file_path(config: dict[str, Any]) -> Path:
@@ -152,7 +152,7 @@ class DiscoveryCache:
             self.cache_file.rename(backup)
             self.data = create_default_cache()
             self.save()
-            raise PackagingError(
+            raise StateError(
                 f"Corrupted cache file backed up to {backup}. "
                 f"Created fresh cache file."
             ) from err

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -67,7 +67,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt.exceptions import PackagingError
+from napt.exceptions import StateError
 
 
 def deployment_state_path(state_dir: Path, recipe_id: str) -> Path:
@@ -115,7 +115,7 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
         Deployment state dictionary.
 
     Raises:
-        PackagingError: If the file exists but contains invalid JSON.
+        StateError: If the file exists but contains invalid JSON.
             Deployment state is authoritative, so a corrupted file is
             never silently replaced.
 
@@ -126,7 +126,7 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
     except FileNotFoundError:
         return create_default_deployment_state()
     except json.JSONDecodeError as err:
-        raise PackagingError(
+        raise StateError(
             f"Corrupted deployment state file: {state_path}. "
             "Deployment state is authoritative and is not auto-replaced. "
             "Fix the JSON or restore the file from a backup."
@@ -250,7 +250,7 @@ def summarize_deployment_states(deployment_dir: Path) -> list[dict[str, Any]]:
             Empty when the directory does not exist or holds no state.
 
     Raises:
-        PackagingError: On a corrupted deployment state file.
+        StateError: On a corrupted deployment state file.
 
     """
     if not deployment_dir.is_dir():

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -236,3 +236,40 @@ def record_deployed(
     pending = state.get("pending")
     if pending and pending.get("sha256") == sha256:
         state["pending"] = None
+
+
+def summarize_deployment_states(deployment_dir: Path) -> list[dict[str, Any]]:
+    """Summarizes all per-app deployment state files in a directory.
+
+    Args:
+        deployment_dir: Directory holding per-app deployment state files.
+
+    Returns:
+        One summary dict per app, sorted by app id, each with the app id,
+            deployed version, pending version, and a ring-to-version map.
+            Empty when the directory does not exist or holds no state.
+
+    Raises:
+        PackagingError: On a corrupted deployment state file.
+
+    """
+    if not deployment_dir.is_dir():
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for path in sorted(deployment_dir.glob("*.json")):
+        state = load_deployment_state(path)
+        deployed = state.get("deployed") or {}
+        pending = state.get("pending") or {}
+        rings = state.get("rings") or {}
+        rows.append(
+            {
+                "app_id": path.stem,
+                "deployed": deployed.get("version"),
+                "pending": pending.get("version"),
+                "rings": {
+                    name: entry.get("version") for name, entry in sorted(rings.items())
+                },
+            }
+        )
+    return rows

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -738,6 +738,7 @@ def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
             package's installer hash does not match the pending release
             in deployment state, or no pending release is recorded while
             deployment.require_pending is enabled.
+        StateError: On a corrupted deployment state file.
 
     Example:
         Upload and print the resulting Intune app IDs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,8 @@ from napt.cli import (
     cmd_discover,
     cmd_init,
     cmd_package,
+    cmd_promote_plan,
+    cmd_status,
     cmd_upload,
     cmd_validate,
 )
@@ -719,3 +721,125 @@ class TestResolveBuildDirFromRecipe:
         with patch("napt.cli.load_effective_config", return_value=mock_config):
             result = _resolve_build_dir_from_recipe(recipe, builds_dir=custom_builds)
         assert result == app_ver_dir
+
+
+# =============================================================================
+# cmd_promote_plan
+# =============================================================================
+
+
+class TestCmdPromotePlan:
+    """Tests for cmd_promote_plan handler."""
+
+    def test_actions_write_plan_and_return_zero(self, tmp_path, capsys):
+        """Tests that planned actions print a summary and report the plan file."""
+        actions = [
+            {
+                "type": "enter_ring",
+                "app_id": "test-app",
+                "version": "1.0.0",
+                "sha256": "a" * 64,
+                "ring": "pilot",
+                "groups": ["sg-pilot"],
+            }
+        ]
+        with (
+            patch("napt.cli.plan_promotions", return_value=actions),
+            patch("napt.cli.write_plan_file", return_value=True) as write_mock,
+        ):
+            code = cmd_promote_plan(
+                _args(recipes="recipes", state_dir=tmp_path / "state")
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "enters ring 'pilot'" in out
+        assert "Plan written" in out
+        assert write_mock.call_args.args[0] == actions
+
+    def test_no_actions_returns_zero(self, tmp_path, capsys):
+        """Tests that an empty plan reports nothing to promote."""
+        with (
+            patch("napt.cli.plan_promotions", return_value=[]),
+            patch("napt.cli.write_plan_file", return_value=False),
+        ):
+            code = cmd_promote_plan(
+                _args(recipes="recipes", state_dir=tmp_path / "state")
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Nothing to promote" in out
+
+    def test_config_error_returns_one(self, tmp_path, capsys):
+        """Tests that ConfigError is caught and returns 1."""
+        with patch("napt.cli.plan_promotions", side_effect=ConfigError("bad")):
+            code = cmd_promote_plan(
+                _args(recipes="recipes", state_dir=tmp_path / "state")
+            )
+        assert code == 1
+        assert "bad" in capsys.readouterr().out
+
+
+# =============================================================================
+# cmd_status
+# =============================================================================
+
+
+class TestCmdStatus:
+    """Tests for cmd_status handler."""
+
+    def test_table_lists_apps(self, tmp_path, capsys):
+        """Tests that the text table lists each app with its versions."""
+        from napt.state import (
+            create_default_deployment_state,
+            deployment_state_path,
+            save_deployment_state,
+        )
+
+        state = create_default_deployment_state()
+        state["deployed"] = {"version": "1.2.3", "sha256": "a"}
+        state["rings"] = {
+            "pilot": {"version": "1.2.3", "sha256": "a", "entered_at": "x"}
+        }
+        save_deployment_state(
+            state,
+            deployment_state_path(tmp_path / "state" / "deployment", "napt-chrome"),
+        )
+
+        code = cmd_status(_args(state_dir=tmp_path / "state", format="text"))
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "napt-chrome" in out
+        assert "1.2.3" in out
+        assert "pilot=1.2.3" in out
+
+    def test_json_format(self, tmp_path, capsys):
+        """Tests that JSON output parses and carries the summary."""
+        import json as json_module
+
+        from napt.state import (
+            create_default_deployment_state,
+            deployment_state_path,
+            save_deployment_state,
+        )
+
+        state = create_default_deployment_state()
+        state["pending"] = {"version": "2.0.0", "sha256": "b", "url": "u"}
+        save_deployment_state(
+            state,
+            deployment_state_path(tmp_path / "state" / "deployment", "app-x"),
+        )
+
+        code = cmd_status(_args(state_dir=tmp_path / "state", format="json"))
+
+        assert code == 0
+        rows = json_module.loads(capsys.readouterr().out)
+        assert rows[0]["app_id"] == "app-x"
+        assert rows[0]["pending"] == "2.0.0"
+
+    def test_empty_state_dir_returns_zero(self, tmp_path, capsys):
+        """Tests that no state files reports cleanly with exit 0."""
+        code = cmd_status(_args(state_dir=tmp_path / "state", format="text"))
+
+        assert code == 0
+        assert "No deployment state found" in capsys.readouterr().out

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -10,8 +10,13 @@ from typing import Any
 import pytest
 import yaml
 
-from napt.exceptions import ConfigError
-from napt.promote import plan_path_for, plan_promotions, write_plan_file
+from napt.exceptions import ConfigError, StateError
+from napt.promote import (
+    plan_path_for,
+    plan_promotions,
+    resolve_state_dir,
+    write_plan_file,
+)
 from napt.state import (
     create_default_deployment_state,
     deployment_state_path,
@@ -19,6 +24,22 @@ from napt.state import (
 )
 
 NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_project(tmp_path, monkeypatch):
+    """Makes each test a self-contained NAPT project.
+
+    pytest's basetemp lives inside the repo (.pytest-tmp), so the config
+    loader's upward walk from a test recipe would otherwise find the
+    repo's own defaults/org.yaml (which configures real deployment
+    rings). A minimal org.yaml in tmp_path stops the walk there.
+    """
+    monkeypatch.chdir(tmp_path)
+    org = tmp_path / "defaults" / "org.yaml"
+    org.parent.mkdir(parents=True, exist_ok=True)
+    org.write_text("apiVersion: napt/v1\n", encoding="utf-8")
+
 
 _RINGS = [
     {"name": "pilot", "groups": ["sg-pilot"], "promote_after_days": 2},
@@ -290,13 +311,51 @@ class TestPlanPromotions:
             },
         )
 
-        with pytest.raises(ConfigError, match="entered_at"):
+        with pytest.raises(StateError, match="entered_at"):
             plan_promotions(recipe, state_dir=state_dir, now=NOW)
 
     def test_missing_recipes_path_raises(self, tmp_path):
         """Tests that a nonexistent recipes path raises ConfigError."""
         with pytest.raises(ConfigError, match="not found"):
             plan_promotions(tmp_path / "nope", state_dir=tmp_path, now=NOW)
+
+    def test_omitted_state_dir_uses_recipe_config(self, tmp_path, monkeypatch):
+        """Tests that directories.state from config applies without a flag."""
+        monkeypatch.chdir(tmp_path)
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        # Point the recipe's directories.state at a custom location
+        data = yaml.safe_load(recipe.read_text(encoding="utf-8"))
+        data["directories"] = {"state": "customstate"}
+        recipe.write_text(yaml.dump(data), encoding="utf-8")
+
+        deployment_dir = tmp_path / "customstate" / "deployment"
+        state = create_default_deployment_state()
+        state["deployed"] = _deployed()
+        save_deployment_state(state, deployment_state_path(deployment_dir, "test-app"))
+
+        actions = plan_promotions(recipe, state_dir=None, now=NOW)
+
+        assert len(actions) == 1
+        assert actions[0]["type"] == "enter_ring"
+
+
+class TestResolveStateDir:
+    """Tests for state directory resolution from configuration."""
+
+    def test_resolves_configured_state_dir(self, tmp_path):
+        """Tests that directories.state is read from the first recipe."""
+        recipe = _write_recipe(tmp_path)
+        data = yaml.safe_load(recipe.read_text(encoding="utf-8"))
+        data["directories"] = {"state": "customstate"}
+        recipe.write_text(yaml.dump(data), encoding="utf-8")
+
+        assert resolve_state_dir(recipe) == Path("customstate")
+
+    def test_default_state_dir(self, tmp_path):
+        """Tests that the built-in default resolves to state."""
+        recipe = _write_recipe(tmp_path)
+
+        assert resolve_state_dir(recipe) == Path("state")
 
 
 class TestWritePlanFile:

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,342 @@
+"""Tests for napt.promote.planner."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from napt.exceptions import ConfigError
+from napt.promote import plan_path_for, plan_promotions, write_plan_file
+from napt.state import (
+    create_default_deployment_state,
+    deployment_state_path,
+    save_deployment_state,
+)
+
+NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=UTC)
+
+_RINGS = [
+    {"name": "pilot", "groups": ["sg-pilot"], "promote_after_days": 2},
+    {"name": "broad", "groups": ["sg-broad"], "promote_after_days": 5},
+    {"name": "production", "groups": ["sg-prod"]},
+]
+
+
+def _write_recipe(
+    tmp_path: Path,
+    app_id: str = "test-app",
+    rings: list[dict[str, Any]] | None = None,
+    install_groups: list[str] | None = None,
+) -> Path:
+    """Writes a minimal recipe with a deployment section."""
+    deployment: dict[str, Any] = {}
+    if rings is not None:
+        deployment["rings"] = rings
+    if install_groups is not None:
+        deployment["install"] = {"intent": "available", "groups": install_groups}
+
+    recipe: dict[str, Any] = {
+        "apiVersion": "napt/v1",
+        "name": f"App {app_id}",
+        "id": app_id,
+        "discovery": {
+            "strategy": "url_download",
+            "url": "https://example.com/app.msi",
+        },
+    }
+    if deployment:
+        recipe["deployment"] = deployment
+
+    recipes_dir = tmp_path / "recipes"
+    recipes_dir.mkdir(exist_ok=True)
+    path = recipes_dir / f"{app_id}.yaml"
+    path.write_text(yaml.dump(recipe), encoding="utf-8")
+    return path
+
+
+def _write_state(
+    tmp_path: Path,
+    app_id: str = "test-app",
+    deployed: dict[str, Any] | None = None,
+    rings: dict[str, Any] | None = None,
+    install_assigned: bool = False,
+) -> Path:
+    """Writes a deployment state file and returns the deployment dir."""
+    deployment_dir = tmp_path / "state" / "deployment"
+    state = create_default_deployment_state()
+    state["deployed"] = deployed
+    if rings:
+        state["rings"] = rings
+    if install_assigned:
+        state["install_assigned"] = True
+    save_deployment_state(state, deployment_state_path(deployment_dir, app_id))
+    return deployment_dir
+
+
+def _deployed(
+    version: str = "1.0.0",
+    sha256: str = "a" * 64,
+    update_id: str | None = "update-1",
+    install_id: str | None = "install-1",
+) -> dict[str, Any]:
+    return {
+        "version": version,
+        "sha256": sha256,
+        "intune_app_id": install_id,
+        "intune_update_app_id": update_id,
+    }
+
+
+class TestPlanPromotions:
+    """Tests for promotion action computation."""
+
+    def test_nothing_deployed_plans_nothing(self, tmp_path):
+        """Tests that an app with no deployed release yields no actions."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(tmp_path, deployed=None)
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == []
+
+    def test_deployed_release_enters_first_ring(self, tmp_path):
+        """Tests that a deployed release holding no ring enters ring 0."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(tmp_path, deployed=_deployed())
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == [
+            {
+                "type": "enter_ring",
+                "app_id": "test-app",
+                "version": "1.0.0",
+                "sha256": "a" * 64,
+                "ring": "pilot",
+                "groups": ["sg-pilot"],
+            }
+        ]
+
+    def test_install_assignment_planned_once(self, tmp_path):
+        """Tests that install assignment is planned only when unassigned."""
+        recipe = _write_recipe(tmp_path, install_groups=["All Users"])
+        state_dir = _write_state(tmp_path, deployed=_deployed())
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == [
+            {
+                "type": "assign_install",
+                "app_id": "test-app",
+                "version": "1.0.0",
+                "sha256": "a" * 64,
+                "intent": "available",
+                "groups": ["All Users"],
+            }
+        ]
+
+        state_dir = _write_state(tmp_path, deployed=_deployed(), install_assigned=True)
+        assert plan_promotions(recipe, state_dir=state_dir, now=NOW) == []
+
+    def test_baking_release_does_not_advance(self, tmp_path):
+        """Tests that a release still baking holds its ring."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "2026-07-07T12:00:00+00:00",  # 1 day < 2
+                }
+            },
+        )
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == []
+
+    def test_baked_release_advances_to_next_ring(self, tmp_path):
+        """Tests that an eligible release advances with the next ring's groups."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "2026-07-06T12:00:00+00:00",  # exactly 2 days
+                }
+            },
+        )
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == [
+            {
+                "type": "advance_ring",
+                "app_id": "test-app",
+                "version": "1.0.0",
+                "sha256": "a" * 64,
+                "from_ring": "pilot",
+                "ring": "broad",
+                "groups": ["sg-broad"],
+            }
+        ]
+
+    def test_final_ring_never_advances(self, tmp_path):
+        """Tests that a release at the final ring plans nothing."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "production": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        )
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == []
+
+    def test_ring_without_promote_after_days_holds(self, tmp_path):
+        """Tests that a ring with no promote_after_days never auto-advances."""
+        rings = [
+            {"name": "pilot", "groups": ["sg-pilot"]},  # manual gate
+            {"name": "production", "groups": ["sg-prod"]},
+        ]
+        recipe = _write_recipe(tmp_path, rings=rings)
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        )
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == []
+
+    def test_new_release_restarts_at_first_ring(self, tmp_path):
+        """Tests that a newly deployed release re-enters ring 0."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(version="2.0.0", sha256="b" * 64),
+            rings={
+                "broad": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,  # old release holds broad
+                    "entered_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        )
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert len(actions) == 1
+        assert actions[0]["type"] == "enter_ring"
+        assert actions[0]["ring"] == "pilot"
+        assert actions[0]["version"] == "2.0.0"
+
+    def test_app_without_update_entry_skips_rings(self, tmp_path):
+        """Tests that rings are skipped when there is no update entry."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS, install_groups=["All Users"])
+        state_dir = _write_state(tmp_path, deployed=_deployed(update_id=None))
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert [a["type"] for a in actions] == ["assign_install"]
+
+    def test_actions_sorted_by_app_id(self, tmp_path):
+        """Tests that actions across apps are deterministically ordered."""
+        _write_recipe(tmp_path, app_id="zeta-app", rings=_RINGS)
+        _write_recipe(tmp_path, app_id="alpha-app", rings=_RINGS)
+        _write_state(tmp_path, app_id="zeta-app", deployed=_deployed())
+        state_dir = _write_state(tmp_path, app_id="alpha-app", deployed=_deployed())
+
+        actions = plan_promotions(tmp_path / "recipes", state_dir=state_dir, now=NOW)
+
+        assert [a["app_id"] for a in actions] == ["alpha-app", "zeta-app"]
+
+    def test_corrupted_entered_at_raises(self, tmp_path):
+        """Tests that an unparseable ring timestamp raises ConfigError."""
+        recipe = _write_recipe(tmp_path, rings=_RINGS)
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "not-a-timestamp",
+                }
+            },
+        )
+
+        with pytest.raises(ConfigError, match="entered_at"):
+            plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+    def test_missing_recipes_path_raises(self, tmp_path):
+        """Tests that a nonexistent recipes path raises ConfigError."""
+        with pytest.raises(ConfigError, match="not found"):
+            plan_promotions(tmp_path / "nope", state_dir=tmp_path, now=NOW)
+
+
+class TestWritePlanFile:
+    """Tests for plan file lifecycle."""
+
+    def test_writes_deterministic_plan(self, tmp_path):
+        """Tests that identical actions produce byte-identical plan files."""
+        plan_path = plan_path_for(tmp_path / "state")
+        actions = [
+            {
+                "type": "enter_ring",
+                "app_id": "a",
+                "version": "1.0",
+                "sha256": "x",
+                "ring": "pilot",
+                "groups": ["g"],
+            }
+        ]
+
+        assert write_plan_file(actions, plan_path) is True
+        first = plan_path.read_bytes()
+        assert write_plan_file(actions, plan_path) is True
+
+        assert plan_path.read_bytes() == first
+        assert json.loads(first.decode("utf-8")) == {"actions": actions}
+
+    def test_no_actions_removes_stale_plan(self, tmp_path):
+        """Tests that an empty plan removes an existing plan file."""
+        plan_path = plan_path_for(tmp_path / "state")
+        plan_path.parent.mkdir(parents=True)
+        plan_path.write_text('{"actions": []}', encoding="utf-8")
+
+        assert write_plan_file([], plan_path) is False
+
+        assert not plan_path.exists()
+
+    def test_no_actions_no_file_is_noop(self, tmp_path):
+        """Tests that an empty plan with no existing file writes nothing."""
+        plan_path = plan_path_for(tmp_path / "state")
+
+        assert write_plan_file([], plan_path) is False
+
+        assert not plan_path.exists()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from napt.exceptions import PackagingError
+from napt.exceptions import StateError
 from napt.state import (
     DiscoveryCache,
     create_default_deployment_state,
@@ -157,7 +157,7 @@ class TestDiscoveryCache:
 
         cache = DiscoveryCache(cache_file)
 
-        with pytest.raises(PackagingError, match="Corrupted cache file"):
+        with pytest.raises(StateError, match="Corrupted cache file"):
             cache.load()
 
         # Should create backup
@@ -317,7 +317,7 @@ class TestDeploymentStateFiles:
         state_path = tmp_path / "napt-chrome.json"
         state_path.write_text("not JSON{{{", encoding="utf-8")
 
-        with pytest.raises(PackagingError, match="Corrupted deployment state"):
+        with pytest.raises(StateError, match="Corrupted deployment state"):
             load_deployment_state(state_path)
 
         # The corrupted file must be left untouched (never silently replaced).

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -26,6 +26,7 @@ from napt.state import (
     record_pending,
     save_cache,
     save_deployment_state,
+    summarize_deployment_states,
 )
 from napt.state.cache import create_default_cache
 
@@ -522,3 +523,36 @@ class TestRecordDeployed:
 
         assert state["deployed"]["version"] == "2.0.0"
         assert state["deployed"]["intune_app_id"] == "c"
+
+
+class TestSummarizeDeploymentStates:
+    """Tests for deployment state aggregation."""
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        """Tests that a nonexistent directory summarizes to nothing."""
+        assert summarize_deployment_states(tmp_path / "nope") == []
+
+    def test_summarizes_apps_sorted(self, tmp_path):
+        """Tests that summaries are sorted and carry the key fields."""
+        deployment_dir = tmp_path / "deployment"
+
+        zeta = create_default_deployment_state()
+        zeta["deployed"] = {"version": "2.0", "sha256": "b"}
+        zeta["rings"] = {"pilot": {"version": "2.0", "sha256": "b", "entered_at": "x"}}
+        save_deployment_state(zeta, deployment_state_path(deployment_dir, "zeta"))
+
+        alpha = create_default_deployment_state()
+        alpha["pending"] = {"version": "1.0", "sha256": "a", "url": "u"}
+        save_deployment_state(alpha, deployment_state_path(deployment_dir, "alpha"))
+
+        rows = summarize_deployment_states(deployment_dir)
+
+        assert rows == [
+            {"app_id": "alpha", "deployed": None, "pending": "1.0", "rings": {}},
+            {
+                "app_id": "zeta",
+                "deployed": "2.0",
+                "pending": None,
+                "rings": {"pilot": "2.0"},
+            },
+        ]


### PR DESCRIPTION
## Description

Adds the read-only half of deployment promotion. `napt promote plan` computes which releases enter or advance the configured rings — plus first-time install-entry assignments — as a pure function of (deployment state, config, clock), and writes a reviewable `state/plan.json`. `napt status` aggregates all per-app state files into one view (text table or `--format json`).

## Motivation

The planner encodes the core invariant: each ring holds at most one release — the newest that reached it. A deployed release holding no ring enters the first ring; after `promote_after_days` in its furthest ring it advances to the next; a new release restarts at ring 0. Plans are the reviewable artifact for promotion PRs; `napt promote apply` (next PR) executes them.

## Changes

- New `napt/promote/planner.py`: eligibility evaluation, deterministic action ordering, plan file lifecycle — written only when actions exist, stale plan removed when none (the file''s git status is the CI signal; exit codes stay 0/1, per discussion no detailed exit codes)
- Rings without `promote_after_days` never auto-advance (terminal ring or manual gate)
- `napt status` + `summarize_deployment_states` aggregation
- CLI: nested `promote plan` subcommand, `status` command

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

647 tests pass; planner covered with a fixed clock (enter/advance/bake/final-ring/manual-gate/restart-at-ring-0/ordering/corrupted-timestamp) plus plan-file determinism and lifecycle. End-to-end CLI smoke test: plan writes expected actions, re-run is byte-identical, status renders table and JSON, empty plan removes the stale file.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors