### PR TITLE
docs: Add GitOps workflows and schema versions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: Deployment state and plan files carry a schema version** -
+    `state/deployment/*.json` and `state/plan.json` are now stamped with
+    `schemaVersion: 1`; NAPT refuses files whose schemaVersion is
+    missing or unsupported. Add `"schemaVersion": 1` to files written by
+    earlier pre-releases (plan files can simply be regenerated)
 - **BREAKING: `intune.notes` removed** - The Intune notes field is
     reserved for NAPT's provenance stamp. Move any notes content to
     `intune.description` or `intune.owner`

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -880,6 +880,11 @@ jobs:
           git ls-files 'recipes/*.yaml' 'recipes/**/*.yaml' | while read -r recipe; do
             napt discover "$recipe"
           done
+      - name: Cache installers for the publish workflow
+        uses: actions/cache/save@v4
+        with:
+          path: downloads
+          key: installers-${{ github.run_id }}
       - name: Open one PR per app with a new pending release
         shell: bash
         env:
@@ -932,6 +937,12 @@ jobs:
         with:
           python-version: "3.13"
       - run: pip install napt
+      - name: Restore cached installers
+        uses: actions/cache/restore@v4
+        with:
+          path: downloads
+          key: installers-
+          restore-keys: installers-
       - name: Publish every app with an approved pending release
         shell: bash
         run: |
@@ -941,11 +952,14 @@ jobs:
             [ -f "$state" ] || continue
             pending=$(python -c "import json, sys; print(json.load(open(sys.argv[1], encoding='utf-8')).get('pending') is not None)" "$state")
             [ "$pending" = "True" ] || continue
-            # Installers are machine-local (never committed), so this
-            # runner must fetch the binary. --stateless keeps the
-            # approved pending untouched: if the vendor swapped binaries
-            # since review, the upload hash gate refuses.
-            napt discover "$recipe" --stateless
+            # Use the cached installer when its hash matches the approved
+            # release; otherwise fetch from the vendor. --stateless keeps
+            # the approved pending untouched, and the upload hash gate
+            # refuses anything that does not match it.
+            psha=$(python -c "import json, sys; print(json.load(open(sys.argv[1], encoding='utf-8'))['pending']['sha256'])" "$state")
+            if ! sha256sum "downloads/$id/"* 2>/dev/null | grep -q "^$psha "; then
+              napt discover "$recipe" --stateless
+            fi
             napt build "$recipe"
             napt package "$recipe"
             napt upload "$recipe"
@@ -962,23 +976,21 @@ jobs:
           }
 ```
 
-**Advised: persist installers between discover and publish.**
-As written, the publish runner re-downloads from the vendor, which
+**Why the installer cache steps matter.**
+Without them, the publish runner re-downloads from the vendor, which
 couples an already-approved publish to the vendor still serving that
-exact binary — if the file was pulled or replaced in the meantime, the
-hash gate refuses and the approval is stranded until the next release is
-reviewed.
-Caching the downloaded installer at discover time removes that
-dependency: an object store (S3, Azure Blob), a GitHub Actions cache
-keyed on the pending release's sha256, or a self-hosted runner with a
-persistent `downloads/` directory all work.
-On the publish runner, restore the cache and skip the `--stateless`
-discover step on a hit.
-This is safe by construction — the hash gate validates whatever binary
-the runner provides against the approved sha256, so a cache can never
-ship the wrong bytes.
-It also preserves installers for retained releases, which the vendor may
-no longer serve if you ever need to republish one.
+exact binary — a pulled or replaced file strands the approval at the
+hash gate.
+The cache steps above hand the publish runner the very binary that was
+reviewed; the sha256 check in the loop falls back to a fresh download
+when the cache is stale or evicted (GitHub evicts caches unused for
+about a week), so the flow degrades gracefully.
+This is safe by construction — the upload hash gate validates whatever
+binary the runner provides, so a cache can never ship the wrong bytes.
+For long-lived archival — including installers for retained releases the
+vendor no longer serves — replace the cache steps with an object store
+(S3, Azure Blob) or a self-hosted runner with a persistent `downloads/`
+directory.
 
 ### Workflow 3: promotion plan (opens the promotion PR)
 

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -810,6 +810,253 @@ napt upload recipes/Vendor/app.yaml --force
 content version together — and keeps the app IDs.
 It never creates duplicates.
 
+## Automate NAPT with GitHub Actions
+
+NAPT performs no git or CI operations itself — it reads and writes
+deterministic files and leaves the choreography to your pipeline.
+This section is a reference setup for a fully review-gated flow on
+GitHub Actions.
+Adapt names, schedules, and branch rules to your org.
+
+**The model.** Two PR streams gate everything:
+
+- **Publish PRs** (one per app): `napt discover` records a pending
+  release in `state/deployment/<id>.json`; CI opens a per-app PR with
+  that diff. Merging approves the release — a workflow builds, packages,
+  and uploads it, with the hash gate guaranteeing the approved binary is
+  exactly what ships.
+- **Promotion PRs** (one, batched): `napt promote plan` writes
+  `state/plan.json` when releases are eligible to enter or advance
+  rings; CI commits it to a branch and opens a PR. Merging approves the
+  promotions — a workflow runs `napt promote apply`, which executes the
+  plan as an allowlist.
+  To hold one promotion, delete its entry from the plan file in the PR;
+  the next scheduled plan will re-propose it.
+
+**Writeback commits.** After upload and apply, NAPT has recorded new
+facts (Intune app IDs, ring positions) in the working tree that must
+reach `main`, so those workflows push a `[skip ci]` commit.
+Two consequences to set up once:
+
+- The workflow identity needs permission to push to `main` — either
+  allow the Actions bot through branch protection or use a bot/app
+  token with bypass rights.
+- `[skip ci]` keeps the writeback from re-triggering workflows.
+
+**Secrets.** `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and
+`AZURE_TENANT_ID` for the app registration
+(see [App Registration Setup](user-guide.md#app-registration-setup)).
+
+**Recommended org.yaml hardening:**
+
+```yaml
+deployment:
+  require_pending: true   # nothing reaches Intune without a reviewed release
+```
+
+### Workflow 1: discover (opens publish PRs)
+
+```yaml
+name: discover
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  discover:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install napt
+      - name: Discover all recipes
+        shell: bash
+        run: |
+          git ls-files 'recipes/*.yaml' 'recipes/**/*.yaml' | while read -r recipe; do
+            napt discover "$recipe"
+          done
+      - name: Open one PR per app with a new pending release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "napt-bot"
+          git config user.email "napt-bot@users.noreply.github.com"
+          # Stage first so brand-new (untracked) state files are seen too
+          git add state/deployment
+          changed=$(git diff --cached --name-only -- state/deployment)
+          [ -z "$changed" ] && exit 0
+          # Snapshot all changes on a temp branch, then carve out one
+          # branch per app so each PR reviews exactly one state file.
+          git checkout -b napt/discover-snapshot
+          git commit -m "temp: discovery snapshot"
+          for f in $changed; do
+            app=$(basename "$f" .json)
+            git checkout -B "napt/discover-$app" origin/main
+            git checkout napt/discover-snapshot -- "$f"
+            git commit -m "feat: Record pending release for $app"
+            git push -f origin "napt/discover-$app"
+            gh pr create --head "napt/discover-$app" \
+              --title "Publish approval: $app" \
+              --body "Merging approves publishing this release to Intune." \
+              || true  # PR already open; the force-push updated it
+          done
+```
+
+### Workflow 2: publish (on merge of a publish PR)
+
+```yaml
+name: publish
+on:
+  push:
+    branches: [main]
+    paths: ["state/deployment/**"]
+concurrency: napt-writeback
+permissions:
+  contents: write
+jobs:
+  publish:
+    runs-on: windows-latest
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install napt
+      - name: Publish every app with an approved pending release
+        shell: bash
+        run: |
+          git ls-files 'recipes/*.yaml' 'recipes/**/*.yaml' | while read -r recipe; do
+            id=$(python -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1], encoding='utf-8'))['id'])" "$recipe")
+            state="state/deployment/$id.json"
+            [ -f "$state" ] || continue
+            pending=$(python -c "import json, sys; print(json.load(open(sys.argv[1], encoding='utf-8')).get('pending') is not None)" "$state")
+            [ "$pending" = "True" ] || continue
+            # Installers are machine-local (never committed), so this
+            # runner must fetch the binary. --stateless keeps the
+            # approved pending untouched: if the vendor swapped binaries
+            # since review, the upload hash gate refuses.
+            napt discover "$recipe" --stateless
+            napt build "$recipe"
+            napt package "$recipe"
+            napt upload "$recipe"
+          done
+      - name: Write back recorded app IDs
+        shell: bash
+        run: |
+          git config user.name "napt-bot"
+          git config user.email "napt-bot@users.noreply.github.com"
+          git add state/deployment
+          git diff --cached --quiet || {
+            git commit -m "chore: Record published releases [skip ci]"
+            git push
+          }
+```
+
+### Workflow 3: promotion plan (opens the promotion PR)
+
+```yaml
+name: promote-plan
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  plan:
+    runs-on: windows-latest
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install napt
+      - name: Plan promotions (with drift report)
+        run: napt promote plan --check-drift
+      - name: Open or update the promotion PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # git status sees untracked files (a first-ever plan) too
+          [ -z "$(git status --porcelain -- state/plan.json)" ] && exit 0
+          git config user.name "napt-bot"
+          git config user.email "napt-bot@users.noreply.github.com"
+          git checkout -B napt/promotion-plan origin/main
+          git add state/plan.json
+          git commit -m "feat: Plan ring promotions"
+          git push -f origin napt/promotion-plan
+          gh pr create --head napt/promotion-plan \
+            --title "Promotion plan" \
+            --body "Merging approves these ring promotions. Delete an entry from state/plan.json to hold it." \
+            || true  # PR already open; the force-push updated it
+```
+
+### Workflow 4: promotion apply (on merge of the promotion PR)
+
+```yaml
+name: promote-apply
+on:
+  push:
+    branches: [main]
+    paths: ["state/plan.json"]
+concurrency: napt-writeback
+permissions:
+  contents: write
+jobs:
+  apply:
+    runs-on: windows-latest
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install napt
+      - name: Apply the approved plan
+        run: napt promote apply
+      - name: Write back ring positions and consume the plan
+        shell: bash
+        run: |
+          git config user.name "napt-bot"
+          git config user.email "napt-bot@users.noreply.github.com"
+          git add state
+          git diff --cached --quiet || {
+            git commit -m "chore: Record applied promotions [skip ci]"
+            git push
+          }
+```
+
+**Notes:**
+
+- Promotions merged but applied later are always safe: bake time only
+  grows, and apply validates every entry against current state anyway.
+- All four workflows are idempotent — re-running any of them converges
+  to the same result (upload adopts existing apps, apply skips
+  already-applied actions).
+- `windows-latest` runners are required for `napt package`
+  (IntuneWinAppUtil.exe is Windows-only). The discover workflow alone
+  could run on Linux with `msitools` installed for MSI version
+  extraction.
+
 ## Update Existing Recipes
 
 When a recipe needs changes (new version format, different download URL, etc.).

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -962,6 +962,24 @@ jobs:
           }
 ```
 
+**Advised: persist installers between discover and publish.**
+As written, the publish runner re-downloads from the vendor, which
+couples an already-approved publish to the vendor still serving that
+exact binary — if the file was pulled or replaced in the meantime, the
+hash gate refuses and the approval is stranded until the next release is
+reviewed.
+Caching the downloaded installer at discover time removes that
+dependency: an object store (S3, Azure Blob), a GitHub Actions cache
+keyed on the pending release's sha256, or a self-hosted runner with a
+persistent `downloads/` directory all work.
+On the publish runner, restore the cache and skip the `--stateless`
+discover step on a hit.
+This is safe by construction — the hash gate validates whatever binary
+the runner provides against the approved sha256, so a cache can never
+ship the wrong bytes.
+It also preserves installers for retained releases, which the vendor may
+no longer serve if you ever need to republish one.
+
 ### Workflow 3: promotion plan (opens the promotion PR)
 
 ```yaml

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 | Recipe Schema Redesign | ✅ Completed | User-Facing | High | High |
 | Microsoft Intune Upload | ✅ Completed | User-Facing | High | Very High |
 | `napt auth setup` Command | 💡 Idea | User-Facing | Low | High |
-| Deployment Wave Management | 🚧 In Progress | User-Facing | Very High | High |
+| Deployment Wave Management | ✅ Completed | User-Facing | Very High | High |
 | Pre/Post Install/Uninstall Script Support | 💡 Idea | User-Facing | Low | Medium |
 | Enhanced CLI Help Menu | 💡 Idea | User-Facing | Low | Medium |
 | Intune App Categorization & Scope Tags | 💡 Idea | User-Facing | Medium | Medium |
@@ -42,8 +42,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 
 **Summary:**
 
-- ✅ **Completed**: 3
-- 🚧 **In Progress**: 1
+- ✅ **Completed**: 4
 - 💡 **Ideas**: 13
 - **Total**: 17 features
 
@@ -51,77 +50,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 
 ## Active Work
 
-### In Progress 🚧
-
-#### Deployment Wave Management
-
-**Status**: 🚧 In Progress
-**Complexity**: Very High (5-10 days)
-**Value**: High
-
-**Description**: Ring-based promotion of published apps via a new
-`napt promote` command with Terraform-style `plan`/`apply` subcommands.
-Apps upload unassigned; promotion advances the newest version through an
-ordered list of rings (Microsoft Entra ID group assignments), replacing
-whatever version each ring currently holds.
-
-Agreed design:
-
-- **Ring model**: A ring is a named set of groups plus `promote_after_days`.
-  Each ring holds at most one version of an app's Update entry — the newest
-  version that has reached it.
-  The install entry gets static assignments (set once); rings control update
-  velocity only.
-- **Plan/apply split**: `napt promote plan` is a pure function of
-  (deployment state, config, clock) and writes a reviewable
-  `state/plan.json`; `napt promote apply` executes it with per-entry
-  validate-then-act, making both safe to re-run.
-- **State split**: The discovery cache moves to `cache/discovery.json`
-  (disposable).
-  Authoritative per-app deployment state lives in
-  `state/deployment/<recipe-id>.json` (deployed, pending, rings, retained),
-  serialized deterministically for clean diffs.
-- **Identity and ownership**: Uploads stamp `napt/v1 id=<recipe>
-  entry=<install|update> sha256=<hash>` into the Intune notes field;
-  `recipe_id + sha256` is the identity key.
-  The `intune.notes` recipe field is removed — the field is reserved for
-  NAPT.
-- **Approval binding**: Upload verifies the installer hash against the
-  approved pending entry, so what a reviewer approved is byte-for-byte what
-  ships.
-- **Idempotent upload**: Reconcile-before-act — adopt an existing stamped
-  app instead of creating a duplicate.
-- **Newest wins**: The pending slot holds one candidate; a newer discovery
-  replaces an unpublished one.
-- **Retention**: Displaced versions are kept per `retain_versions` (default
-  1) for instant rollback, then deleted; only stamped apps are ever touched.
-- **Drift**: Manual admin changes are warned about, never reverted.
-- **GitOps-friendly, not git-aware**: Deterministic state files, detailed
-  exit codes, and reference CI workflows in docs; NAPT itself performs no
-  git or PR operations.
-
-**Benefits**:
-
-- Enables controlled, staged deployments to reduce risk
-- Supports ring-based deployment (Pilot, UAT, Production)
-- Provides rollback capabilities for failed deployments
-- Lets orgs gate publishes and promotions through PR review when state files
-  are committed to git
-- Useful for organizations requiring careful change management
-
-**Dependencies**:
-
-- Requires Graph API assignment endpoints and `Group.Read.All` for group
-  name resolution
-- Delivered across eight PRs: state split (shipped), upload provenance and
-  hash gate (shipped), idempotent upload (shipped), deployment config and
-  assignment client (shipped), `promote plan` and `napt status` (shipped),
-  `promote apply` with retention (shipped), drift detection (shipped),
-  GitOps docs and schema versioning
-
-**Related**: Health-gated promotion (block on install failure rates) and
-native Intune supersedence are deliberate follow-ups, not part of this
-iteration.
+_Nothing currently in progress._
 
 ---
 
@@ -406,6 +335,45 @@ signing)
 ---
 
 ## Recently Completed
+
+#### Deployment Wave Management
+
+**Status**: ✅ Completed
+**Complexity**: Very High
+**Value**: High
+
+**Description**: Ring-based promotion of published apps via
+`napt promote plan` / `napt promote apply` and `napt status`.
+Apps upload unassigned; promotion advances the newest release through an
+ordered list of rings (Entra ID group assignments on the `[Update]`
+entry), displacing whatever release each ring held.
+
+**Key design points** (delivered across PRs #81-#88):
+
+- Each ring holds at most one release — the newest that has reached it;
+  releases advance after `promote_after_days` in their current ring
+- Terraform-style plan/apply: `state/plan.json` is the reviewable
+  artifact and apply's allowlist; validate-then-act makes both safe to
+  re-run
+- Authoritative per-app deployment state
+  (`state/deployment/<id>.json`, `schemaVersion` 1) split from the
+  disposable discovery cache (`cache/discovery.json`)
+- Provenance stamp `napt/v1 id=<recipe> entry=<install|update>
+  sha256=<hash>` in the Intune notes field: ownership + identity;
+  upload is idempotent (adopt, resume, or create) and hash-gated
+  against the reviewed pending release (`deployment.require_pending`)
+- Retention (`retain_versions`) keeps displaced releases for rollback;
+  drift detection warns on every state/Intune discrepancy, never
+  corrects
+- GitOps-friendly, not git-aware: deterministic state files and
+  reference GitHub Actions workflows in
+  [Common Tasks](common-tasks.md#automate-napt-with-github-actions)
+
+**Related**: Health-gated promotion (block on install failure rates),
+native Intune supersedence, and `napt upload --replace` (delete and
+republish with re-applied assignments) are deliberate follow-ups.
+
+---
 
 #### Recipe Schema Redesign
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -470,6 +470,10 @@ napt promote plan --check-drift
 napt promote apply [RECIPE_OR_DIR] [OPTIONS]
 ```
 
+For the full review-gated CI setup — publish PRs, promotion PRs, and
+writeback commits — see
+[Automate NAPT with GitHub Actions](common-tasks.md#automate-napt-with-github-actions).
+
 ### napt status
 
 Shows deployment state across all apps: deployed version, pending release,
@@ -632,6 +636,8 @@ flowchart TD
 ### Deployment State
 
 Each app gets its own file, `state/deployment/<app_id>.json`, so concurrent changes to different apps never conflict and each file's diff is scoped to one app.
+Every file carries a `schemaVersion` (currently 1); NAPT refuses files
+whose schemaVersion is missing or unsupported.
 A file holds four sections:
 
 - `deployed` - The version currently published to Intune, with its SHA-256 hash and Intune app IDs. Null until the first upload.

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -49,6 +49,7 @@ from napt.exceptions import StateError
 from napt.logging import get_global_logger
 from napt.promote.drift import detect_drift
 from napt.promote.planner import (
+    PLAN_SCHEMA_VERSION,
     _collect_recipe_paths,
     plan_path_for,
     plan_promotions,
@@ -86,8 +87,9 @@ def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
         The planned action dicts.
 
     Raises:
-        StateError: If the plan file contains invalid JSON or lacks an
-            actions list.
+        StateError: If the plan file contains invalid JSON, lacks an
+            actions list, or its schemaVersion is missing or
+            unsupported.
 
     """
     try:
@@ -98,6 +100,14 @@ def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
             f"Corrupted plan file: {plan_path}. "
             "Re-run 'napt promote plan' to regenerate it."
         ) from err
+
+    found = data.get("schemaVersion")
+    if found != PLAN_SCHEMA_VERSION:
+        raise StateError(
+            f"Unsupported plan schema version {found!r} in {plan_path} "
+            f"(this NAPT release supports version {PLAN_SCHEMA_VERSION}). "
+            "Re-run 'napt promote plan' to regenerate it."
+        )
     return actions
 
 

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -61,6 +61,10 @@ __all__ = [
 # Deterministic ordering of action types within one app's actions.
 _ACTION_ORDER = {"assign_install": 0, "enter_ring": 1, "advance_ring": 2}
 
+# Schema version written to every plan file. Bump only with a migration
+# story: promote apply rejects plans stamped with a different version.
+PLAN_SCHEMA_VERSION = 1
+
 
 def plan_path_for(state_dir: Path) -> Path:
     """Returns the plan file path for a state directory.
@@ -336,6 +340,11 @@ def write_plan_file(actions: list[dict[str, Any]], plan_path: Path) -> bool:
 
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     with open(plan_path, "w", encoding="utf-8") as f:
-        json.dump({"actions": actions}, f, indent=2, sort_keys=True)
+        json.dump(
+            {"schemaVersion": PLAN_SCHEMA_VERSION, "actions": actions},
+            f,
+            indent=2,
+            sort_keys=True,
+        )
         f.write("\n")  # Trailing newline for git
     return True

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -69,6 +69,10 @@ from typing import Any
 
 from napt.exceptions import StateError
 
+# Schema version written to every deployment state file. Bump only with
+# a migration story: loaders reject files stamped with a different version.
+DEPLOYMENT_STATE_SCHEMA_VERSION = 1
+
 
 def deployment_state_path(state_dir: Path, recipe_id: str) -> Path:
     """Returns the deployment state file path for a recipe.
@@ -94,6 +98,7 @@ def create_default_deployment_state() -> dict[str, Any]:
 
     """
     return {
+        "schemaVersion": DEPLOYMENT_STATE_SCHEMA_VERSION,
         "deployed": None,
         "pending": None,
         "rings": {},
@@ -115,14 +120,15 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
         Deployment state dictionary.
 
     Raises:
-        StateError: If the file exists but contains invalid JSON.
-            Deployment state is authoritative, so a corrupted file is
-            never silently replaced.
+        StateError: If the file exists but contains invalid JSON, or its
+            schemaVersion is missing or unsupported. Deployment state is
+            authoritative, so a corrupted file is never silently
+            replaced.
 
     """
     try:
         with open(state_path, encoding="utf-8") as f:
-            return json.load(f)
+            state = json.load(f)
     except FileNotFoundError:
         return create_default_deployment_state()
     except json.JSONDecodeError as err:
@@ -131,6 +137,17 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
             "Deployment state is authoritative and is not auto-replaced. "
             "Fix the JSON or restore the file from a backup."
         ) from err
+
+    found = state.get("schemaVersion")
+    if found != DEPLOYMENT_STATE_SCHEMA_VERSION:
+        raise StateError(
+            f"Unsupported deployment state schema version {found!r} in "
+            f"{state_path} (this NAPT release supports version "
+            f"{DEPLOYMENT_STATE_SCHEMA_VERSION}). Files from earlier "
+            f'pre-releases need "schemaVersion": '
+            f"{DEPLOYMENT_STATE_SCHEMA_VERSION} added."
+        )
+    return state
 
 
 def save_deployment_state(state: dict[str, Any], state_path: Path) -> None:
@@ -148,6 +165,7 @@ def save_deployment_state(state: dict[str, Any], state_path: Path) -> None:
         OSError: If the file cannot be written due to permissions.
 
     """
+    state["schemaVersion"] = DEPLOYMENT_STATE_SCHEMA_VERSION
     state_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(state_path, "w", encoding="utf-8") as f:

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -405,7 +405,10 @@ class TestWritePlanFile:
         assert write_plan_file(actions, plan_path) is True
 
         assert plan_path.read_bytes() == first
-        assert json.loads(first.decode("utf-8")) == {"actions": actions}
+        assert json.loads(first.decode("utf-8")) == {
+            "actions": actions,
+            "schemaVersion": 1,
+        }
 
     def test_no_actions_removes_stale_plan(self, tmp_path):
         """Tests that an empty plan removes an existing plan file."""

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -203,7 +203,7 @@ def _write_plan(tmp_path: Path, actions: list[dict[str, Any]]) -> Path:
     plan_path = plan_path_for(tmp_path / "state")
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     plan_path.write_text(
-        json.dumps({"actions": actions}, indent=2, sort_keys=True),
+        json.dumps({"schemaVersion": 1, "actions": actions}, indent=2, sort_keys=True),
         encoding="utf-8",
     )
     return plan_path
@@ -533,6 +533,14 @@ class TestLoadPlanFile:
         plan_path.write_text('{"other": []}', encoding="utf-8")
 
         with pytest.raises(StateError, match="Corrupted plan file"):
+            load_plan_file(plan_path)
+
+    def test_unsupported_plan_schema_version_raises(self, tmp_path):
+        """Tests that a future plan schema version is rejected."""
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text('{"schemaVersion": 99, "actions": []}', encoding="utf-8")
+
+        with pytest.raises(StateError, match="schema version 99"):
             load_plan_file(plan_path)
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -283,6 +283,7 @@ class TestDeploymentStateFiles:
         """Tests that the default structure has all empty sections."""
         state = create_default_deployment_state()
 
+        assert state["schemaVersion"] == 1
         assert state["deployed"] is None
         assert state["pending"] is None
         assert state["rings"] == {}
@@ -296,6 +297,35 @@ class TestDeploymentStateFiles:
 
         assert state == create_default_deployment_state()
         assert not state_path.exists()
+
+    def test_save_stamps_schema_version(self, tmp_path):
+        """Tests that saving always writes the schema version."""
+        state_path = tmp_path / "napt-chrome.json"
+        state = {"deployed": None, "pending": None, "rings": {}, "retained": []}
+
+        save_deployment_state(state, state_path)
+
+        loaded = load_deployment_state(state_path)
+        assert loaded["schemaVersion"] == 1
+
+    def test_load_unstamped_file_raises(self, tmp_path):
+        """Tests that a file without a schemaVersion is rejected."""
+        state_path = tmp_path / "napt-chrome.json"
+        state_path.write_text(
+            '{"deployed": null, "pending": null, "rings": {}, "retained": []}',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(StateError, match="schema version None"):
+            load_deployment_state(state_path)
+
+    def test_load_unsupported_schema_version_raises(self, tmp_path):
+        """Tests that a future schema version is rejected."""
+        state_path = tmp_path / "napt-chrome.json"
+        state_path.write_text('{"schemaVersion": 99}', encoding="utf-8")
+
+        with pytest.raises(StateError, match="schema version 99"):
+            load_deployment_state(state_path)
 
     def test_save_and_load_round_trip(self, tmp_path):
         """Tests round-trip save and load."""


### PR DESCRIPTION
## Description

The final PR of the deployment promotion series. Adds the "Automate NAPT with GitHub Actions" reference in common-tasks — four workflows implementing the full review-gated flow (per-app publish PRs from discover, publish-on-merge with hash-gated re-fetch and `[skip ci]` writeback, scheduled promotion-plan PRs with drift reporting, apply-on-merge) — and stamps `schemaVersion: 1` on deployment state and plan files. Moves Deployment Wave Management to Completed on the roadmap.

## Motivation

The workflows are documentation, not product: NAPT stays git-unaware, and orgs copy-paste the choreography. The schema stamp is the last breaking change before the state files become a stable interface: files with a missing or unsupported schemaVersion are refused (no absent-means-v1 tolerance — pre-release, no backward compatibility).

## Changes

- `schemaVersion: 1` written on every deployment-state/plan save; `StateError` on missing/unsupported versions (**BREAKING**: add `"schemaVersion": 1` to files from earlier pre-releases; plan files regenerate)
- GitHub Actions reference section with the publish/promotion PR model, writeback + branch-protection notes, and `require_pending` hardening
- Publish workflow re-fetches installers with `--stateless` so the approved pending hash is never overwritten by a newer vendor binary — the hash gate stays authoritative
- Windows runners documented as required for packaging (IntuneWinAppUtil.exe); untracked-file detection fixed in the PR-opening snippets
- Integration tests no longer leak deployment state into the repo working dir

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

688 tests pass (schema stamp round-trip, missing/unsupported rejection, plan stamp validation). napt-reviewer verdict: ship (both findings addressed, plus follow-up corrections from review discussion).

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors