### PR TITLE
feat: Add drift detection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Assignment drift detection** - `napt promote apply` (always) and
+    `napt promote plan --check-drift` (opt-in) compare Intune assignments
+    against deployment state and warn on every discrepancy: removed or
+    changed NAPT assignments, admin-made assignments on NAPT-managed
+    apps, releases missing from the tenant, and stamped apps no state
+    references. Drift is reported, never corrected.
 - **Built-in assignment targets** - `"All Users"` and `"All Devices"` in
     deployment group lists assign Intune's virtual targets instead of
     Entra ID groups. A real group sharing one of these display names must

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -714,6 +714,11 @@ release has proven itself.
    Ring groups are assigned to the release's `[Update]` entry as required
    installs; the displaced older release is unassigned and retired per
    `deployment.retain_versions`.
+   Every apply also prints a drift check — discrepancies between
+   deployment state and Intune (removed assignments, admin-made changes,
+   stray apps) are warned about, never corrected.
+   Use `napt promote plan --check-drift` for the same report without
+   applying anything.
    Run `napt status` to see where every app stands.
 
 Run plan and apply on a schedule and promotion becomes automatic: each

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,8 +116,8 @@ Agreed design:
 - Delivered across eight PRs: state split (shipped), upload provenance and
   hash gate (shipped), idempotent upload (shipped), deployment config and
   assignment client (shipped), `promote plan` and `napt status` (shipped),
-  `promote apply` with retention (shipped), drift detection, GitOps docs
-  and schema versioning
+  `promote apply` with retention (shipped), drift detection (shipped),
+  GitOps docs and schema versioning
 
 **Related**: Health-gated promotion (block on install failure rates) and
 native Intune supersedence are deliberate follow-ups, not part of this

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -456,8 +456,17 @@ re-running after a partial failure is safe. Assignments NAPT does not
 manage — admin-made groups, all-device targets, exclusions — are always
 preserved.
 
+Both commands report **assignment drift**: every discrepancy between what
+deployment state says should be assigned and what Intune actually has —
+removed or changed NAPT assignments, admin-made assignments on
+NAPT-managed apps, releases missing from the tenant, and stamped apps no
+state file references. Drift is warned about and never corrected. Apply
+checks automatically; plan checks with `--check-drift` (which needs Graph
+credentials — without the flag, plan stays fully offline).
+
 ```bash
 napt promote plan [RECIPE_OR_DIR] [OPTIONS]
+napt promote plan --check-drift
 napt promote apply [RECIPE_OR_DIR] [OPTIONS]
 ```
 

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -101,6 +101,7 @@ from napt.exceptions import (
 from napt.logging import get_logger, set_global_logger
 from napt.promote import (
     apply_plan,
+    check_drift,
     plan_path_for,
     plan_promotions,
     resolve_state_dir,
@@ -702,6 +703,16 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
         plan_path = plan_path_for(state_dir)
         actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
         write_plan_file(actions, plan_path)
+        drift = (
+            check_drift(recipes, state_dir / "deployment") if args.check_drift else []
+        )
+    except AuthError as err:
+        print(f"Authentication error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
     except (ConfigError, StateError) as err:
         print(f"Error: {err}")
         if args.verbose or args.debug:
@@ -732,7 +743,24 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
         print()
         print("[OK] Nothing to promote. No plan file needed.")
 
+    if args.check_drift:
+        _print_drift(drift)
+
     return 0
+
+
+def _print_drift(drift: list[dict[str, Any]]) -> None:
+    """Prints drift findings as a warnings section."""
+    print()
+    print("=" * 70)
+    print("DRIFT CHECK")
+    print("=" * 70)
+    if drift:
+        for finding in drift:
+            print(f"  [WARNING] {finding['app_id']}: {finding['detail']}")
+    else:
+        print("  No drift detected.")
+    print("=" * 70)
 
 
 def cmd_promote_apply(args: argparse.Namespace) -> int:
@@ -808,6 +836,10 @@ def cmd_promote_apply(args: argparse.Namespace) -> int:
     for entry in skipped:
         print(f"  [SKIP] {_describe_action(entry['action'])} ({entry['reason']})")
     print("=" * 70)
+
+    if summary.get("drift"):
+        _print_drift(summary["drift"])
+
     print()
     print(f"[SUCCESS] Applied {len(applied)} action(s), " f"skipped {len(skipped)}.")
 
@@ -1373,6 +1405,14 @@ def main() -> None:
         help=(
             "State directory holding deployment/ and plan.json "
             "(default: directories.state from config)"
+        ),
+    )
+    parser_promote_plan.add_argument(
+        "--check-drift",
+        action="store_true",
+        help=(
+            "Also compare Intune assignments against deployment state "
+            "(requires Graph credentials); findings are warnings only"
         ),
     )
     parser_promote_plan.add_argument(

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -23,9 +23,14 @@ The core invariant: each ring holds at most one release of an app's Update
 entry — the newest release that has reached it. Promotion advances the
 deployed release into the next ring once it has held its current ring for
 the ring's ``promote_after_days``.
+
+Assignment drift — differences between what deployment state says should
+be assigned and what Intune actually has — is detected on every apply and
+on ``plan --check-drift``, and is always reported, never corrected.
 """
 
 from .applier import apply_plan, load_plan_file
+from .drift import check_drift, detect_drift
 from .planner import (
     plan_path_for,
     plan_promotions,
@@ -35,6 +40,8 @@ from .planner import (
 
 __all__ = [
     "apply_plan",
+    "check_drift",
+    "detect_drift",
     "load_plan_file",
     "plan_path_for",
     "plan_promotions",

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -47,6 +47,7 @@ from typing import Any
 from napt.config import load_effective_config
 from napt.exceptions import StateError
 from napt.logging import get_global_logger
+from napt.promote.drift import detect_drift
 from napt.promote.planner import (
     _collect_recipe_paths,
     plan_path_for,
@@ -59,13 +60,12 @@ from napt.state import (
 )
 from napt.upload.auth import get_access_token
 from napt.upload.graph import (
-    VIRTUAL_TARGETS,
     assign_app,
     build_assignment,
     delete_mobile_app,
     get_app_assignments,
     list_mobile_apps,
-    resolve_group_id,
+    resolve_assignment_target,
 )
 from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
 
@@ -223,20 +223,10 @@ class _ApplyRun:
         built-in virtual targets; anything else resolves to an Entra ID
         group target.
         """
-        targets: list[dict[str, Any]] = []
-        for group in groups:
-            if group in VIRTUAL_TARGETS:
-                targets.append(dict(VIRTUAL_TARGETS[group]))
-                continue
-            if group not in self._group_ids:
-                self._group_ids[group] = resolve_group_id(self.access_token, group)
-            targets.append(
-                {
-                    "@odata.type": "#microsoft.graph.groupAssignmentTarget",
-                    "groupId": self._group_ids[group],
-                }
-            )
-        return targets
+        return [
+            resolve_assignment_target(self.access_token, group, self._group_ids)
+            for group in groups
+        ]
 
     def skip(self, action: dict[str, Any], reason: str) -> None:
         """Records a skipped action and warns."""
@@ -436,6 +426,10 @@ def apply_plan(
     Deployment state is saved after each applied action, so a failed run
     resumes safely — already-applied actions validate as no-ops.
 
+    Assignment drift is checked on every run — including runs with
+    nothing to apply, which therefore still authenticate — and reported
+    in the summary, never corrected.
+
     Args:
         recipes: A recipe YAML file, or a directory scanned recursively.
         state_dir: State directory holding ``deployment/`` and
@@ -447,7 +441,8 @@ def apply_plan(
             Defaults to the current UTC time.
 
     Returns:
-        A summary dict with "applied" and "skipped" action lists.
+        A summary dict with "applied" and "skipped" action lists and
+            "drift" findings.
 
     Raises:
         AuthError: If authentication fails.
@@ -471,9 +466,6 @@ def apply_plan(
         actions = plan_promotions(recipes, state_dir=deployment_dir, now=now)
         logger.info("PROMOTE", "No plan file found; planning and applying")
 
-    if not actions:
-        return {"applied": [], "skipped": []}
-
     configs = {
         config["id"]: config
         for config in (
@@ -481,6 +473,9 @@ def apply_plan(
         )
     }
 
+    # Authenticate even when there is nothing to apply: the steady state
+    # (no eligible promotions) is exactly when out-of-band assignment
+    # changes accumulate, so drift is checked on every apply run.
     access_token = get_access_token()
     run = _ApplyRun(access_token, configs, deployment_dir, now)
 
@@ -497,4 +492,8 @@ def apply_plan(
         plan_path.unlink()
         logger.verbose("PROMOTE", f"Consumed plan file: {plan_path}")
 
-    return {"applied": run.applied, "skipped": run.skipped}
+    # Drift is checked after the actions so freshly applied assignments
+    # are reflected. Findings are warnings only, never corrected.
+    drift = detect_drift(access_token, configs, deployment_dir, run.existing_apps)
+
+    return {"applied": run.applied, "skipped": run.skipped, "drift": drift}

--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -1,0 +1,315 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assignment drift detection for NAPT deployment promotion.
+
+Compares what deployment state says should be assigned in Intune against
+what actually is, and reports every discrepancy as a finding. Strictly
+observational: drift is warned about and never corrected — manual admin
+changes are deliberately left alone.
+
+Finding kinds:
+
+- ``missing_app``: State references a release whose stamped Intune entry
+    no longer exists.
+- ``missing_assignment``: An assignment NAPT applied (ring group or
+    install group) is no longer present.
+- ``intent_mismatch``: An expected assignment exists with a different
+    intent.
+- ``unexpected_assignment``: A NAPT-stamped app carries an assignment
+    NAPT did not make (typically admin-made; left alone).
+- ``orphaned_release``: A stamped app exists for a release that no state
+    file references (e.g., a crashed run replaced by newest-wins).
+- ``unknown_app``: A stamped app references a recipe id with no recipe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from napt.config import load_effective_config
+from napt.promote.planner import _collect_recipe_paths
+from napt.state import deployment_state_path, load_deployment_state
+from napt.upload.auth import get_access_token
+from napt.upload.graph import (
+    get_app_assignments,
+    list_mobile_apps,
+    resolve_assignment_target,
+)
+from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, parse_stamp
+
+__all__ = ["check_drift", "detect_drift"]
+
+
+def _target_key(target: dict[str, Any] | None) -> tuple[str, str]:
+    """Returns a comparable identity for an assignment target."""
+    target = target or {}
+    return (target.get("@odata.type", ""), target.get("groupId", ""))
+
+
+def _describe_target(target: dict[str, Any] | None, names: dict) -> str:
+    """Returns a human-readable name for an assignment target."""
+    target = target or {}
+    odata_type = target.get("@odata.type", "")
+    if "allLicensedUsers" in odata_type:
+        return "All Users"
+    if "allDevices" in odata_type:
+        return "All Devices"
+    group_id = target.get("groupId", "")
+    return names.get(_target_key(target), f"group {group_id or 'unknown'}")
+
+
+def _referenced_shas(state: dict[str, Any]) -> set[str]:
+    """Returns every release hash a deployment state file references."""
+    shas: set[str] = set()
+    for section in ("deployed", "pending"):
+        entry = state.get(section) or {}
+        if entry.get("sha256"):
+            shas.add(entry["sha256"])
+    for holder in (state.get("rings") or {}).values():
+        if holder.get("sha256"):
+            shas.add(holder["sha256"])
+    for retained in state.get("retained") or []:
+        if retained.get("sha256"):
+            shas.add(retained["sha256"])
+    install_assigned = state.get("install_assigned") or {}
+    if install_assigned.get("sha256"):
+        shas.add(install_assigned["sha256"])
+    return shas
+
+
+def _expected_assignments(
+    access_token: str,
+    config: dict[str, Any],
+    state: dict[str, Any],
+    group_id_cache: dict[str, str],
+    names: dict,
+) -> dict[tuple[str, str], dict[tuple[str, str], str]]:
+    """Builds the expected assignment map for one app.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        config: The app's effective configuration.
+        state: The app's deployment state.
+        group_id_cache: Shared cache for group name resolution.
+        names: Target-key to configured-name map, filled as a side
+            effect for readable findings.
+
+    Returns:
+        A map of (entry type, release sha256) to a map of target key to
+            expected intent.
+
+    """
+    deployment = config["deployment"]
+    rings_by_name = {ring["name"]: ring for ring in deployment["rings"]}
+    expected: dict[tuple[str, str], dict[tuple[str, str], str]] = {}
+
+    for ring_name, holder in (state.get("rings") or {}).items():
+        ring_cfg = rings_by_name.get(ring_name)
+        if ring_cfg is None or not holder.get("sha256"):
+            continue  # Ring removed from config; nothing is expected.
+        slot = expected.setdefault((ENTRY_UPDATE, holder["sha256"]), {})
+        for group in ring_cfg["groups"]:
+            target = resolve_assignment_target(access_token, group, group_id_cache)
+            key = _target_key(target)
+            names[key] = group
+            slot[key] = "required"
+
+    install_assigned = state.get("install_assigned") or {}
+    install_cfg = deployment["install"]
+    if install_assigned.get("sha256") and install_cfg["groups"]:
+        slot = expected.setdefault((ENTRY_INSTALL, install_assigned["sha256"]), {})
+        for group in install_cfg["groups"]:
+            target = resolve_assignment_target(access_token, group, group_id_cache)
+            key = _target_key(target)
+            names[key] = group
+            slot[key] = install_cfg["intent"]
+
+    return expected
+
+
+def detect_drift(
+    access_token: str,
+    configs: dict[str, dict[str, Any]],
+    deployment_dir: Path,
+    existing_apps: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Detects assignment drift between deployment state and Intune.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        configs: Effective configurations keyed by recipe id.
+        deployment_dir: Directory holding per-app deployment state files.
+        existing_apps: Mobile app dicts from list_mobile_apps.
+
+    Returns:
+        Finding dicts, each with "app_id", "kind", and "detail" keys,
+            sorted for deterministic output. Empty when Intune matches
+            state.
+
+    Raises:
+        AuthError: On 401 or 403.
+        ConfigError: If a configured group cannot be resolved.
+        NetworkError: On Graph API failures.
+        StateError: On a corrupted deployment state file.
+
+    """
+    findings: list[dict[str, Any]] = []
+    group_id_cache: dict[str, str] = {}
+    names: dict = {}
+
+    stamped_by_recipe: dict[str, list[tuple[dict, dict]]] = {}
+    for app in existing_apps:
+        stamp = parse_stamp(app.get("notes"))
+        if stamp is None:
+            continue
+        if stamp["id"] not in configs:
+            findings.append(
+                {
+                    "app_id": stamp["id"],
+                    "kind": "unknown_app",
+                    "detail": (
+                        f"stamped app '{app.get('displayName', app['id'])}' "
+                        f"references recipe id '{stamp['id']}', which has "
+                        "no recipe"
+                    ),
+                }
+            )
+            continue
+        stamped_by_recipe.setdefault(stamp["id"], []).append((stamp, app))
+
+    for app_id, config in configs.items():
+        state = load_deployment_state(deployment_state_path(deployment_dir, app_id))
+        expected = _expected_assignments(
+            access_token, config, state, group_id_cache, names
+        )
+        referenced = _referenced_shas(state)
+        stamped = stamped_by_recipe.get(app_id, [])
+        stamped_keys = {(s["entry"], s["sha256"]) for s, _ in stamped}
+
+        for entry, sha in expected:
+            if (entry, sha) not in stamped_keys:
+                findings.append(
+                    {
+                        "app_id": app_id,
+                        "kind": "missing_app",
+                        "detail": (
+                            f"state expects a stamped {entry} entry for "
+                            f"release {sha[:12]}, but none exists in the "
+                            "tenant"
+                        ),
+                    }
+                )
+
+        for stamp, app in stamped:
+            entry = stamp["entry"]
+            sha = stamp["sha256"]
+            if sha not in referenced:
+                findings.append(
+                    {
+                        "app_id": app_id,
+                        "kind": "orphaned_release",
+                        "detail": (
+                            f"stamped {entry} entry "
+                            f"'{app.get('displayName', app['id'])}' for "
+                            f"release {sha[:12]} is not referenced by "
+                            "deployment state"
+                        ),
+                    }
+                )
+                continue
+
+            expected_targets = expected.get((entry, sha), {})
+            actual = {
+                _target_key(a.get("target")): a
+                for a in get_app_assignments(access_token, app["id"])
+            }
+
+            for key, intent in expected_targets.items():
+                if key not in actual:
+                    findings.append(
+                        {
+                            "app_id": app_id,
+                            "kind": "missing_assignment",
+                            "detail": (
+                                f"{entry} entry for {sha[:12]}: expected "
+                                f"assignment '{names.get(key, key)}' "
+                                f"({intent}) is not present in Intune"
+                            ),
+                        }
+                    )
+                elif actual[key].get("intent") != intent:
+                    findings.append(
+                        {
+                            "app_id": app_id,
+                            "kind": "intent_mismatch",
+                            "detail": (
+                                f"{entry} entry for {sha[:12]}: "
+                                f"'{names.get(key, key)}' has intent "
+                                f"'{actual[key].get('intent')}' "
+                                f"(expected '{intent}')"
+                            ),
+                        }
+                    )
+
+            for key, assignment in actual.items():
+                if key not in expected_targets:
+                    findings.append(
+                        {
+                            "app_id": app_id,
+                            "kind": "unexpected_assignment",
+                            "detail": (
+                                f"{entry} entry for {sha[:12]}: assignment "
+                                f"'{_describe_target(assignment.get('target'), names)}' "
+                                f"({assignment.get('intent')}) was not made "
+                                "by NAPT - leaving it alone"
+                            ),
+                        }
+                    )
+
+    findings.sort(key=lambda f: (f["app_id"], f["kind"], f["detail"]))
+    return findings
+
+
+def check_drift(recipes: Path, deployment_dir: Path) -> list[dict[str, Any]]:
+    """Authenticates and detects drift for a recipe or directory of recipes.
+
+    Convenience wrapper for standalone drift checks (``napt promote plan
+    --check-drift``): loads the effective configurations, authenticates,
+    lists the tenant, and runs detect_drift.
+
+    Args:
+        recipes: A recipe YAML file, or a directory scanned recursively.
+        deployment_dir: Directory holding per-app deployment state files.
+
+    Returns:
+        Finding dicts from detect_drift.
+
+    Raises:
+        AuthError: If authentication fails.
+        ConfigError: On invalid recipes or unresolvable groups.
+        NetworkError: On Graph API failures.
+        StateError: On a corrupted deployment state file.
+
+    """
+    configs = {
+        config["id"]: config
+        for config in (
+            load_effective_config(path) for path in _collect_recipe_paths(recipes)
+        )
+    }
+    access_token = get_access_token()
+    existing_apps = list_mobile_apps(access_token)
+    return detect_drift(access_token, configs, deployment_dir, existing_apps)

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -79,6 +79,7 @@ __all__ = [
     "get_app_assignments",
     "get_mobile_app",
     "list_mobile_apps",
+    "resolve_assignment_target",
     "resolve_group_id",
     "update_win32_app",
     "upload_to_azure_blob",
@@ -242,6 +243,44 @@ def resolve_group_id(access_token: str, group: str) -> str:
             f"({ids}). Use the object ID of the intended group instead."
         )
     return matches[0]["id"]
+
+
+def resolve_assignment_target(
+    access_token: str,
+    group: str,
+    group_id_cache: dict[str, str] | None = None,
+) -> dict:
+    """Resolves a deployment group entry to an assignment target dict.
+
+    The reserved names "All Users" and "All Devices" map to Intune's
+    built-in virtual targets; anything else resolves to an Entra ID
+    group target via resolve_group_id.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        group: Group displayName, object ID, or reserved virtual name.
+        group_id_cache: Optional cache of name to object ID, shared
+            across calls to avoid repeated lookups.
+
+    Returns:
+        An assignment target dict for use with build_assignment.
+
+    Raises:
+        AuthError: On 401 or 403 (check Group.Read.All permission).
+        ConfigError: If no group or more than one group matches a name.
+        NetworkError: On 5xx or connection error.
+
+    """
+    if group in VIRTUAL_TARGETS:
+        return dict(VIRTUAL_TARGETS[group])
+    if group_id_cache is None:
+        group_id_cache = {}
+    if group not in group_id_cache:
+        group_id_cache[group] = resolve_group_id(access_token, group)
+    return {
+        "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+        "groupId": group_id_cache[group],
+    }
 
 
 def get_app_assignments(access_token: str, app_id: str) -> list[dict]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -749,7 +749,9 @@ class TestCmdPromotePlan:
             patch("napt.cli.write_plan_file", return_value=True) as write_mock,
         ):
             code = cmd_promote_plan(
-                _args(recipes="recipes", state_dir=tmp_path / "state")
+                _args(
+                    recipes="recipes", state_dir=tmp_path / "state", check_drift=False
+                )
             )
         assert code == 0
         out = capsys.readouterr().out
@@ -764,7 +766,9 @@ class TestCmdPromotePlan:
             patch("napt.cli.write_plan_file", return_value=False),
         ):
             code = cmd_promote_plan(
-                _args(recipes="recipes", state_dir=tmp_path / "state")
+                _args(
+                    recipes="recipes", state_dir=tmp_path / "state", check_drift=False
+                )
             )
         assert code == 0
         out = capsys.readouterr().out
@@ -774,7 +778,9 @@ class TestCmdPromotePlan:
         """Tests that ConfigError is caught and returns 1."""
         with patch("napt.cli.plan_promotions", side_effect=ConfigError("bad")):
             code = cmd_promote_plan(
-                _args(recipes="recipes", state_dir=tmp_path / "state")
+                _args(
+                    recipes="recipes", state_dir=tmp_path / "state", check_drift=False
+                )
             )
         assert code == 1
         assert "bad" in capsys.readouterr().out
@@ -920,3 +926,58 @@ class TestCmdPromoteApply:
             )
         assert code == 1
         assert "bad plan" in capsys.readouterr().out
+
+
+# =============================================================================
+# drift output
+# =============================================================================
+
+
+class TestDriftOutput:
+    """Tests for drift warning presentation."""
+
+    def test_plan_check_drift_prints_findings(self, tmp_path, capsys):
+        """Tests that --check-drift findings are printed as warnings."""
+        finding = {
+            "app_id": "test-app",
+            "kind": "missing_assignment",
+            "detail": "expected assignment gone",
+        }
+        with (
+            patch("napt.cli.plan_promotions", return_value=[]),
+            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.check_drift", return_value=[finding]),
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=True,
+                )
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "DRIFT CHECK" in out
+        assert "[WARNING] test-app: expected assignment gone" in out
+
+    def test_apply_prints_drift_from_summary(self, tmp_path, capsys):
+        """Tests that apply prints drift findings from the summary."""
+        summary = {
+            "applied": [],
+            "skipped": [],
+            "drift": [
+                {
+                    "app_id": "test-app",
+                    "kind": "orphaned_release",
+                    "detail": "stray app",
+                }
+            ],
+        }
+        with patch("napt.cli.apply_plan", return_value=summary):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "DRIFT CHECK" in out
+        assert "[WARNING] test-app: stray app" in out

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -20,6 +20,7 @@ from napt.state import (
     load_deployment_state,
     save_deployment_state,
 )
+from napt.upload.graph import VIRTUAL_TARGETS
 
 NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=UTC)
 
@@ -129,11 +130,24 @@ def _tenant(sha_new: str = "b" * 64, sha_old: str = "a" * 64) -> list[dict[str, 
     ]
 
 
+def _fake_resolve_target(
+    token: str, group: str, cache: dict | None = None
+) -> dict[str, Any]:
+    """Mirrors resolve_assignment_target without Graph calls."""
+    if group in VIRTUAL_TARGETS:
+        return dict(VIRTUAL_TARGETS[group])
+    return {
+        "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+        "groupId": f"gid-{group}",
+    }
+
+
 def _run_apply(
     tmp_path: Path,
     existing_apps: list[dict[str, Any]] | None = None,
     assignments: dict[str, list[dict[str, Any]]] | None = None,
     assign_side_effect: Any = None,
+    drift_findings: list[dict[str, Any]] | None = None,
 ) -> tuple[dict[str, Any], dict[str, MagicMock]]:
     """Runs apply_plan with all Graph calls mocked.
 
@@ -155,7 +169,7 @@ def _run_apply(
         "get_app_assignments": MagicMock(
             side_effect=lambda token, app_id: list(assignments.get(app_id, []))
         ),
-        "resolve_group_id": MagicMock(side_effect=lambda token, g: f"gid-{g}"),
+        "resolve_assignment_target": MagicMock(side_effect=_fake_resolve_target),
     }
 
     with ExitStack() as stack:
@@ -170,6 +184,12 @@ def _run_apply(
         )
         for name, mock in mocks.items():
             stack.enter_context(patch(f"napt.promote.applier.{name}", mock))
+        stack.enter_context(
+            patch(
+                "napt.promote.applier.detect_drift",
+                return_value=drift_findings or [],
+            )
+        )
         summary = apply_plan(
             tmp_path / "recipes",
             state_dir=tmp_path / "state",
@@ -429,7 +449,6 @@ class TestApplyInstallActions:
                 },
             }
         ]
-        mocks["resolve_group_id"].assert_not_called()
         state = load_deployment_state(state_path)
         assert state["install_assigned"] == {"version": "2.0.0", "sha256": "b" * 64}
 
@@ -480,7 +499,7 @@ class TestApplyOrchestration:
 
         summary, mocks = _run_apply(tmp_path, existing_apps=[])
 
-        assert summary == {"applied": [], "skipped": []}
+        assert summary == {"applied": [], "skipped": [], "drift": []}
         mocks["assign_app"].assert_not_called()
 
     def test_unknown_app_in_plan_skipped(self, tmp_path):
@@ -515,3 +534,19 @@ class TestLoadPlanFile:
 
         with pytest.raises(StateError, match="Corrupted plan file"):
             load_plan_file(plan_path)
+
+
+class TestApplyDrift:
+    """Tests for drift reporting in the apply summary."""
+
+    def test_drift_findings_included_in_summary(self, tmp_path):
+        """Tests that drift findings pass through to the summary."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed())
+        finding = {"app_id": "test-app", "kind": "missing_assignment", "detail": "x"}
+
+        summary, _ = _run_apply(
+            tmp_path, existing_apps=_tenant(), drift_findings=[finding]
+        )
+
+        assert summary["drift"] == [finding]

--- a/tests/test_promote_drift.py
+++ b/tests/test_promote_drift.py
@@ -1,0 +1,312 @@
+"""Tests for napt.promote.drift."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from napt.promote import detect_drift
+from napt.state import (
+    create_default_deployment_state,
+    deployment_state_path,
+    save_deployment_state,
+)
+
+TOKEN = "tok"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_project(tmp_path, monkeypatch):
+    """Makes each test a self-contained NAPT project.
+
+    pytest's basetemp lives inside the repo (.pytest-tmp), so the config
+    loader's upward walk from a test recipe would otherwise find the
+    repo's own defaults/org.yaml. A minimal org.yaml in tmp_path stops
+    the walk there.
+    """
+    monkeypatch.chdir(tmp_path)
+    org = tmp_path / "defaults" / "org.yaml"
+    org.parent.mkdir(parents=True, exist_ok=True)
+    org.write_text("apiVersion: napt/v1\n", encoding="utf-8")
+
+
+def _config(
+    app_id: str = "test-app",
+    rings: list[dict[str, Any]] | None = None,
+    install_groups: list[str] | None = None,
+) -> dict[str, Any]:
+    """Builds an effective config via the real loader for realism."""
+    from napt.config import load_effective_config
+
+    deployment: dict[str, Any] = {}
+    if rings is not None:
+        deployment["rings"] = rings
+    deployment["install"] = {
+        "intent": "available",
+        "groups": install_groups or [],
+    }
+
+    recipe: dict[str, Any] = {
+        "apiVersion": "napt/v1",
+        "name": f"App {app_id}",
+        "id": app_id,
+        "discovery": {
+            "strategy": "url_download",
+            "url": "https://example.com/app.msi",
+        },
+        "deployment": deployment,
+    }
+    path = Path("recipes") / f"{app_id}.yaml"
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(yaml.dump(recipe), encoding="utf-8")
+    return load_effective_config(path)
+
+
+def _write_state(
+    tmp_path: Path,
+    app_id: str = "test-app",
+    **sections: Any,
+) -> Path:
+    """Writes a deployment state file and returns the deployment dir."""
+    deployment_dir = tmp_path / "state" / "deployment"
+    state = create_default_deployment_state()
+    state.update(sections)
+    save_deployment_state(state, deployment_state_path(deployment_dir, app_id))
+    return deployment_dir
+
+
+def _stamped(app_id: str, entry: str, sha256: str, graph_id: str) -> dict[str, Any]:
+    return {
+        "id": graph_id,
+        "displayName": f"{app_id} ({entry})",
+        "notes": f"napt/v1 id={app_id} entry={entry} sha256={sha256}",
+    }
+
+
+def _group_target(group: str) -> dict[str, Any]:
+    return {
+        "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+        "groupId": f"gid-{group}",
+    }
+
+
+def _assignment(group: str, intent: str = "required") -> dict[str, Any]:
+    return {"id": "a1", "intent": intent, "target": _group_target(group)}
+
+
+_RINGS = [{"name": "pilot", "groups": ["Pilot Devices"], "promote_after_days": 2}]
+
+_HELD_PILOT = {
+    "pilot": {
+        "version": "1.0.0",
+        "sha256": "a" * 64,
+        "entered_at": "2026-07-01T00:00:00+00:00",
+    }
+}
+
+
+def _detect(
+    tmp_path: Path,
+    config: dict[str, Any],
+    deployment_dir: Path,
+    existing_apps: list[dict[str, Any]],
+    assignments: dict[str, list[dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Runs detect_drift with Graph calls mocked."""
+    assignments = assignments or {}
+    with (
+        patch(
+            "napt.promote.drift.resolve_assignment_target",
+            side_effect=lambda token, group, cache=None: _group_target(group),
+        ),
+        patch(
+            "napt.promote.drift.get_app_assignments",
+            MagicMock(
+                side_effect=lambda token, app_id: list(assignments.get(app_id, []))
+            ),
+        ),
+    ):
+        return detect_drift(
+            TOKEN, {config["id"]: config}, deployment_dir, existing_apps
+        )
+
+
+class TestDetectDrift:
+    """Tests for drift finding computation."""
+
+    def test_matching_state_reports_nothing(self, tmp_path):
+        """Tests that Intune matching state produces no findings."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            rings=_HELD_PILOT,
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "update", "a" * 64, "update-1")],
+            assignments={"update-1": [_assignment("Pilot Devices")]},
+        )
+
+        assert findings == []
+
+    def test_missing_assignment_reported(self, tmp_path):
+        """Tests that a removed ring assignment is reported."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            rings=_HELD_PILOT,
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "update", "a" * 64, "update-1")],
+            assignments={"update-1": []},
+        )
+
+        assert [f["kind"] for f in findings] == ["missing_assignment"]
+        assert "Pilot Devices" in findings[0]["detail"]
+
+    def test_intent_mismatch_reported(self, tmp_path):
+        """Tests that a changed assignment intent is reported."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            rings=_HELD_PILOT,
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "update", "a" * 64, "update-1")],
+            assignments={
+                "update-1": [_assignment("Pilot Devices", intent="available")]
+            },
+        )
+
+        assert [f["kind"] for f in findings] == ["intent_mismatch"]
+
+    def test_unexpected_assignment_reported(self, tmp_path):
+        """Tests that an admin-made assignment is reported, not corrected."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            rings=_HELD_PILOT,
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "update", "a" * 64, "update-1")],
+            assignments={
+                "update-1": [
+                    _assignment("Pilot Devices"),
+                    _assignment("Admin Group"),
+                ]
+            },
+        )
+
+        assert [f["kind"] for f in findings] == ["unexpected_assignment"]
+        assert "leaving it alone" in findings[0]["detail"]
+
+    def test_missing_app_reported(self, tmp_path):
+        """Tests that a state-referenced release missing from Intune reports."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            rings=_HELD_PILOT,
+        )
+
+        findings = _detect(tmp_path, config, deployment_dir, [])
+
+        assert [f["kind"] for f in findings] == ["missing_app"]
+
+    def test_orphaned_release_reported(self, tmp_path):
+        """Tests that a stamped app unreferenced by state is reported."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "2.0.0", "sha256": "b" * 64},
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [
+                _stamped("test-app", "update", "b" * 64, "update-2"),
+                _stamped("test-app", "update", "f" * 64, "update-ghost"),
+            ],
+        )
+
+        assert [f["kind"] for f in findings] == ["orphaned_release"]
+        assert "f" * 12 in findings[0]["detail"]
+
+    def test_unknown_recipe_reported(self, tmp_path):
+        """Tests that a stamped app without a recipe is reported."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(tmp_path)
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("ghost-app", "update", "a" * 64, "update-x")],
+        )
+
+        assert [f["kind"] for f in findings] == ["unknown_app"]
+
+    def test_install_assignment_checked(self, tmp_path):
+        """Tests that install-entry expectations are checked too."""
+        config = _config(install_groups=["All Users"])
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            install_assigned={"version": "1.0.0", "sha256": "a" * 64},
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "install", "a" * 64, "install-1")],
+            assignments={"install-1": []},
+        )
+
+        assert [f["kind"] for f in findings] == ["missing_assignment"]
+        assert "All Users" in findings[0]["detail"]
+
+    def test_removed_ring_expects_nothing(self, tmp_path):
+        """Tests that a ring removed from config drops its expectations."""
+        config = _config(rings=[])  # all rings removed
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            rings=_HELD_PILOT,
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "update", "a" * 64, "update-1")],
+            assignments={"update-1": [_assignment("Pilot Devices")]},
+        )
+
+        # The old ring assignment is no longer expected -> unexpected
+        assert [f["kind"] for f in findings] == ["unexpected_assignment"]


### PR DESCRIPTION
## Description

Warn-and-leave assignment drift detection: compares what deployment state says should be assigned in Intune against what actually is, and reports every discrepancy. Six finding kinds: `missing_app`, `missing_assignment`, `intent_mismatch`, `unexpected_assignment` (admin-made; explicitly left alone), `orphaned_release` (stamped app no state references), `unknown_app` (stamped, no recipe). `napt promote apply` checks on every run — including no-op runs, which now authenticate; `napt promote plan --check-drift` opts in without giving up plan''s offline default.

## Motivation

Every promise the promotion engine makes assumes state matches Intune; drift is how that assumption breaking gets surfaced before it produces a wrong outcome (e.g., a hand-removed ring assignment validates as "already applied" and would never self-heal — the warning is the only signal). Findings are reported, never corrected: the admin decides whether the portal or git is right.

## Changes

- New `napt/promote/drift.py` (`detect_drift` + `check_drift` wrapper)
- Drift findings in the apply summary and a DRIFT CHECK output section in both commands
- `resolve_assignment_target` extracted to `graph.py` (dedup with the applier)
- Rings removed from config drop their expectations; their old assignments surface as `unexpected_assignment`

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

684 tests pass; drift covered per finding kind plus clean-state, removed-ring, and install-entry cases; CLI presentation and apply-summary passthrough tested. napt-reviewer verdict: ship (all findings addressed). A live `napt promote apply` against the dev tenant will exercise the drift pass end-to-end.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors