### PR TITLE
feat: Add napt promote apply with retention

### DIFF
--- a/defaults/org.yaml
+++ b/defaults/org.yaml
@@ -73,6 +73,12 @@ directories:
   icons: "icons"
 
 deployment:
+  # Install entry: available to everyone in Company Portal.
+  # "All Users" is Intune's built-in target, not an Entra ID group.
+  install:
+    intent: "available"
+    groups: ["All Users"]
+
   # Update promotion rings (ring 0 -> 1 -> 2). Groups are Entra ID
   # display names, resolved to object IDs at apply time.
   rings:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`napt promote apply`** - Executes a promotion plan against Intune:
+    assigns install entries, enters and advances releases through rings,
+    unassigns displaced releases, and retires them per
+    `deployment.retain_versions` (only NAPT-stamped apps are ever
+    deleted). Consumes `state/plan.json` when present, plans fresh
+    otherwise. Stale or already-applied actions are skipped, so
+    re-running after a partial failure is safe. Admin-made assignments
+    are always preserved
+
 - **`napt promote plan`** - Computes which releases enter or advance the
     configured deployment rings (plus first-time install-entry
     assignments) and writes a reviewable `state/plan.json`. The plan file

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Built-in assignment targets** - `"All Users"` and `"All Devices"` in
+    deployment group lists assign Intune's virtual targets instead of
+    Entra ID groups. A real group sharing one of these display names must
+    be referenced by its object ID
 - **`napt promote apply`** - Executes a promotion plan against Intune:
     assigns install entries, enters and advances releases through rings,
     unassigns displaced releases, and retires them per

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -673,6 +673,54 @@ For a legitimate manual upload under this policy, run `napt discover` first,
 or add a pending entry (version, sha256, url) to
 `state/deployment/<id>.json`.
 
+### Promote updates through rings
+
+Roll updates out gradually: pilot devices first, everyone else after the
+release has proven itself.
+
+1. **Define rings once in `defaults/org.yaml`** (groups are Entra ID
+   display names or object IDs):
+
+   ```yaml
+   deployment:
+     rings:
+       - name: "pilot"
+         groups: ["Pilot Devices"]
+         promote_after_days: 2
+       - name: "production"
+         groups: ["Production Devices"]
+     install:
+       intent: "available"
+       groups: ["All Users"]
+   ```
+
+2. **Plan** — compute what is eligible (read-only):
+
+   ```bash
+   napt promote plan
+   ```
+
+   A newly uploaded release enters the first ring; a release that has held
+   its ring for `promote_after_days` advances to the next.
+   Eligible actions are written to `state/plan.json`; review the file, or
+   commit it and gate the apply on a pull request.
+
+3. **Apply** — execute the plan against Intune:
+
+   ```bash
+   napt promote apply
+   ```
+
+   Ring groups are assigned to the release's `[Update]` entry as required
+   installs; the displaced older release is unassigned and retired per
+   `deployment.retain_versions`.
+   Run `napt status` to see where every app stands.
+
+Run plan and apply on a schedule and promotion becomes automatic: each
+release baked long enough moves one ring further on the next run.
+A ring without `promote_after_days` is a manual gate — releases hold it
+until you change the configuration.
+
 ### Set a custom app icon
 
 `napt build` extracts an icon from the installer to `icons/{id}.png`

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -1026,6 +1026,12 @@ Display names are resolved via the Graph API, which requires the
 `Group.Read.All` application permission (see
 [App Registration Setup](user-guide.md#app-registration-setup)).
 
+Two names are reserved for Intune's built-in targets: `"All Users"` and
+`"All Devices"` assign the corresponding virtual group instead of looking
+up an Entra ID group.
+The reserved names always win — a real Entra ID group that shares one of
+these display names must be referenced by its object ID.
+
 ### require_pending
 
 **Type:** `boolean`
@@ -1063,6 +1069,9 @@ required installs).
 
 Assignment for the install entry (net-new installs).
 `intent` is `"available"` (Company Portal) or `"required"`.
+No install assignment happens unless groups are configured; a common
+org-wide choice is `groups: ["All Users"]` for Company Portal
+self-service.
 The assignment is planned by `napt promote plan` and executed once per
 release by `napt promote apply`.
 

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -1051,8 +1051,9 @@ Each ring requires a unique `name` and a non-empty `groups` list;
 `promote_after_days` (optional) sets how many days a version holds the ring
 before becoming eligible for the next one.
 
-**Note:** `napt promote plan` evaluates rings to plan promotions;
-assignments are executed by the upcoming `napt promote apply`.
+Rings are evaluated by `napt promote plan` and executed by
+`napt promote apply` (ring groups are assigned to the `[Update]` entry as
+required installs).
 
 ### install
 
@@ -1062,9 +1063,8 @@ assignments are executed by the upcoming `napt promote apply`.
 
 Assignment for the install entry (net-new installs).
 `intent` is `"available"` (Company Portal) or `"required"`.
-
-**Note:** `napt promote plan` plans the install assignment; it is executed
-by the upcoming `napt promote apply`.
+The assignment is planned by `napt promote plan` and executed once per
+release by `napt promote apply`.
 
 ### retain_versions
 
@@ -1074,8 +1074,7 @@ by the upcoming `napt promote apply`.
 
 How many superseded versions stay in Intune for rollback before deletion.
 `0` deletes a version as soon as it holds no rings.
-
-**Note:** Consumed by the upcoming `napt promote apply`; no effect yet.
+Enforced by `napt promote apply`; only NAPT-stamped apps are ever deleted.
 
 ## Variable Substitution
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,8 +116,8 @@ Agreed design:
 - Delivered across eight PRs: state split (shipped), upload provenance and
   hash gate (shipped), idempotent upload (shipped), deployment config and
   assignment client (shipped), `promote plan` and `napt status` (shipped),
-  `promote apply` with retention, drift detection, GitOps docs and schema
-  versioning
+  `promote apply` with retention (shipped), drift detection, GitOps docs
+  and schema versioning
 
 **Related**: Health-gated promotion (block on install failure rates) and
 native Intune supersedence are deliberate follow-ups, not part of this

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -442,14 +442,23 @@ napt package recipes/Google/chrome.yaml --version 130.0.6723.116
 
 ### napt promote
 
-Plans ring-based promotion of published apps. `promote plan` computes which
-releases enter or advance deployment rings (per `deployment.rings`) and
-writes `state/plan.json` when there is work; a stale plan file is removed
-when nothing is eligible. Read-only: neither Intune nor deployment state is
-modified. Applying plans arrives with `napt promote apply`.
+Plans and applies ring-based promotion of published apps. `promote plan`
+computes which releases enter or advance deployment rings (per
+`deployment.rings`) and writes `state/plan.json` when there is work; a
+stale plan file is removed when nothing is eligible. Read-only.
+
+`promote apply` executes the plan against Intune: assigns install entries,
+enters and advances rings, unassigns displaced releases, and retires them
+per `deployment.retain_versions`. It consumes `state/plan.json` when one
+exists (removing it after a fully successful run) and plans fresh
+otherwise. Stale or already-applied actions are skipped with a warning, so
+re-running after a partial failure is safe. Assignments NAPT does not
+manage — admin-made groups, all-device targets, exclusions — are always
+preserved.
 
 ```bash
 napt promote plan [RECIPE_OR_DIR] [OPTIONS]
+napt promote apply [RECIPE_OR_DIR] [OPTIONS]
 ```
 
 ### napt status
@@ -618,8 +627,8 @@ A file holds four sections:
 
 - `deployed` - The version currently published to Intune, with its SHA-256 hash and Intune app IDs. Null until the first upload.
 - `pending` - The discovered release awaiting publication (version, SHA-256 hash, download URL). A single slot: a newer discovery replaces an unpublished candidate (newest wins), and discovering the already-deployed release clears it. Identity is the SHA-256 hash, so a vendor re-release of the same version with a different binary counts as new.
-- `rings` - Which version currently holds each deployment ring (used by upcoming promotion features).
-- `retained` - Superseded versions kept in Intune for rollback (used by upcoming promotion features).
+- `rings` - Which version currently holds each deployment ring, with the timestamp it entered (written by `napt promote apply`).
+- `retained` - Superseded versions kept in Intune for rollback per `deployment.retain_versions` (written by `napt promote apply`).
 
 `napt discover` records the pending candidate.
 Later pipeline stages consume it.
@@ -636,6 +645,9 @@ needed — no special exit codes (`napt` always exits 0 on success, 1 on
 error).
 Plan output is deterministic, so re-running plan against unchanged state
 produces a byte-identical file.
+`napt promote apply` executes the plan as an allowlist — entries that no
+longer validate against current state are skipped, never improvised — and
+removes the file after a fully successful run.
 
 ### Default Behavior (Stateful)
 
@@ -737,6 +749,8 @@ to its own:
 | `napt discover` | `--output-dir` | Where to save downloaded installers | `directories.discover` | `downloads` |
 | `napt discover` | `--cache-file` | Discovery cache file (`<dir>/discovery.json`) | `directories.cache` | `cache` |
 | `napt discover` | `--state-dir` | Per-app deployment state (`<dir>/deployment/`) | `directories.state` | `state` |
+| `napt promote` | `--state-dir` | Deployment state and plan.json | `directories.state` | `state` |
+| `napt status` | `--state-dir` | Deployment state to summarize (no config lookup) | - | `state` |
 | `napt build` | `--downloads-dir` | Where to find the installer | `directories.discover` | `downloads` |
 | `napt build` | `--output-dir` | Where to save builds | `directories.build` | `builds` |
 | `napt package` | `--builds-dir` | Where to find the build | `directories.build` | `builds` |

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -25,7 +25,7 @@ Commands:
     build: Build PSADT package from recipe
     package: Create .intunewin package for Intune (recipe-based)
     upload: Upload .intunewin package to Microsoft Intune
-    promote: Plan (and later apply) deployment ring promotion
+    promote: Plan and apply deployment ring promotion
     status: Show deployment state across all apps
 
 Example:
@@ -100,6 +100,7 @@ from napt.exceptions import (
 )
 from napt.logging import get_logger, set_global_logger
 from napt.promote import (
+    apply_plan,
     plan_path_for,
     plan_promotions,
     resolve_state_dir,
@@ -734,6 +735,85 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_promote_apply(args: argparse.Namespace) -> int:
+    """Handler for 'napt promote apply' command.
+
+    Executes a promotion plan against Intune: assigns install entries,
+    enters and advances releases through rings, displaces superseded
+    releases, and retires them per the retention policy. Consumes the
+    plan file when one exists; otherwise plans fresh and applies
+    immediately. Stale or already-applied actions are skipped with a
+    warning, so re-running after a partial failure is safe.
+
+    Args:
+        args: Parsed command-line arguments containing the recipes path,
+            state directory, plan file, and flags.
+
+    Returns:
+        Exit code (0 for success — including nothing to apply,
+        1 for failure).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    recipes = Path(args.recipes)
+
+    print(f"Applying promotions for: {recipes}")
+    print()
+
+    try:
+        state_dir = (
+            Path(args.state_dir)
+            if args.state_dir is not None
+            else resolve_state_dir(recipes)
+        )
+        summary = apply_plan(
+            recipes,
+            state_dir=state_dir,
+            plan_file=args.plan_file,
+        )
+    except AuthError as err:
+        print(f"Authentication error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+    except (ConfigError, NetworkError, StateError) as err:
+        print(f"Error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+    except NAPTError as err:
+        print(f"Error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    applied = summary["applied"]
+    skipped = summary["skipped"]
+
+    print("=" * 70)
+    print("PROMOTION APPLY")
+    print("=" * 70)
+    if not applied and not skipped:
+        print("  Nothing to apply.")
+    for action in applied:
+        print(f"  [OK] {_describe_action(action)}")
+    for entry in skipped:
+        print(f"  [SKIP] {_describe_action(entry['action'])} ({entry['reason']})")
+    print("=" * 70)
+    print()
+    print(f"[SUCCESS] Applied {len(applied)} action(s), " f"skipped {len(skipped)}.")
+
+    return 0
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     """Handler for 'napt status' command.
 
@@ -1253,13 +1333,13 @@ def main() -> None:
     # 'promote' command with subcommands
     parser_promote = subparsers.add_parser(
         "promote",
-        help="Plan deployment ring promotion",
+        help="Plan and apply deployment ring promotion",
         description=(
-            "Plan (and later apply) ring-based promotion of published apps.\n\n"
+            "Plan and apply ring-based promotion of published apps.\n\n"
             "Examples:\n"
             "  napt promote plan\n"
-            "  napt promote plan recipes/Google/chrome.yaml\n"
-            "  napt promote plan --state-dir state\n\n"
+            "  napt promote apply\n"
+            "  napt promote plan recipes/Google/chrome.yaml\n\n"
             "See docs for the promotion model and workflows."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1308,6 +1388,54 @@ def main() -> None:
         help="Show detailed debugging output (implies --verbose)",
     )
     parser_promote_plan.set_defaults(func=cmd_promote_plan)
+
+    parser_promote_apply = promote_sub.add_parser(
+        "apply",
+        help="Execute a promotion plan against Intune",
+        description=(
+            "Execute promotion actions: assign install entries, enter and "
+            "advance rings, displace superseded releases, and retire them "
+            "per deployment.retain_versions. Consumes state/plan.json when "
+            "it exists; otherwise plans fresh and applies immediately. "
+            "Stale or already-applied actions are skipped, so re-running "
+            "is safe."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser_promote_apply.add_argument(
+        "recipes",
+        nargs="?",
+        default="recipes",
+        help="Recipe file or directory to apply for (default: recipes/)",
+    )
+    parser_promote_apply.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help=(
+            "State directory holding deployment/ and plan.json "
+            "(default: directories.state from config)"
+        ),
+    )
+    parser_promote_apply.add_argument(
+        "--plan-file",
+        type=Path,
+        default=None,
+        help="Plan file to execute (default: <state-dir>/plan.json if present)",
+    )
+    parser_promote_apply.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_promote_apply.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_promote_apply.set_defaults(func=cmd_promote_apply)
 
     # 'status' command
     parser_status = subparsers.add_parser(

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -236,7 +236,9 @@ apiVersion: napt/v1
 #     - name: "production"
 #       groups: ["sg-intune-all-workstations"]
 #
-#   # Install entry assignment (used by upcoming napt promote).
+#   # Install entry assignment, applied by napt promote.
+#   # "All Users" and "All Devices" are Intune's built-in targets, not
+#   # Entra ID groups. No install assignment happens unless configured.
 #   install:
 #     intent: "available"  # available or required
 #     groups: ["All Users"]

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -25,6 +25,7 @@ deployed release into the next ring once it has held its current ring for
 the ring's ``promote_after_days``.
 """
 
+from .applier import apply_plan, load_plan_file
 from .planner import (
     plan_path_for,
     plan_promotions,
@@ -33,6 +34,8 @@ from .planner import (
 )
 
 __all__ = [
+    "apply_plan",
+    "load_plan_file",
     "plan_path_for",
     "plan_promotions",
     "resolve_state_dir",

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -1,0 +1,476 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Promotion apply for NAPT deployment rings.
+
+Executes a promotion plan against Intune: assigns install entries,
+enters and advances releases through rings, displaces superseded
+releases, and retires them per the retention policy.
+
+Every action is validated against current deployment state before
+executing (validate-then-act): stale actions — the deployed release
+changed since the plan was written, or the action already applied —
+are skipped with a warning instead of failing, so re-running apply
+after a partial failure is safe. Deployment state is saved after each
+applied action, and ring ``entered_at`` timestamps are written here
+and only here.
+
+Displaced releases are found through their provenance stamps (the
+tenant is listed once per run), not through deployment state — state
+only records the current release's app IDs. A displaced release that
+no longer holds any ring moves to the retained list; releases beyond
+``deployment.retain_versions`` have their Intune apps deleted.
+
+Assignments NAPT does not manage are preserved: assignment sets are
+read, modified, and written back, so admin-made assignments and
+non-group targets survive every apply.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from napt.config import load_effective_config
+from napt.exceptions import StateError
+from napt.logging import get_global_logger
+from napt.promote.planner import (
+    _collect_recipe_paths,
+    plan_path_for,
+    plan_promotions,
+)
+from napt.state import (
+    deployment_state_path,
+    load_deployment_state,
+    save_deployment_state,
+)
+from napt.upload.auth import get_access_token
+from napt.upload.graph import (
+    assign_app,
+    build_group_assignment,
+    delete_mobile_app,
+    get_app_assignments,
+    list_mobile_apps,
+    resolve_group_id,
+)
+from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
+
+__all__ = ["apply_plan", "load_plan_file"]
+
+# Ring assignments target the Update entry, which is gated to devices
+# with an older release installed — always a required install.
+_RING_INTENT = "required"
+
+
+def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
+    """Loads planned actions from a plan file.
+
+    Args:
+        plan_path: Path to the plan file.
+
+    Returns:
+        The planned action dicts.
+
+    Raises:
+        StateError: If the plan file contains invalid JSON or lacks an
+            actions list.
+
+    """
+    try:
+        data = json.loads(plan_path.read_text(encoding="utf-8"))
+        actions = data["actions"]
+    except (json.JSONDecodeError, KeyError, TypeError) as err:
+        raise StateError(
+            f"Corrupted plan file: {plan_path}. "
+            "Re-run 'napt promote plan' to regenerate it."
+        ) from err
+    return actions
+
+
+def _strip_assignment(assignment: dict[str, Any]) -> dict[str, Any]:
+    """Returns an assignment payload safe to send back to the assign action.
+
+    Args:
+        assignment: A mobileAppAssignment dict from get_app_assignments.
+
+    Returns:
+        The assignment without its read-only id, with the assignment
+            @odata.type present.
+
+    """
+    cleaned = {key: value for key, value in assignment.items() if key != "id"}
+    cleaned.setdefault("@odata.type", "#microsoft.graph.mobileAppAssignment")
+    return cleaned
+
+
+def _targeted_group_id(assignment: dict[str, Any]) -> str | None:
+    """Returns the group ID an assignment targets, or None for other targets."""
+    target = assignment.get("target") or {}
+    return target.get("groupId")
+
+
+def _add_group_assignments(
+    access_token: str,
+    app_id: str,
+    group_ids: list[str],
+    intent: str,
+) -> None:
+    """Adds group assignments to an app, preserving everything else.
+
+    Existing assignments that target the same groups are replaced (the
+    intent may have changed); all other assignments — admin-made groups,
+    all-devices/all-users targets, exclusions — pass through untouched.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app.
+        group_ids: Entra ID group object IDs to assign.
+        intent: Assignment intent for the added groups.
+
+    """
+    current = get_app_assignments(access_token, app_id)
+    kept = [
+        _strip_assignment(a) for a in current if _targeted_group_id(a) not in group_ids
+    ]
+    added = [build_group_assignment(gid, intent) for gid in group_ids]
+    assign_app(access_token, app_id, kept + added)
+
+
+def _remove_group_assignments(
+    access_token: str,
+    app_id: str,
+    group_ids: list[str],
+) -> None:
+    """Removes specific group assignments from an app, preserving the rest.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app.
+        group_ids: Entra ID group object IDs to unassign.
+
+    """
+    current = get_app_assignments(access_token, app_id)
+    kept = [
+        _strip_assignment(a) for a in current if _targeted_group_id(a) not in group_ids
+    ]
+    if len(kept) != len(current):
+        assign_app(access_token, app_id, kept)
+
+
+class _ApplyRun:
+    """Holds the shared context of one apply run.
+
+    Caches per-app deployment state (saved after every applied action),
+    resolved group IDs, recipe configurations, and the tenant app list.
+    """
+
+    def __init__(
+        self,
+        access_token: str,
+        configs: dict[str, dict[str, Any]],
+        deployment_dir: Path,
+        now: datetime,
+    ):
+        self.access_token = access_token
+        self.configs = configs
+        self.deployment_dir = deployment_dir
+        self.now = now
+        self.existing_apps = list_mobile_apps(access_token)
+        self._states: dict[str, dict[str, Any]] = {}
+        self._group_ids: dict[str, str] = {}
+        self.applied: list[dict[str, Any]] = []
+        self.skipped: list[dict[str, Any]] = []
+
+    def state_for(self, app_id: str) -> dict[str, Any]:
+        """Returns the cached deployment state for an app, loading once."""
+        if app_id not in self._states:
+            self._states[app_id] = load_deployment_state(
+                deployment_state_path(self.deployment_dir, app_id)
+            )
+        return self._states[app_id]
+
+    def save_state(self, app_id: str) -> None:
+        """Persists an app's deployment state after an applied action."""
+        save_deployment_state(
+            self._states[app_id],
+            deployment_state_path(self.deployment_dir, app_id),
+        )
+
+    def resolve_groups(self, groups: list[str]) -> list[str]:
+        """Resolves group names/IDs to object IDs with a per-run cache."""
+        ids = []
+        for group in groups:
+            if group not in self._group_ids:
+                self._group_ids[group] = resolve_group_id(self.access_token, group)
+            ids.append(self._group_ids[group])
+        return ids
+
+    def skip(self, action: dict[str, Any], reason: str) -> None:
+        """Records a skipped action and warns."""
+        logger = get_global_logger()
+        logger.warning(
+            "PROMOTE",
+            f"Skipping {action['type']} for '{action['app_id']}': {reason}",
+        )
+        self.skipped.append({"action": action, "reason": reason})
+
+
+def _holds_any_ring(state: dict[str, Any], sha256: str) -> bool:
+    """Returns True when a release still holds at least one ring."""
+    return any(
+        entry.get("sha256") == sha256 for entry in (state.get("rings") or {}).values()
+    )
+
+
+def _retire_release(run: _ApplyRun, app_id: str, version: str, sha256: str) -> None:
+    """Retires a fully displaced release per the retention policy.
+
+    The release joins the retained list (newest last). Releases beyond
+    ``deployment.retain_versions`` have their stamped Intune apps
+    deleted, oldest first. The currently deployed release is never
+    deleted.
+
+    Args:
+        run: The apply run context.
+        app_id: Recipe identifier.
+        version: Displaced release's version string.
+        sha256: Displaced release's installer hash.
+
+    """
+    logger = get_global_logger()
+    state = run.state_for(app_id)
+    retained: list[dict[str, Any]] = state.setdefault("retained", [])
+
+    if not any(entry.get("sha256") == sha256 for entry in retained):
+        retained.append({"version": version, "sha256": sha256})
+        logger.info(
+            "PROMOTE",
+            f"{app_id}: retained displaced release {version} for rollback",
+        )
+
+    retain_limit: int = run.configs[app_id]["deployment"]["retain_versions"]
+    deployed = state.get("deployed") or {}
+    while len(retained) > retain_limit:
+        oldest = retained.pop(0)
+        if oldest.get("sha256") == deployed.get("sha256"):
+            continue  # Never delete the currently deployed release.
+        for entry_type in (ENTRY_INSTALL, ENTRY_UPDATE):
+            app = find_stamped_app(
+                run.existing_apps, app_id, entry_type, oldest["sha256"]
+            )
+            if app is not None:
+                delete_mobile_app(run.access_token, app["id"])
+                logger.info(
+                    "PROMOTE",
+                    f"{app_id}: deleted retired {entry_type} entry "
+                    f"{oldest.get('version')} ({app['id']})",
+                )
+
+
+def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
+    """Applies an enter_ring or advance_ring action.
+
+    Args:
+        run: The apply run context.
+        action: The planned action.
+
+    Returns:
+        True when applied, False when skipped.
+
+    """
+    app_id: str = action["app_id"]
+    sha256: str = action["sha256"]
+    ring: str = action["ring"]
+    state = run.state_for(app_id)
+    deployed = state.get("deployed") or {}
+
+    if deployed.get("sha256") != sha256:
+        run.skip(action, "stale action - the deployed release has changed")
+        return False
+    ring_names = [r["name"] for r in run.configs[app_id]["deployment"]["rings"]]
+    if ring not in ring_names:
+        run.skip(action, f"ring '{ring}' is no longer configured")
+        return False
+    rings_state: dict[str, Any] = state.setdefault("rings", {})
+    if rings_state.get(ring, {}).get("sha256") == sha256:
+        run.skip(action, "already applied")
+        return False
+
+    update_app = find_stamped_app(run.existing_apps, app_id, ENTRY_UPDATE, sha256)
+    if update_app is None:
+        run.skip(action, "no stamped update entry found in the tenant")
+        return False
+
+    group_ids = run.resolve_groups(action["groups"])
+    _add_group_assignments(run.access_token, update_app["id"], group_ids, _RING_INTENT)
+
+    # Displace the previous holder of this ring (an older release's app).
+    previous = rings_state.get(ring)
+    if previous and previous.get("sha256") != sha256:
+        previous_app = find_stamped_app(
+            run.existing_apps, app_id, ENTRY_UPDATE, previous["sha256"]
+        )
+        if previous_app is not None:
+            _remove_group_assignments(run.access_token, previous_app["id"], group_ids)
+        else:
+            get_global_logger().warning(
+                "PROMOTE",
+                f"{app_id}: displaced release {previous.get('version')} has "
+                "no stamped update entry in the tenant; nothing to unassign",
+            )
+
+    rings_state[ring] = {
+        "version": action["version"],
+        "sha256": sha256,
+        "entered_at": run.now.isoformat(),
+    }
+
+    if previous and previous.get("sha256") != sha256:
+        if not _holds_any_ring(state, previous["sha256"]):
+            _retire_release(
+                run, app_id, previous.get("version", "?"), previous["sha256"]
+            )
+
+    run.save_state(app_id)
+    run.applied.append(action)
+    return True
+
+
+def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
+    """Applies an assign_install action.
+
+    Args:
+        run: The apply run context.
+        action: The planned action.
+
+    Returns:
+        True when applied, False when skipped.
+
+    """
+    app_id: str = action["app_id"]
+    sha256: str = action["sha256"]
+    state = run.state_for(app_id)
+    deployed = state.get("deployed") or {}
+
+    if deployed.get("sha256") != sha256:
+        run.skip(action, "stale action - the deployed release has changed")
+        return False
+    if state.get("install_assigned") == sha256:
+        run.skip(action, "already applied")
+        return False
+
+    install_app = find_stamped_app(run.existing_apps, app_id, ENTRY_INSTALL, sha256)
+    if install_app is None:
+        run.skip(action, "no stamped install entry found in the tenant")
+        return False
+
+    group_ids = run.resolve_groups(action["groups"])
+    _add_group_assignments(
+        run.access_token, install_app["id"], group_ids, action["intent"]
+    )
+
+    # Displace the previous release's install assignment.
+    previous_sha = state.get("install_assigned")
+    if previous_sha and previous_sha != sha256:
+        previous_app = find_stamped_app(
+            run.existing_apps, app_id, ENTRY_INSTALL, previous_sha
+        )
+        if previous_app is not None:
+            _remove_group_assignments(run.access_token, previous_app["id"], group_ids)
+        if not _holds_any_ring(state, previous_sha):
+            _retire_release(run, app_id, "?", previous_sha)
+
+    state["install_assigned"] = sha256
+    run.save_state(app_id)
+    run.applied.append(action)
+    return True
+
+
+def apply_plan(
+    recipes: Path,
+    state_dir: Path,
+    plan_file: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Executes a promotion plan against Intune.
+
+    Consumes the plan file when one exists (removing it after a fully
+    successful run); otherwise plans fresh and applies immediately.
+    Deployment state is saved after each applied action, so a failed run
+    resumes safely — already-applied actions validate as no-ops.
+
+    Args:
+        recipes: A recipe YAML file, or a directory scanned recursively.
+        state_dir: State directory holding ``deployment/`` and
+            ``plan.json``.
+        plan_file: Explicit plan file path. When omitted, the default
+            plan location is used if present, else a fresh plan is
+            computed and applied.
+        now: Evaluation clock for ring timestamps and fresh planning.
+            Defaults to the current UTC time.
+
+    Returns:
+        A summary dict with "applied" and "skipped" action lists.
+
+    Raises:
+        AuthError: If authentication fails.
+        ConfigError: On invalid recipes or unresolvable groups.
+        NetworkError: On Graph API failures.
+        StateError: On corrupted deployment state or plan file.
+
+    """
+    logger = get_global_logger()
+    if now is None:
+        now = datetime.now(UTC)
+
+    plan_path = plan_file if plan_file is not None else plan_path_for(state_dir)
+    deployment_dir = state_dir / "deployment"
+
+    from_file = plan_path.exists()
+    if from_file:
+        actions = load_plan_file(plan_path)
+        logger.info("PROMOTE", f"Applying plan file: {plan_path}")
+    else:
+        actions = plan_promotions(recipes, state_dir=deployment_dir, now=now)
+        logger.info("PROMOTE", "No plan file found; planning and applying")
+
+    if not actions:
+        return {"applied": [], "skipped": []}
+
+    configs = {
+        config["id"]: config
+        for config in (
+            load_effective_config(path) for path in _collect_recipe_paths(recipes)
+        )
+    }
+
+    access_token = get_access_token()
+    run = _ApplyRun(access_token, configs, deployment_dir, now)
+
+    for action in actions:
+        if action["app_id"] not in configs:
+            run.skip(action, "no recipe found for this app")
+            continue
+        if action["type"] == "assign_install":
+            _apply_install_action(run, action)
+        else:
+            _apply_ring_action(run, action)
+
+    if from_file:
+        plan_path.unlink()
+        logger.verbose("PROMOTE", f"Consumed plan file: {plan_path}")
+
+    return {"applied": run.applied, "skipped": run.skipped}

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -59,8 +59,9 @@ from napt.state import (
 )
 from napt.upload.auth import get_access_token
 from napt.upload.graph import (
+    VIRTUAL_TARGETS,
     assign_app,
-    build_group_assignment,
+    build_assignment,
     delete_mobile_app,
     get_app_assignments,
     list_mobile_apps,
@@ -116,55 +117,61 @@ def _strip_assignment(assignment: dict[str, Any]) -> dict[str, Any]:
     return cleaned
 
 
-def _targeted_group_id(assignment: dict[str, Any]) -> str | None:
-    """Returns the group ID an assignment targets, or None for other targets."""
-    target = assignment.get("target") or {}
-    return target.get("groupId")
+def _target_key(target: dict[str, Any] | None) -> tuple[str, str]:
+    """Returns a comparable identity for an assignment target."""
+    target = target or {}
+    return (target.get("@odata.type", ""), target.get("groupId", ""))
 
 
-def _add_group_assignments(
+def _add_assignments(
     access_token: str,
     app_id: str,
-    group_ids: list[str],
+    targets: list[dict[str, Any]],
     intent: str,
 ) -> None:
-    """Adds group assignments to an app, preserving everything else.
+    """Adds assignments for the given targets, preserving everything else.
 
-    Existing assignments that target the same groups are replaced (the
-    intent may have changed); all other assignments — admin-made groups,
-    all-devices/all-users targets, exclusions — pass through untouched.
+    Existing assignments with the same targets are replaced (the intent
+    may have changed); all other assignments — admin-made groups, other
+    virtual targets, exclusions — pass through untouched.
 
     Args:
         access_token: Bearer token for Graph API.
         app_id: Graph API object ID of the app.
-        group_ids: Entra ID group object IDs to assign.
-        intent: Assignment intent for the added groups.
+        targets: Resolved assignment target dicts.
+        intent: Assignment intent for the added targets.
 
     """
+    keys = {_target_key(t) for t in targets}
     current = get_app_assignments(access_token, app_id)
     kept = [
-        _strip_assignment(a) for a in current if _targeted_group_id(a) not in group_ids
+        _strip_assignment(a)
+        for a in current
+        if _target_key(a.get("target")) not in keys
     ]
-    added = [build_group_assignment(gid, intent) for gid in group_ids]
+    added = [build_assignment(t, intent) for t in targets]
     assign_app(access_token, app_id, kept + added)
 
 
-def _remove_group_assignments(
+def _remove_assignments(
     access_token: str,
     app_id: str,
-    group_ids: list[str],
+    targets: list[dict[str, Any]],
 ) -> None:
-    """Removes specific group assignments from an app, preserving the rest.
+    """Removes assignments for the given targets, preserving the rest.
 
     Args:
         access_token: Bearer token for Graph API.
         app_id: Graph API object ID of the app.
-        group_ids: Entra ID group object IDs to unassign.
+        targets: Resolved assignment target dicts to unassign.
 
     """
+    keys = {_target_key(t) for t in targets}
     current = get_app_assignments(access_token, app_id)
     kept = [
-        _strip_assignment(a) for a in current if _targeted_group_id(a) not in group_ids
+        _strip_assignment(a)
+        for a in current
+        if _target_key(a.get("target")) not in keys
     ]
     if len(kept) != len(current):
         assign_app(access_token, app_id, kept)
@@ -209,14 +216,27 @@ class _ApplyRun:
             deployment_state_path(self.deployment_dir, app_id),
         )
 
-    def resolve_groups(self, groups: list[str]) -> list[str]:
-        """Resolves group names/IDs to object IDs with a per-run cache."""
-        ids = []
+    def resolve_targets(self, groups: list[str]) -> list[dict[str, Any]]:
+        """Resolves group names/IDs to assignment targets with a per-run cache.
+
+        The reserved names "All Users" and "All Devices" map to Intune's
+        built-in virtual targets; anything else resolves to an Entra ID
+        group target.
+        """
+        targets: list[dict[str, Any]] = []
         for group in groups:
+            if group in VIRTUAL_TARGETS:
+                targets.append(dict(VIRTUAL_TARGETS[group]))
+                continue
             if group not in self._group_ids:
                 self._group_ids[group] = resolve_group_id(self.access_token, group)
-            ids.append(self._group_ids[group])
-        return ids
+            targets.append(
+                {
+                    "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+                    "groupId": self._group_ids[group],
+                }
+            )
+        return targets
 
     def skip(self, action: dict[str, Any], reason: str) -> None:
         """Records a skipped action and warns."""
@@ -314,8 +334,8 @@ def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
         run.skip(action, "no stamped update entry found in the tenant")
         return False
 
-    group_ids = run.resolve_groups(action["groups"])
-    _add_group_assignments(run.access_token, update_app["id"], group_ids, _RING_INTENT)
+    targets = run.resolve_targets(action["groups"])
+    _add_assignments(run.access_token, update_app["id"], targets, _RING_INTENT)
 
     # Displace the previous holder of this ring (an older release's app).
     previous = rings_state.get(ring)
@@ -324,7 +344,7 @@ def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
             run.existing_apps, app_id, ENTRY_UPDATE, previous["sha256"]
         )
         if previous_app is not None:
-            _remove_group_assignments(run.access_token, previous_app["id"], group_ids)
+            _remove_assignments(run.access_token, previous_app["id"], targets)
         else:
             get_global_logger().warning(
                 "PROMOTE",
@@ -368,7 +388,8 @@ def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
     if deployed.get("sha256") != sha256:
         run.skip(action, "stale action - the deployed release has changed")
         return False
-    if state.get("install_assigned") == sha256:
+    previous = state.get("install_assigned") or {}
+    if previous.get("sha256") == sha256:
         run.skip(action, "already applied")
         return False
 
@@ -377,23 +398,26 @@ def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
         run.skip(action, "no stamped install entry found in the tenant")
         return False
 
-    group_ids = run.resolve_groups(action["groups"])
-    _add_group_assignments(
-        run.access_token, install_app["id"], group_ids, action["intent"]
-    )
+    targets = run.resolve_targets(action["groups"])
+    _add_assignments(run.access_token, install_app["id"], targets, action["intent"])
 
     # Displace the previous release's install assignment.
-    previous_sha = state.get("install_assigned")
+    previous_sha = previous.get("sha256")
     if previous_sha and previous_sha != sha256:
         previous_app = find_stamped_app(
             run.existing_apps, app_id, ENTRY_INSTALL, previous_sha
         )
         if previous_app is not None:
-            _remove_group_assignments(run.access_token, previous_app["id"], group_ids)
+            _remove_assignments(run.access_token, previous_app["id"], targets)
         if not _holds_any_ring(state, previous_sha):
-            _retire_release(run, app_id, "?", previous_sha)
+            _retire_release(
+                run, app_id, previous.get("version", "unknown"), previous_sha
+            )
 
-    state["install_assigned"] = sha256
+    state["install_assigned"] = {
+        "version": action["version"],
+        "sha256": sha256,
+    }
     run.save_state(app_id)
     run.applied.append(action)
     return True

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -129,12 +129,15 @@ def _plan_app_actions(
     version: str = deployed["version"]
     sha256: str = deployed["sha256"]
 
-    # Install entry: assigned once, when groups are configured.
+    # Install entry: assigned once per release, when groups are configured.
+    # install_assigned records the sha256 of the release whose install
+    # entry currently carries the assignment, so a new release plans a
+    # fresh assignment (and apply displaces the old one).
     install_cfg: dict[str, Any] = deployment["install"]
     if (
         deployed.get("intune_app_id")
         and install_cfg["groups"]
-        and not state.get("install_assigned")
+        and state.get("install_assigned") != sha256
     ):
         actions.append(
             {

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -130,14 +130,15 @@ def _plan_app_actions(
     sha256: str = deployed["sha256"]
 
     # Install entry: assigned once per release, when groups are configured.
-    # install_assigned records the sha256 of the release whose install
+    # install_assigned records the release (version + sha256) whose install
     # entry currently carries the assignment, so a new release plans a
     # fresh assignment (and apply displaces the old one).
     install_cfg: dict[str, Any] = deployment["install"]
+    install_assigned = state.get("install_assigned") or {}
     if (
         deployed.get("intune_app_id")
         and install_cfg["groups"]
-        and state.get("install_assigned") != sha256
+        and install_assigned.get("sha256") != sha256
     ):
         actions.append(
             {

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -68,7 +68,9 @@ from napt.exceptions import AuthError, ConfigError, NetworkError
 from napt.upload.intunewin import IntunewinMetadata
 
 __all__ = [
+    "VIRTUAL_TARGETS",
     "assign_app",
+    "build_assignment",
     "build_group_assignment",
     "create_win32_app",
     "create_content_version",
@@ -263,6 +265,33 @@ def get_app_assignments(access_token: str, app_id: str) -> list[dict]:
     return body.get("value", [])
 
 
+# Intune's built-in virtual assignment targets, reserved by these exact
+# names in deployment group lists. A real Entra ID group that happens to
+# share one of these display names must be referenced by object ID.
+VIRTUAL_TARGETS: dict[str, dict] = {
+    "All Users": {"@odata.type": "#microsoft.graph.allLicensedUsersAssignmentTarget"},
+    "All Devices": {"@odata.type": "#microsoft.graph.allDevicesAssignmentTarget"},
+}
+
+
+def build_assignment(target: dict, intent: str) -> dict:
+    """Build a mobileAppAssignment payload for a resolved target.
+
+    Args:
+        target: An assignment target dict (group or virtual target).
+        intent: Assignment intent, "available" or "required".
+
+    Returns:
+        A mobileAppAssignment dict for use with assign_app.
+
+    """
+    return {
+        "@odata.type": "#microsoft.graph.mobileAppAssignment",
+        "intent": intent,
+        "target": target,
+    }
+
+
 def build_group_assignment(group_id: str, intent: str) -> dict:
     """Build a mobileAppAssignment payload targeting one Entra ID group.
 
@@ -274,14 +303,13 @@ def build_group_assignment(group_id: str, intent: str) -> dict:
         A mobileAppAssignment dict for use with assign_app.
 
     """
-    return {
-        "@odata.type": "#microsoft.graph.mobileAppAssignment",
-        "intent": intent,
-        "target": {
+    return build_assignment(
+        {
             "@odata.type": "#microsoft.graph.groupAssignmentTarget",
             "groupId": group_id,
         },
-    }
+        intent,
+    )
 
 
 def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -114,7 +114,7 @@ def _json_headers(access_token: str) -> dict[str, str]:
 
 
 def _check_response(response: requests.Response, context: str) -> dict:
-    """Check an HTTP response and raise the appropriate NAPT exception.
+    """Checks an HTTP response and raises the appropriate NAPT exception.
 
     Args:
         response: The HTTP response to check.
@@ -158,7 +158,7 @@ def _poll(
     success_state: str,
     context: str,
 ) -> dict:
-    """Poll a Graph API endpoint until the expected uploadState is reached.
+    """Polls a Graph API endpoint until the expected uploadState is reached.
 
     Args:
         access_token: Bearer token for Authorization header.
@@ -199,7 +199,7 @@ _GUID_RE = re.compile(
 
 
 def resolve_group_id(access_token: str, group: str) -> str:
-    """Resolve an Entra ID group name or object ID to an object ID.
+    """Resolves an Entra ID group name or object ID to an object ID.
 
     Values that already look like object IDs (GUIDs) pass through without
     a Graph call. Names are looked up by exact displayName match, which
@@ -245,7 +245,7 @@ def resolve_group_id(access_token: str, group: str) -> str:
 
 
 def get_app_assignments(access_token: str, app_id: str) -> list[dict]:
-    """Get the current assignments of a mobile app.
+    """Gets the current assignments of a mobile app.
 
     Args:
         access_token: Bearer token for Graph API.
@@ -275,7 +275,7 @@ VIRTUAL_TARGETS: dict[str, dict] = {
 
 
 def build_assignment(target: dict, intent: str) -> dict:
-    """Build a mobileAppAssignment payload for a resolved target.
+    """Builds a mobileAppAssignment payload for a resolved target.
 
     Args:
         target: An assignment target dict (group or virtual target).
@@ -293,7 +293,7 @@ def build_assignment(target: dict, intent: str) -> dict:
 
 
 def build_group_assignment(group_id: str, intent: str) -> dict:
-    """Build a mobileAppAssignment payload targeting one Entra ID group.
+    """Builds a mobileAppAssignment payload targeting one Entra ID group.
 
     Args:
         group_id: Object ID of the target group.
@@ -313,7 +313,7 @@ def build_group_assignment(group_id: str, intent: str) -> dict:
 
 
 def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:
-    """Set a mobile app's assignments.
+    """Sets a mobile app's assignments.
 
     The assign action replaces the app's entire assignment set. Callers
     that intend to preserve existing assignments must read them first with
@@ -339,7 +339,7 @@ def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:
 
 
 def list_mobile_apps(access_token: str) -> list[dict]:
-    """List all mobile apps in the tenant with id, displayName, and notes.
+    """Lists all mobile apps in the tenant with id, displayName, and notes.
 
     Follows @odata.nextLink pagination until the collection is exhausted.
 
@@ -368,7 +368,7 @@ def list_mobile_apps(access_token: str) -> list[dict]:
 
 
 def delete_mobile_app(access_token: str, app_id: str) -> None:
-    """Delete a mobile app from Intune.
+    """Deletes a mobile app from Intune.
 
     A 404 is tolerated — the app being already gone is the desired end
     state, so retried deletions stay idempotent.
@@ -390,7 +390,7 @@ def delete_mobile_app(access_token: str, app_id: str) -> None:
 
 
 def get_mobile_app(access_token: str, app_id: str) -> dict:
-    """Get one mobile app's full object by Graph API ID.
+    """Gets one mobile app's full object by Graph API ID.
 
     Used to read subtype fields that $select on the collection cannot
     reliably return, such as win32LobApp.committedContentVersion.
@@ -413,7 +413,7 @@ def get_mobile_app(access_token: str, app_id: str) -> dict:
 
 
 def create_win32_app(access_token: str, app_metadata: dict) -> str:
-    """Create a new Win32 LOB app record in Intune.
+    """Creates a new Win32 LOB app record in Intune.
 
     Args:
         access_token: Bearer token for Graph API.
@@ -438,7 +438,7 @@ def create_win32_app(access_token: str, app_metadata: dict) -> str:
 
 
 def update_win32_app(access_token: str, app_id: str, app_metadata: dict) -> None:
-    """Update an existing Win32 LOB app record's metadata in Intune.
+    """Updates an existing Win32 LOB app record's metadata in Intune.
 
     Args:
         access_token: Bearer token for Graph API.
@@ -459,7 +459,7 @@ def update_win32_app(access_token: str, app_id: str, app_metadata: dict) -> None
 
 
 def create_content_version(access_token: str, app_id: str) -> str:
-    """Create a new content version for a Win32 app.
+    """Creates a new content version for a Win32 app.
 
     Args:
         access_token: Bearer token for Graph API.
@@ -488,7 +488,7 @@ def create_content_version_file(
     cv_id: str,
     metadata: IntunewinMetadata,
 ) -> tuple[str, str]:
-    """Create a file entry for a content version and wait for the SAS URI.
+    """Creates a file entry for a content version and waits for the SAS URI.
 
     Posts the file size information to Graph API, then polls until Azure
     Storage has provisioned a SAS URI for the upload.
@@ -540,7 +540,7 @@ def upload_to_azure_blob(
     sas_uri: str,
     encrypted_payload_path: Path,
 ) -> None:
-    """Upload the encrypted payload to Azure Blob Storage using block blobs.
+    """Uploads the encrypted payload to Azure Blob Storage using block blobs.
 
     Splits the file into CHUNK_SIZE chunks, uploads each as a block with a
     base64-encoded block ID, then commits the block list. Prints an inline
@@ -637,7 +637,7 @@ def commit_content_version_file(
     file_id: str,
     metadata: IntunewinMetadata,
 ) -> None:
-    """Commit the uploaded file with encryption metadata, then wait for confirmation.
+    """Commits the uploaded file with encryption metadata, then waits for confirmation.
 
     Sends the encryption key, MAC, IV, and digest to Graph API, then polls
     until Intune confirms the file is committed.
@@ -689,7 +689,7 @@ def commit_content_version_file(
 
 
 def commit_content_version(access_token: str, app_id: str, cv_id: str) -> None:
-    """Set the committed content version on the Win32 app.
+    """Sets the committed content version on the Win32 app.
 
     This is the final step — after calling this, the app is fully published
     in Intune and available for assignment.

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -73,6 +73,7 @@ __all__ = [
     "create_win32_app",
     "create_content_version",
     "create_content_version_file",
+    "delete_mobile_app",
     "get_app_assignments",
     "get_mobile_app",
     "list_mobile_apps",
@@ -336,6 +337,28 @@ def list_mobile_apps(access_token: str) -> list[dict]:
         apps.extend(body.get("value", []))
         url = body.get("@odata.nextLink")
     return apps
+
+
+def delete_mobile_app(access_token: str, app_id: str) -> None:
+    """Delete a mobile app from Intune.
+
+    A 404 is tolerated — the app being already gone is the desired end
+    state, so retried deletions stay idempotent.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        app_id: Graph API object ID of the app to delete.
+
+    Raises:
+        AuthError: On 401 or 403.
+        NetworkError: On 5xx or connection error.
+
+    """
+    url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
+    resp = requests.delete(url, headers=_auth_headers(access_token), timeout=30)
+    if resp.status_code == 404:
+        return
+    _check_response(resp, "delete_mobile_app")
 
 
 def get_mobile_app(access_token: str, app_id: str) -> dict:

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -63,7 +63,12 @@ from napt.upload.graph import (
     upload_to_azure_blob,
 )
 from napt.upload.intunewin import extract_encrypted_payload, parse_intunewin
-from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, build_stamp, parse_stamp
+from napt.upload.stamp import (
+    ENTRY_INSTALL,
+    ENTRY_UPDATE,
+    build_stamp,
+    find_stamped_app,
+)
 
 __all__ = ["upload_package"]
 
@@ -489,36 +494,6 @@ def _build_app_metadata(
     return payload
 
 
-def _find_stamped_app(
-    apps: list[dict[str, Any]],
-    recipe_id: str,
-    entry: str,
-    sha256: str,
-) -> dict[str, Any] | None:
-    """Finds the app whose provenance stamp matches a publish instance.
-
-    Args:
-        apps: Mobile app dicts from list_mobile_apps.
-        recipe_id: Recipe identifier to match.
-        entry: Entry type to match ("install" or "update").
-        sha256: Installer hash to match.
-
-    Returns:
-        The matching app dict, or None when no stamped app matches.
-
-    """
-    for app in apps:
-        stamp = parse_stamp(app.get("notes"))
-        if (
-            stamp
-            and stamp["id"] == recipe_id
-            and stamp["entry"] == entry
-            and stamp["sha256"] == sha256
-        ):
-            return app
-    return None
-
-
 def _upload_app_content(
     access_token: str,
     intune_app_id: str,
@@ -615,7 +590,7 @@ def _upload_single_app(
     logger = get_global_logger()
     display_name: str = app_metadata["displayName"]
 
-    match = _find_stamped_app(existing_apps, recipe_id, entry, installer_sha256)
+    match = find_stamped_app(existing_apps, recipe_id, entry, installer_sha256)
     patch_metadata_after_content = False
     if match is not None:
         intune_app_id: str = match["id"]

--- a/napt/upload/stamp.py
+++ b/napt/upload/stamp.py
@@ -68,6 +68,36 @@ def build_stamp(recipe_id: str, entry: str, sha256: str) -> str:
     return stamp
 
 
+def find_stamped_app(
+    apps: list[dict],
+    recipe_id: str,
+    entry: str,
+    sha256: str,
+) -> dict | None:
+    """Finds the app whose provenance stamp matches a publish instance.
+
+    Args:
+        apps: Mobile app dicts (with "notes") from list_mobile_apps.
+        recipe_id: Recipe identifier to match.
+        entry: Entry type to match ("install" or "update").
+        sha256: Installer hash to match.
+
+    Returns:
+        The matching app dict, or None when no stamped app matches.
+
+    """
+    for app in apps:
+        stamp = parse_stamp(app.get("notes"))
+        if (
+            stamp
+            and stamp["id"] == recipe_id
+            and stamp["entry"] == entry
+            and stamp["sha256"] == sha256
+        ):
+            return app
+    return None
+
+
 def parse_stamp(notes: str | None) -> dict[str, str] | None:
     """Parses a provenance stamp from an Intune notes field value.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from napt.cli import (
     cmd_discover,
     cmd_init,
     cmd_package,
+    cmd_promote_apply,
     cmd_promote_plan,
     cmd_status,
     cmd_upload,
@@ -843,3 +844,79 @@ class TestCmdStatus:
 
         assert code == 0
         assert "No deployment state found" in capsys.readouterr().out
+
+
+# =============================================================================
+# cmd_promote_apply
+# =============================================================================
+
+
+class TestCmdPromoteApply:
+    """Tests for cmd_promote_apply handler."""
+
+    def test_applied_actions_print_and_return_zero(self, tmp_path, capsys):
+        """Tests that applied and skipped actions are summarized."""
+        summary = {
+            "applied": [
+                {
+                    "type": "enter_ring",
+                    "app_id": "test-app",
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "ring": "pilot",
+                    "groups": ["sg-pilot"],
+                }
+            ],
+            "skipped": [
+                {
+                    "action": {
+                        "type": "assign_install",
+                        "app_id": "other-app",
+                        "version": "1.0.0",
+                        "sha256": "b" * 64,
+                        "intent": "available",
+                        "groups": ["All Users"],
+                    },
+                    "reason": "already applied",
+                }
+            ],
+        }
+        with patch("napt.cli.apply_plan", return_value=summary):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "[OK]" in out
+        assert "[SKIP]" in out
+        assert "already applied" in out
+        assert "Applied 1 action(s), skipped 1." in out
+
+    def test_nothing_to_apply_returns_zero(self, tmp_path, capsys):
+        """Tests that an empty summary reports cleanly."""
+        with patch("napt.cli.apply_plan", return_value={"applied": [], "skipped": []}):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 0
+        assert "Nothing to apply" in capsys.readouterr().out
+
+    def test_auth_error_returns_one(self, tmp_path, capsys):
+        """Tests that AuthError is caught and returns 1."""
+        with patch("napt.cli.apply_plan", side_effect=AuthError("no creds")):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 1
+        assert "Authentication error" in capsys.readouterr().out
+
+    def test_state_error_returns_one(self, tmp_path, capsys):
+        """Tests that StateError is caught and returns 1."""
+        from napt.exceptions import StateError
+
+        with patch("napt.cli.apply_plan", side_effect=StateError("bad plan")):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 1
+        assert "bad plan" in capsys.readouterr().out

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -94,7 +94,7 @@ def _write_state(
     if rings:
         state["rings"] = rings
     if install_assigned:
-        state["install_assigned"] = install_assigned
+        state["install_assigned"] = {"version": "prev", "sha256": install_assigned}
     save_deployment_state(state, deployment_state_path(deployment_dir, app_id))
     return deployment_dir
 
@@ -165,6 +165,15 @@ class TestPlanPromotions:
             tmp_path, deployed=_deployed(), install_assigned="a" * 64
         )
         assert plan_promotions(recipe, state_dir=state_dir, now=NOW) == []
+
+    def test_no_install_groups_plans_no_install_assignment(self, tmp_path):
+        """Tests that NAPT assigns nothing unless groups are configured."""
+        recipe = _write_recipe(tmp_path)  # no deployment section at all
+        state_dir = _write_state(tmp_path, deployed=_deployed())
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert actions == []
 
     def test_new_release_replans_install_assignment(self, tmp_path):
         """Tests that a new release plans install assignment again."""

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -85,7 +85,7 @@ def _write_state(
     app_id: str = "test-app",
     deployed: dict[str, Any] | None = None,
     rings: dict[str, Any] | None = None,
-    install_assigned: bool = False,
+    install_assigned: str | None = None,
 ) -> Path:
     """Writes a deployment state file and returns the deployment dir."""
     deployment_dir = tmp_path / "state" / "deployment"
@@ -94,7 +94,7 @@ def _write_state(
     if rings:
         state["rings"] = rings
     if install_assigned:
-        state["install_assigned"] = True
+        state["install_assigned"] = install_assigned
     save_deployment_state(state, deployment_state_path(deployment_dir, app_id))
     return deployment_dir
 
@@ -161,8 +161,24 @@ class TestPlanPromotions:
             }
         ]
 
-        state_dir = _write_state(tmp_path, deployed=_deployed(), install_assigned=True)
+        state_dir = _write_state(
+            tmp_path, deployed=_deployed(), install_assigned="a" * 64
+        )
         assert plan_promotions(recipe, state_dir=state_dir, now=NOW) == []
+
+    def test_new_release_replans_install_assignment(self, tmp_path):
+        """Tests that a new release plans install assignment again."""
+        recipe = _write_recipe(tmp_path, install_groups=["All Users"])
+        state_dir = _write_state(
+            tmp_path,
+            deployed=_deployed(version="2.0.0", sha256="b" * 64),
+            install_assigned="a" * 64,  # previous release's assignment
+        )
+
+        actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
+
+        assert [a["type"] for a in actions] == ["assign_install"]
+        assert actions[0]["sha256"] == "b" * 64
 
     def test_baking_release_does_not_advance(self, tmp_path):
         """Tests that a release still baking holds its ring."""

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -95,7 +95,7 @@ def _write_state(
     if retained:
         state["retained"] = retained
     if install_assigned:
-        state["install_assigned"] = install_assigned
+        state["install_assigned"] = {"version": "prev", "sha256": install_assigned}
     path = deployment_state_path(tmp_path / "state" / "deployment", app_id)
     save_deployment_state(state, path)
     return path
@@ -417,9 +417,21 @@ class TestApplyInstallActions:
         assert len(summary["applied"]) == 1
         call = mocks["assign_app"].call_args
         assert call.args[1] == "install-new"
-        assert call.args[2][0]["intent"] == "available"
+        # "All Users" is Intune's built-in virtual target, not a group
+        assert call.args[2] == [
+            {
+                "@odata.type": "#microsoft.graph.mobileAppAssignment",
+                "intent": "available",
+                "target": {
+                    "@odata.type": (
+                        "#microsoft.graph.allLicensedUsersAssignmentTarget"
+                    ),
+                },
+            }
+        ]
+        mocks["resolve_group_id"].assert_not_called()
         state = load_deployment_state(state_path)
-        assert state["install_assigned"] == "b" * 64
+        assert state["install_assigned"] == {"version": "2.0.0", "sha256": "b" * 64}
 
     def test_displaces_previous_install_assignment(self, tmp_path):
         """Tests that the previous release's install entry loses the groups."""
@@ -430,8 +442,7 @@ class TestApplyInstallActions:
             "id": "x",
             "intent": "available",
             "target": {
-                "@odata.type": "#microsoft.graph.groupAssignmentTarget",
-                "groupId": "gid-All Users",
+                "@odata.type": "#microsoft.graph.allLicensedUsersAssignmentTarget",
             },
         }
 

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -1,0 +1,506 @@
+"""Tests for napt.promote.applier."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from napt.exceptions import NetworkError, StateError
+from napt.promote import apply_plan, load_plan_file, plan_path_for
+from napt.state import (
+    create_default_deployment_state,
+    deployment_state_path,
+    load_deployment_state,
+    save_deployment_state,
+)
+
+NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=UTC)
+
+_RINGS = [
+    {"name": "pilot", "groups": ["Pilot Devices"], "promote_after_days": 2},
+    {"name": "broad", "groups": ["Broad Devices"], "promote_after_days": 5},
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_project(tmp_path, monkeypatch):
+    """Makes each test a self-contained NAPT project.
+
+    pytest's basetemp lives inside the repo (.pytest-tmp), so the config
+    loader's upward walk from a test recipe would otherwise find the
+    repo's own defaults/org.yaml. A minimal org.yaml in tmp_path stops
+    the walk there.
+    """
+    monkeypatch.chdir(tmp_path)
+    org = tmp_path / "defaults" / "org.yaml"
+    org.parent.mkdir(parents=True, exist_ok=True)
+    org.write_text("apiVersion: napt/v1\n", encoding="utf-8")
+
+
+def _write_recipe(
+    tmp_path: Path,
+    app_id: str = "test-app",
+    rings: list[dict[str, Any]] | None = None,
+    install_groups: list[str] | None = None,
+    retain_versions: int | None = None,
+) -> Path:
+    """Writes a minimal recipe with a deployment section."""
+    deployment: dict[str, Any] = {}
+    if rings is not None:
+        deployment["rings"] = rings
+    if install_groups is not None:
+        deployment["install"] = {"intent": "available", "groups": install_groups}
+    if retain_versions is not None:
+        deployment["retain_versions"] = retain_versions
+
+    recipe: dict[str, Any] = {
+        "apiVersion": "napt/v1",
+        "name": f"App {app_id}",
+        "id": app_id,
+        "discovery": {
+            "strategy": "url_download",
+            "url": "https://example.com/app.msi",
+        },
+    }
+    if deployment:
+        recipe["deployment"] = deployment
+
+    recipes_dir = tmp_path / "recipes"
+    recipes_dir.mkdir(exist_ok=True)
+    path = recipes_dir / f"{app_id}.yaml"
+    path.write_text(yaml.dump(recipe), encoding="utf-8")
+    return path
+
+
+def _write_state(
+    tmp_path: Path,
+    app_id: str = "test-app",
+    deployed: dict[str, Any] | None = None,
+    rings: dict[str, Any] | None = None,
+    retained: list[dict[str, Any]] | None = None,
+    install_assigned: str | None = None,
+) -> Path:
+    """Writes a deployment state file and returns its path."""
+    state = create_default_deployment_state()
+    state["deployed"] = deployed
+    if rings:
+        state["rings"] = rings
+    if retained:
+        state["retained"] = retained
+    if install_assigned:
+        state["install_assigned"] = install_assigned
+    path = deployment_state_path(tmp_path / "state" / "deployment", app_id)
+    save_deployment_state(state, path)
+    return path
+
+
+def _deployed(version: str = "2.0.0", sha256: str = "b" * 64) -> dict[str, Any]:
+    return {
+        "version": version,
+        "sha256": sha256,
+        "intune_app_id": "install-new",
+        "intune_update_app_id": "update-new",
+    }
+
+
+def _stamped(app_id: str, entry: str, sha256: str, graph_id: str) -> dict[str, Any]:
+    return {
+        "id": graph_id,
+        "displayName": app_id,
+        "notes": f"napt/v1 id={app_id} entry={entry} sha256={sha256}",
+    }
+
+
+def _tenant(sha_new: str = "b" * 64, sha_old: str = "a" * 64) -> list[dict[str, Any]]:
+    """Returns a fake tenant with stamped apps for two releases."""
+    return [
+        _stamped("test-app", "install", sha_new, "install-new"),
+        _stamped("test-app", "update", sha_new, "update-new"),
+        _stamped("test-app", "install", sha_old, "install-old"),
+        _stamped("test-app", "update", sha_old, "update-old"),
+        {"id": "foreign", "displayName": "Hand-made", "notes": "by an admin"},
+    ]
+
+
+def _run_apply(
+    tmp_path: Path,
+    existing_apps: list[dict[str, Any]] | None = None,
+    assignments: dict[str, list[dict[str, Any]]] | None = None,
+    assign_side_effect: Any = None,
+) -> tuple[dict[str, Any], dict[str, MagicMock]]:
+    """Runs apply_plan with all Graph calls mocked.
+
+    Args:
+        tmp_path: Test project directory.
+        existing_apps: list_mobile_apps return value.
+        assignments: Map of app graph ID to current assignment list
+            (default empty for every app).
+        assign_side_effect: Optional side effect for assign_app.
+
+    Returns:
+        A tuple of (summary, mocks).
+
+    """
+    assignments = assignments or {}
+    mocks = {
+        "assign_app": MagicMock(side_effect=assign_side_effect),
+        "delete_mobile_app": MagicMock(),
+        "get_app_assignments": MagicMock(
+            side_effect=lambda token, app_id: list(assignments.get(app_id, []))
+        ),
+        "resolve_group_id": MagicMock(side_effect=lambda token, g: f"gid-{g}"),
+    }
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("napt.promote.applier.get_access_token", return_value="tok")
+        )
+        stack.enter_context(
+            patch(
+                "napt.promote.applier.list_mobile_apps",
+                return_value=existing_apps if existing_apps is not None else [],
+            )
+        )
+        for name, mock in mocks.items():
+            stack.enter_context(patch(f"napt.promote.applier.{name}", mock))
+        summary = apply_plan(
+            tmp_path / "recipes",
+            state_dir=tmp_path / "state",
+            now=NOW,
+        )
+
+    return summary, mocks
+
+
+def _write_plan(tmp_path: Path, actions: list[dict[str, Any]]) -> Path:
+    plan_path = plan_path_for(tmp_path / "state")
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text(
+        json.dumps({"actions": actions}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return plan_path
+
+
+def _enter_ring_action(
+    sha256: str = "b" * 64, version: str = "2.0.0"
+) -> dict[str, Any]:
+    return {
+        "type": "enter_ring",
+        "app_id": "test-app",
+        "version": version,
+        "sha256": sha256,
+        "ring": "pilot",
+        "groups": ["Pilot Devices"],
+    }
+
+
+class TestApplyRingActions:
+    """Tests for enter_ring and advance_ring execution."""
+
+    def test_enter_ring_assigns_and_records(self, tmp_path):
+        """Tests that entering a ring assigns groups and writes state."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        state_path = _write_state(tmp_path, deployed=_deployed())
+        plan_path = _write_plan(tmp_path, [_enter_ring_action()])
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert len(summary["applied"]) == 1
+        assert summary["skipped"] == []
+        # Assigned the ring group (required) to the new update app
+        call = mocks["assign_app"].call_args
+        assert call.args[1] == "update-new"
+        assert call.args[2] == [
+            {
+                "@odata.type": "#microsoft.graph.mobileAppAssignment",
+                "intent": "required",
+                "target": {
+                    "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+                    "groupId": "gid-Pilot Devices",
+                },
+            }
+        ]
+        # State records the ring with the apply timestamp
+        state = load_deployment_state(state_path)
+        assert state["rings"]["pilot"] == {
+            "version": "2.0.0",
+            "sha256": "b" * 64,
+            "entered_at": NOW.isoformat(),
+        }
+        # Plan file consumed
+        assert not plan_path.exists()
+
+    def test_preserves_foreign_assignments(self, tmp_path):
+        """Tests that admin-made assignments survive the assign call."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed())
+        _write_plan(tmp_path, [_enter_ring_action()])
+        admin_assignment = {
+            "id": "existing-1",
+            "intent": "available",
+            "target": {"@odata.type": "#microsoft.graph.allDevicesAssignmentTarget"},
+        }
+
+        _, mocks = _run_apply(
+            tmp_path,
+            existing_apps=_tenant(),
+            assignments={"update-new": [admin_assignment]},
+        )
+
+        sent = mocks["assign_app"].call_args.args[2]
+        assert {
+            "@odata.type": "#microsoft.graph.mobileAppAssignment",
+            "intent": "available",
+            "target": {"@odata.type": "#microsoft.graph.allDevicesAssignmentTarget"},
+        } in sent
+        assert all("id" not in a for a in sent)
+
+    def test_displacement_unassigns_previous_release(self, tmp_path):
+        """Tests that the displaced release loses the ring's groups."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        state_path = _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "2026-07-01T00:00:00+00:00",
+                }
+            },
+        )
+        _write_plan(tmp_path, [_enter_ring_action()])
+        old_assignment = {
+            "id": "x",
+            "intent": "required",
+            "target": {
+                "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+                "groupId": "gid-Pilot Devices",
+            },
+        }
+
+        summary, mocks = _run_apply(
+            tmp_path,
+            existing_apps=_tenant(),
+            assignments={"update-old": [old_assignment]},
+        )
+
+        assert len(summary["applied"]) == 1
+        # Second assign call strips the pilot group from the old app
+        targets = [c.args[1] for c in mocks["assign_app"].call_args_list]
+        assert targets == ["update-new", "update-old"]
+        assert mocks["assign_app"].call_args_list[1].args[2] == []
+        # Old release holds nothing and moves to retained
+        state = load_deployment_state(state_path)
+        assert state["retained"] == [{"version": "1.0.0", "sha256": "a" * 64}]
+        mocks["delete_mobile_app"].assert_not_called()
+
+    def test_retention_deletes_beyond_limit(self, tmp_path):
+        """Tests that displaced releases beyond retain_versions are deleted."""
+        _write_recipe(tmp_path, rings=_RINGS, retain_versions=1)
+        _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "entered_at": "2026-07-01T00:00:00+00:00",
+                }
+            },
+            retained=[{"version": "0.9.0", "sha256": "9" * 64}],
+        )
+        _write_plan(tmp_path, [_enter_ring_action()])
+        tenant = _tenant() + [
+            _stamped("test-app", "install", "9" * 64, "install-ancient"),
+            _stamped("test-app", "update", "9" * 64, "update-ancient"),
+        ]
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=tenant)
+
+        assert len(summary["applied"]) == 1
+        deleted = [c.args[1] for c in mocks["delete_mobile_app"].call_args_list]
+        assert deleted == ["install-ancient", "update-ancient"]
+
+    def test_stale_action_skipped(self, tmp_path):
+        """Tests that an action for a superseded release is skipped."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed(version="3.0.0", sha256="c" * 64))
+        _write_plan(tmp_path, [_enter_ring_action()])  # plans v2, deployed v3
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert summary["applied"] == []
+        assert len(summary["skipped"]) == 1
+        assert "stale" in summary["skipped"][0]["reason"]
+        mocks["assign_app"].assert_not_called()
+
+    def test_already_applied_skipped(self, tmp_path):
+        """Tests that an already-held ring skips idempotently."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(
+            tmp_path,
+            deployed=_deployed(),
+            rings={
+                "pilot": {
+                    "version": "2.0.0",
+                    "sha256": "b" * 64,
+                    "entered_at": "2026-07-01T00:00:00+00:00",
+                }
+            },
+        )
+        _write_plan(tmp_path, [_enter_ring_action()])
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert summary["applied"] == []
+        assert summary["skipped"][0]["reason"] == "already applied"
+        mocks["assign_app"].assert_not_called()
+
+    def test_missing_update_app_skipped(self, tmp_path):
+        """Tests that a release without a stamped update entry is skipped."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed())
+        _write_plan(tmp_path, [_enter_ring_action()])
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=[])
+
+        assert summary["applied"] == []
+        assert "no stamped update entry" in summary["skipped"][0]["reason"]
+        mocks["assign_app"].assert_not_called()
+
+    def test_failure_keeps_plan_file(self, tmp_path):
+        """Tests that a Graph failure leaves the plan file for retry."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed())
+        plan_path = _write_plan(tmp_path, [_enter_ring_action()])
+
+        with pytest.raises(NetworkError):
+            _run_apply(
+                tmp_path,
+                existing_apps=_tenant(),
+                assign_side_effect=NetworkError("Graph down"),
+            )
+
+        assert plan_path.exists()
+
+
+class TestApplyInstallActions:
+    """Tests for assign_install execution."""
+
+    def _install_action(self, sha256: str = "b" * 64) -> dict[str, Any]:
+        return {
+            "type": "assign_install",
+            "app_id": "test-app",
+            "version": "2.0.0",
+            "sha256": sha256,
+            "intent": "available",
+            "groups": ["All Users"],
+        }
+
+    def test_assigns_and_records_release(self, tmp_path):
+        """Tests that the install entry is assigned and recorded by sha."""
+        _write_recipe(tmp_path, install_groups=["All Users"])
+        state_path = _write_state(tmp_path, deployed=_deployed())
+        _write_plan(tmp_path, [self._install_action()])
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert len(summary["applied"]) == 1
+        call = mocks["assign_app"].call_args
+        assert call.args[1] == "install-new"
+        assert call.args[2][0]["intent"] == "available"
+        state = load_deployment_state(state_path)
+        assert state["install_assigned"] == "b" * 64
+
+    def test_displaces_previous_install_assignment(self, tmp_path):
+        """Tests that the previous release's install entry loses the groups."""
+        _write_recipe(tmp_path, install_groups=["All Users"])
+        _write_state(tmp_path, deployed=_deployed(), install_assigned="a" * 64)
+        _write_plan(tmp_path, [self._install_action()])
+        old_assignment = {
+            "id": "x",
+            "intent": "available",
+            "target": {
+                "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+                "groupId": "gid-All Users",
+            },
+        }
+
+        summary, mocks = _run_apply(
+            tmp_path,
+            existing_apps=_tenant(),
+            assignments={"install-old": [old_assignment]},
+        )
+
+        assert len(summary["applied"]) == 1
+        targets = [c.args[1] for c in mocks["assign_app"].call_args_list]
+        assert targets == ["install-new", "install-old"]
+        assert mocks["assign_app"].call_args_list[1].args[2] == []
+
+
+class TestApplyOrchestration:
+    """Tests for plan sourcing and file lifecycle."""
+
+    def test_bare_apply_plans_fresh(self, tmp_path):
+        """Tests that apply without a plan file plans and applies."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        state_path = _write_state(tmp_path, deployed=_deployed())
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert len(summary["applied"]) == 1
+        assert mocks["assign_app"].call_count == 1
+        state = load_deployment_state(state_path)
+        assert state["rings"]["pilot"]["sha256"] == "b" * 64
+
+    def test_nothing_to_apply(self, tmp_path):
+        """Tests that no plan and no eligible actions is a clean no-op."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=None)
+
+        summary, mocks = _run_apply(tmp_path, existing_apps=[])
+
+        assert summary == {"applied": [], "skipped": []}
+        mocks["assign_app"].assert_not_called()
+
+    def test_unknown_app_in_plan_skipped(self, tmp_path):
+        """Tests that a plan action without a matching recipe is skipped."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed())
+        action = _enter_ring_action()
+        action["app_id"] = "ghost-app"
+        _write_plan(tmp_path, [action])
+
+        summary, _ = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert summary["applied"] == []
+        assert "no recipe" in summary["skipped"][0]["reason"]
+
+
+class TestLoadPlanFile:
+    """Tests for plan file loading."""
+
+    def test_corrupted_plan_raises(self, tmp_path):
+        """Tests that invalid plan JSON raises StateError."""
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text("not json{{{", encoding="utf-8")
+
+        with pytest.raises(StateError, match="Corrupted plan file"):
+            load_plan_file(plan_path)
+
+    def test_missing_actions_key_raises(self, tmp_path):
+        """Tests that a plan without an actions list raises StateError."""
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text('{"other": []}', encoding="utf-8")
+
+        with pytest.raises(StateError, match="Corrupted plan file"):
+            load_plan_file(plan_path)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -952,6 +952,20 @@ deployment:
         assert len(groups_errors) == 1
         assert "Must be list" in groups_errors[0]
 
+    def test_virtual_targets_valid(self, tmp_path):
+        """Tests that Intune's built-in targets pass validation."""
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(_DEPLOYMENT_RECIPE_HEADER + """
+deployment:
+  install:
+    intent: "available"
+    groups: ["All Users", "All Devices"]
+""")
+
+        result = validate_recipe(recipe)
+
+        assert result.status == "valid"
+
     def test_non_string_group_error(self, tmp_path):
         """Tests that a non-string group entry is detected."""
         recipe = tmp_path / "recipe.yaml"


### PR DESCRIPTION
## Description

`napt promote apply` executes promotion plans against Intune: assigns install entries, enters and advances releases through rings (required-intent assignments on the `[Update]` entry), unassigns displaced releases, and retires them per `deployment.retain_versions`. Consumes `state/plan.json` when present (removed after a fully successful run); plans fresh and applies otherwise.

## Motivation

Completes the promotion engine''s act half. Validate-then-act per action (stale/already-applied entries skip with a warning) plus state saved after every action makes re-running after partial failure safe. Ring `entered_at` timestamps are written here and only here. Displaced releases are located by provenance stamp — Intune as source of truth — since state only records the current release''s app IDs.

## Changes

- New `napt/promote/applier.py` + `napt promote apply` CLI subcommand
- Retention: fully displaced releases join `retained[]`; beyond `retain_versions`, their stamped Intune apps are deleted (never the deployed release, never unstamped apps)
- Assignment writes are read-modify-write: admin-made assignments and non-group targets always preserved
- Fixed a PR 5 latent bug: `install_assigned` now records the release sha instead of a boolean, so each new release gets its install entry assigned (and the previous one displaced)
- `find_stamped_app` moved to `napt/upload/stamp.py` for shared use; new `delete_mobile_app` Graph helper (404-tolerant)
- Docs: promote apply + rings workflow in common-tasks, flag/config table rows (deferred from PR 85 review), recipe-reference notes now describe live behavior

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

670 tests pass; applier covered with mocked Graph: assignment payloads, foreign-assignment preservation, displacement, retention deletes, stale/already-applied/missing-app skips, plan-file consumption and retry-on-failure, bare apply. Not yet exercised against a live tenant — the first real `promote plan` + `apply` run against the dev tenant''s ring groups is the recommended pre-merge test.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors