### PR TITLE
chore: Prepare release 0.7.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-07
+
 ### Added
 
 - **Assignment drift detection** - `napt promote apply` (always) and
@@ -346,7 +348,8 @@ Initial internal release.
 - **Robust Downloads** - Retry logic, atomic writes, SHA-256 verification, and conditional requests
 
 
-[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.7.0...HEAD
+[0.7.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.4.0...0.5.0

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.6.0"
+version = "0.7.0"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description
Release PR for NAPT 0.7.0. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[0.7.0] - 2026-07-07`, and adds a fresh empty `[Unreleased]` section.

## Motivation
Cuts the 0.7.0 release. 

## Changes
- Bump `pyproject.toml` version to 0.7.0
- Bump `napt/__init__.py` `__version__` to 0.7.0
- Promote `[Unreleased]` to `[0.7.0] - 2026-07-07` in `docs/changelog.md`
- Add comparison link `[0.7.0]: ...compare/0.6.0...0.7.0`

Release highlights (from the changelog):
- `napt promote plan` / `napt promote apply` — ring-based update promotion against Intune, with reviewable `state/plan.json`
- `napt status` — deployed version, pending release, and ring positions across all apps
- Assignment drift detection, built-in `"All Users"` / `"All Devices"` targets
- Deployment configuration (`deployment:` recipe section) and per-app deployment state files
- Idempotent upload with resume, provenance stamping, and installer hash verification
- **BREAKING:** deployment state/plan files require `schemaVersion: 1`; `intune.notes` removed; discovery cache moved to `cache/discovery.json` (`--state-file` renamed to `--cache-file`)

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (run via `pytest tests/` — 688 passed)
- [x] Manual testing performed (n/a — release prep only, no code changes)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (changelog promoted)
- [x] Tests pass
- [x] No linting errors