### PR TITLE
fix: Harden build and upload for CI publish runs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `napt upload` failing intermittently with HTTP 403
+    (`SAS identifier cannot be found`) when Azure Storage had not yet
+    propagated a freshly issued SAS URI. Blob uploads now retry
+    transient failures with exponential backoff.
 - Fixed `napt build` failing to find the installer (or its version) on
     machines that never ran `napt discover`, such as CI publish jobs
     restoring `downloads/` from a cache. Build now falls back to the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `napt upload` failing with HTTP 400 (`The mobile app content
+    cannot be updated before the first content version is committed`)
+    when re-running after a crash between app creation and content
+    commit. Such orphaned app records are now deleted and recreated,
+    since Intune cannot resume them in place.
 - Fixed `napt upload` failing intermittently with HTTP 403
     (`SAS identifier cannot be found`) when Azure Storage had not yet
     propagated a freshly issued SAS URI. Blob uploads now retry

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `napt build` failing to find the installer (or its version) on
+    machines that never ran `napt discover`, such as CI publish jobs
+    restoring `downloads/` from a cache. Build now falls back to the
+    pending release URL and version recorded in committed deployment
+    state when the local discovery cache is absent. Previously any
+    non-`url_download` recipe failed with "Cannot locate installer file"
+    in the reference GitOps publish workflow.
+
 ## [0.7.0] - 2026-07-07
 
 ### Added

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -66,6 +66,7 @@ from napt.config import load_effective_config
 from napt.exceptions import ConfigError, PackagingError
 from napt.psadt import get_psadt_release
 from napt.results import BuildResult
+from napt.state import deployment_state_path, load_deployment_state
 from napt.versioning.msi import (
     MSIMetadata,
     extract_msi_metadata,
@@ -119,6 +120,32 @@ def sanitize_filename(name: str, app_id: str = "") -> str:
     return sanitized
 
 
+def _pending_release(config: dict[str, Any]) -> dict[str, Any] | None:
+    """Reads the pending release from the app's deployment state.
+
+    Deployment state is committed alongside recipes, so the pending
+    release (version, sha256, url) is available on machines that never
+    ran discover — such as a CI publish job restoring downloads from a
+    cache.
+
+    Args:
+        config: Recipe configuration.
+
+    Returns:
+        The pending release entry, or None when no state directory is
+            configured or no pending release is recorded.
+
+    Raises:
+        StateError: If the deployment state file exists but is corrupted
+            or has an unsupported schema version.
+    """
+    state_dir = config.get("directories", {}).get("state")
+    if not state_dir:
+        return None
+    state_path = deployment_state_path(Path(state_dir) / "deployment", config["id"])
+    return load_deployment_state(state_path).get("pending")
+
+
 def _get_installer_version(
     installer_file: Path, config: dict[str, Any], cache_file: Path | None = None
 ) -> str:
@@ -128,7 +155,8 @@ def _get_installer_version(
         1. Auto-detect MSI files (`.msi` extension) and extract version
         2. Auto-detect MSIX files (`.msix` extension) and extract version
         3. Fall back to known_version from the discovery cache
-        4. If all else fails, raise an error
+        4. Fall back to the pending release version from deployment state
+        5. If all else fails, raise an error
 
     Args:
         installer_file: Path to the installer file.
@@ -179,6 +207,15 @@ def _get_installer_version(
             logger.verbose("BUILD", f"Using version from cache: {known_version}")
             return known_version
 
+    # Non-MSI/MSIX without a discovery cache: fall back to the pending
+    # release recorded in deployment state
+    pending = _pending_release(config)
+    if pending and pending.get("version"):
+        logger.verbose(
+            "BUILD", f"Using version from deployment state: {pending['version']}"
+        )
+        return pending["version"]
+
     # No version found - provide error
     raise ConfigError(
         f"Could not determine version for {app_id}. Either:\n"
@@ -195,8 +232,10 @@ def _find_installer_file(
     Uses multiple strategies to locate the installer:
     1. URL from recipe (for url_download strategy)
     2. URL from discovery cache (for web_scrape, api_github, api_json strategies)
-    3. Filename matching by app name/id
-    4. Most recent installer (last resort)
+    3. URL of the pending release in deployment state (for machines that
+        never ran discover, such as CI publish jobs)
+    4. Filename matching by app name/id
+    5. Most recent installer (last resort)
 
     Args:
         downloads_dir: Downloads directory to search.
@@ -255,7 +294,23 @@ def _find_installer_file(
         except Exception as err:
             logger.warning("BUILD", f"Could not check discovery cache: {err}")
 
-    # Strategy 3: Fallback - Search for installer matching app name/id
+    # Strategy 3: Extract filename from the pending release URL in
+    # deployment state (committed to the repo, unlike the discovery cache)
+    pending = _pending_release(config)
+    if pending:
+        parsed = urlparse(pending.get("url", ""))
+        filename = Path(parsed.path).name
+        if filename:
+            installer_path = app_dir / filename
+
+            if installer_path.exists():
+                logger.verbose(
+                    "BUILD",
+                    f"Found installer from deployment state: {installer_path}",
+                )
+                return installer_path
+
+    # Strategy 4: Fallback - Search for installer matching app name/id
     app_name = config["name"].lower()
 
     # Try to find installer matching app_id or app_name in filename
@@ -283,8 +338,8 @@ def _find_installer_file(
     # No installer found after trying all strategies
     raise PackagingError(
         f"Cannot locate installer file for {app_id} in {downloads_dir}/{app_id}. "
-        f"Tried locating via recipe URL, state file URL, and filename matching, "
-        f"but no matching installer found. "
+        f"Tried locating via recipe URL, discovery cache URL, deployment "
+        f"state URL, and filename matching, but no matching installer found. "
         f"Verify the installer file exists in {downloads_dir}/{app_id}."
     )
 

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -575,6 +575,70 @@ def create_content_version_file(
     return file_id, data["azureStorageUri"]
 
 
+_BLOB_RETRY_STATUS = (403, 408, 429, 500, 502, 503, 504)
+_BLOB_RETRY_ATTEMPTS = 5
+_BLOB_RETRY_INITIAL_DELAY = 2.0
+
+
+def _blob_put_with_retry(
+    url: str,
+    data: bytes,
+    headers: dict[str, str],
+    context: str,
+    timeout: int = 300,
+) -> None:
+    """PUTs a payload to Azure Blob Storage, retrying transient failures.
+
+    A freshly provisioned SAS URI can be rejected with HTTP 403 ("SAS
+    identifier cannot be found") for a few seconds until the signature
+    propagates to the storage front end, so 403 is retryable here —
+    unlike Graph API calls, where it means missing permissions. Retries
+    use exponential backoff starting at 2 seconds.
+
+    Args:
+        url: Blob endpoint including the SAS query string.
+        data: Request body.
+        headers: Request headers.
+        context: Failure description used in log and error messages.
+        timeout: Per-request timeout in seconds.
+
+    Raises:
+        NetworkError: On a non-retryable HTTP status, or once retries
+            are exhausted.
+
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    delay = _BLOB_RETRY_INITIAL_DELAY
+    for attempt in range(1, _BLOB_RETRY_ATTEMPTS + 1):
+        err: Exception | None = None
+        try:
+            resp = requests.put(url, data=data, headers=headers, timeout=timeout)
+        except requests.RequestException as exc:
+            err = exc
+            detail = str(exc)
+        else:
+            if resp.ok:
+                return
+            detail = f"HTTP {resp.status_code}\n{resp.text}"
+            if resp.status_code not in _BLOB_RETRY_STATUS:
+                raise NetworkError(f"{context}: {detail}")
+
+        if attempt == _BLOB_RETRY_ATTEMPTS:
+            raise NetworkError(
+                f"{context} after {_BLOB_RETRY_ATTEMPTS} attempts: {detail}"
+            ) from err
+
+        logger.warning(
+            "UPLOAD",
+            f"{context} ({detail.splitlines()[0]}); "
+            f"retrying in {delay:.0f}s (attempt {attempt}/{_BLOB_RETRY_ATTEMPTS})",
+        )
+        time.sleep(delay)
+        delay *= 2
+
+
 def upload_to_azure_blob(
     sas_uri: str,
     encrypted_payload_path: Path,
@@ -583,7 +647,9 @@ def upload_to_azure_blob(
 
     Splits the file into CHUNK_SIZE chunks, uploads each as a block with a
     base64-encoded block ID, then commits the block list. Prints an inline
-    progress percentage as each chunk completes.
+    progress percentage as each chunk completes. Transient per-request
+    failures (including 403 from a not-yet-propagated SAS URI) are retried
+    with backoff.
 
     Args:
         sas_uri: Azure Blob Storage SAS URI from create_content_version_file.
@@ -591,7 +657,8 @@ def upload_to_azure_blob(
             (IntunePackage.intunewin from inside the .intunewin ZIP).
 
     Raises:
-        NetworkError: If any block upload or the block list commit fails.
+        NetworkError: If any block upload or the block list commit fails
+            after retries.
 
     """
     from napt.logging import get_global_logger
@@ -616,20 +683,15 @@ def upload_to_azure_blob(
             block_ids.append(block_id)
 
             put_url = f"{sas_uri}&comp=block&blockid={block_id}"
-            resp = requests.put(
+            _blob_put_with_retry(
                 put_url,
-                data=chunk,
+                chunk,
                 headers={
                     "x-ms-blob-type": "BlockBlob",
                     "Content-Length": str(len(chunk)),
                 },
-                timeout=300,
+                context=f"Azure Blob block upload failed (block {block_index})",
             )
-            if not resp.ok:
-                raise NetworkError(
-                    f"Azure Blob block upload failed (block {block_index}): "
-                    f"HTTP {resp.status_code}\n{resp.text}"
-                )
 
             bytes_uploaded += len(chunk)
             if total_bytes:
@@ -648,16 +710,13 @@ def upload_to_azure_blob(
         + "</BlockList>"
     )
     commit_url = f"{sas_uri}&comp=blocklist"
-    resp = requests.put(
+    _blob_put_with_retry(
         commit_url,
-        data=block_list_xml.encode("utf-8"),
+        block_list_xml.encode("utf-8"),
         headers={"Content-Type": "application/xml"},
+        context="Azure Blob block list commit failed",
         timeout=60,
     )
-    if not resp.ok:
-        raise NetworkError(
-            f"Azure Blob block list commit failed: HTTP {resp.status_code}\n{resp.text}"
-        )
 
     elapsed = time.time() - started_at
     speed_mb = (bytes_uploaded / (1024 * 1024)) / elapsed if elapsed > 0 else 0

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -57,6 +57,7 @@ from napt.upload.graph import (
     create_content_version,
     create_content_version_file,
     create_win32_app,
+    delete_mobile_app,
     get_mobile_app,
     list_mobile_apps,
     update_win32_app,
@@ -557,8 +558,10 @@ def _upload_single_app(
     Reconcile-before-act: when a NAPT-stamped app already matches this
     publish instance (recipe id, entry type, installer hash), the app is
     adopted instead of duplicated — skipped entirely if its content is
-    committed, or resumed with a fresh content upload if a previous run
-    crashed between app creation and commit. Otherwise the app record is
+    committed, or deleted and recreated if a previous run crashed between
+    app creation and commit (Intune refuses new content versions for an
+    app whose first content version was never committed, so such an
+    orphan cannot be resumed in place). Otherwise the app record is
     created and its content uploaded and committed.
 
     Adoption does not re-send app metadata or content: a matched app keeps
@@ -594,7 +597,26 @@ def _upload_single_app(
     patch_metadata_after_content = False
     if match is not None:
         intune_app_id: str = match["id"]
-        if force:
+        full_app = get_mobile_app(access_token, intune_app_id)
+        if not full_app.get("committedContentVersion"):
+            # Orphan from a run that crashed between app creation and
+            # content commit. Intune rejects a contentVersions POST until
+            # the first content version is committed, so replace the app
+            # instead of resuming it.
+            logger.step(
+                step_create,
+                total_steps,
+                f"Recreating app record for '{display_name}'...",
+            )
+            delete_mobile_app(access_token, intune_app_id)
+            logger.info(
+                "UPLOAD",
+                f"Deleted Intune app {intune_app_id}: a previous upload "
+                "never committed its content",
+            )
+            intune_app_id = create_win32_app(access_token, app_metadata)
+            logger.info("UPLOAD", f"Created Intune app: {intune_app_id}")
+        elif force:
             logger.step(
                 step_create,
                 total_steps,
@@ -605,28 +627,16 @@ def _upload_single_app(
             # PATCH with HTTP 412 ConditionNotMet (stale internal ETag).
             patch_metadata_after_content = True
         else:
-            full_app = get_mobile_app(access_token, intune_app_id)
-            if full_app.get("committedContentVersion"):
-                logger.step(
-                    step_create,
-                    total_steps,
-                    f"Adopting existing app record for '{display_name}'...",
-                )
-                logger.info(
-                    "UPLOAD",
-                    f"Adopted Intune app: {intune_app_id} (content already committed)",
-                )
-                return intune_app_id
-
             logger.step(
                 step_create,
                 total_steps,
-                f"Resuming upload for existing app record '{display_name}'...",
+                f"Adopting existing app record for '{display_name}'...",
             )
             logger.info(
                 "UPLOAD",
-                f"Reusing Intune app: {intune_app_id} (content was never committed)",
+                f"Adopted Intune app: {intune_app_id} (content already committed)",
             )
+            return intune_app_id
     else:
         logger.step(
             step_create, total_steps, f"Creating app record for '{display_name}'..."

--- a/tests/build/test_manager.py
+++ b/tests/build/test_manager.py
@@ -28,12 +28,27 @@ from napt.build.manager import (
     _create_build_directory,
     _extract_app_icon,
     _find_installer_file,
+    _get_installer_version,
     _write_build_manifest,
 )
 from napt.exceptions import ConfigError
 from napt.versioning.msi import MSIMetadata
 
 # All tests in this file are unit tests (fast, mocked)
+
+
+def _write_pending_state(state_dir: Path, app_id: str, pending: dict) -> None:
+    """Writes a deployment state file with the given pending release."""
+    deployment_dir = state_dir / "deployment"
+    deployment_dir.mkdir(parents=True, exist_ok=True)
+    state = {
+        "schemaVersion": 1,
+        "deployed": None,
+        "pending": pending,
+        "rings": {},
+        "retained": [],
+    }
+    (deployment_dir / f"{app_id}.json").write_text(json.dumps(state))
 
 
 class TestFindInstallerFile:
@@ -105,6 +120,56 @@ class TestFindInstallerFile:
 
         assert result == new
 
+    def test_find_by_deployment_state_url(self, tmp_path):
+        """Tests that the pending release URL locates a vendor filename
+        that name matching cannot."""
+        downloads_dir = tmp_path / "downloads"
+        app_dir = downloads_dir / "napt-test-7zip"
+        app_dir.mkdir(parents=True)
+        installer = app_dir / "7z2602-x64.exe"
+        installer.write_text("fake exe")
+
+        _write_pending_state(
+            tmp_path / "state",
+            "napt-test-7zip",
+            {
+                "version": "26.02",
+                "sha256": "abc123",
+                "url": "https://example.com/dl/7z2602-x64.exe",
+            },
+        )
+
+        config = {
+            "id": "napt-test-7zip",
+            "name": "NAPT Test 7-Zip",
+            "discovery": {},
+            "directories": {"state": str(tmp_path / "state")},
+        }
+
+        result = _find_installer_file(downloads_dir, config)
+
+        assert result == installer
+
+    def test_find_no_pending_state_falls_through(self, tmp_path):
+        """Tests that an empty deployment state falls through to name
+        matching."""
+        downloads_dir = tmp_path / "downloads"
+        app_dir = downloads_dir / "test-app"
+        app_dir.mkdir(parents=True)
+        installer = app_dir / "test-app.msi"
+        installer.write_text("fake msi")
+
+        config = {
+            "id": "test-app",
+            "name": "Test App",
+            "discovery": {},
+            "directories": {"state": str(tmp_path / "state")},
+        }
+
+        result = _find_installer_file(downloads_dir, config)
+
+        assert result == installer
+
     def test_find_not_found_raises(self, tmp_path):
         """Test error when no installer found."""
         downloads_dir = tmp_path / "downloads"
@@ -117,6 +182,75 @@ class TestFindInstallerFile:
 
         with pytest.raises(PackagingError, match="Cannot locate installer file"):
             _find_installer_file(downloads_dir, config)
+
+
+class TestGetInstallerVersion:
+    """Tests for determining installer versions."""
+
+    def test_version_from_deployment_state(self, tmp_path):
+        """Tests that a non-MSI installer version falls back to the
+        pending release in deployment state."""
+        installer = tmp_path / "7z2602-x64.exe"
+        installer.write_text("fake exe")
+
+        _write_pending_state(
+            tmp_path / "state",
+            "napt-test-7zip",
+            {
+                "version": "26.02",
+                "sha256": "abc123",
+                "url": "https://example.com/dl/7z2602-x64.exe",
+            },
+        )
+
+        config = {
+            "id": "napt-test-7zip",
+            "name": "NAPT Test 7-Zip",
+            "directories": {"state": str(tmp_path / "state")},
+        }
+
+        assert _get_installer_version(installer, config) == "26.02"
+
+    def test_discovery_cache_wins_over_state(self, tmp_path):
+        """Tests that the discovery cache version takes priority over
+        deployment state."""
+        installer = tmp_path / "app-setup.exe"
+        installer.write_text("fake exe")
+
+        cache_file = tmp_path / "cache" / "discovery.json"
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text(
+            json.dumps({"apps": {"test-app": {"known_version": "1.2.3"}}})
+        )
+
+        _write_pending_state(
+            tmp_path / "state",
+            "test-app",
+            {"version": "9.9.9", "sha256": "abc123", "url": ""},
+        )
+
+        config = {
+            "id": "test-app",
+            "name": "Test App",
+            "directories": {"state": str(tmp_path / "state")},
+        }
+
+        assert _get_installer_version(installer, config, cache_file) == "1.2.3"
+
+    def test_no_version_source_raises(self, tmp_path):
+        """Tests that a non-MSI installer with no cache and no pending
+        release raises ConfigError."""
+        installer = tmp_path / "app-setup.exe"
+        installer.write_text("fake exe")
+
+        config = {
+            "id": "test-app",
+            "name": "Test App",
+            "directories": {"state": str(tmp_path / "state")},
+        }
+
+        with pytest.raises(ConfigError, match="Could not determine version"):
+            _get_installer_version(installer, config)
 
 
 class TestCreateBuildDirectory:

--- a/tests/upload/test_graph.py
+++ b/tests/upload/test_graph.py
@@ -151,14 +151,57 @@ def test_upload_to_azure_blob_uploads_blocks_and_commits(tmp_path: Path) -> None
 def test_upload_to_azure_blob_block_failure_raises_network_error(
     tmp_path: Path,
 ) -> None:
-    """Tests that a failed block PUT raises NetworkError."""
+    """Tests that a persistently failing block PUT raises NetworkError
+    after exhausting retries."""
     payload = tmp_path / "payload.intunewin"
     payload.write_bytes(b"data")
 
     with req_mock.Mocker() as m:
         m.put(req_mock.ANY, status_code=500)
-        with pytest.raises(NetworkError, match="block upload failed"):
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError, match="block upload failed"):
+                upload_to_azure_blob(SAS_URI, payload)
+
+    assert m.call_count == 5
+
+
+def test_upload_to_azure_blob_retries_transient_403(tmp_path: Path) -> None:
+    """Tests that a transient 403 from a not-yet-propagated SAS URI is
+    retried and the upload succeeds."""
+    payload = tmp_path / "payload.intunewin"
+    payload.write_bytes(b"data")
+
+    with req_mock.Mocker() as m:
+        m.put(
+            req_mock.ANY,
+            [
+                {"text": "SAS identifier cannot be found", "status_code": 403},
+                {"status_code": 201},
+                {"status_code": 201},
+            ],
+        )
+        with patch("napt.upload.graph.time.sleep"):
             upload_to_azure_blob(SAS_URI, payload)
+
+    # One failed block PUT + its retry + the block list commit
+    assert m.call_count == 3
+
+
+def test_upload_to_azure_blob_non_retryable_status_fails_fast(
+    tmp_path: Path,
+) -> None:
+    """Tests that a non-retryable HTTP status raises immediately without
+    retrying."""
+    payload = tmp_path / "payload.intunewin"
+    payload.write_bytes(b"data")
+
+    with req_mock.Mocker() as m:
+        m.put(req_mock.ANY, status_code=400)
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError, match="block upload failed"):
+                upload_to_azure_blob(SAS_URI, payload)
+
+    assert m.call_count == 1
 
 
 # --- commit_content_version_file ---

--- a/tests/upload/test_manager.py
+++ b/tests/upload/test_manager.py
@@ -459,7 +459,8 @@ def _run_upload(
 
     Returns:
         A tuple of (UploadResult, mocks) where mocks holds the
-            "create_app", "create_cv", and "update_app" MagicMocks.
+            "create_app", "create_cv", "update_app", and "delete_app"
+            MagicMocks.
 
     """
     recipe_path = tmp_path / "recipes" / "Vendor" / "test-app.yaml"
@@ -472,6 +473,7 @@ def _run_upload(
         "create_app": MagicMock(side_effect=patches["create_win32_app"]),
         "create_cv": MagicMock(side_effect=patches["create_content_version"]),
         "update_app": MagicMock(),
+        "delete_app": MagicMock(),
     }
     create_app_mock = mocks["create_app"]
     create_cv_mock = mocks["create_cv"]
@@ -523,6 +525,9 @@ def _run_upload(
         )
         stack.enter_context(
             patch("napt.upload.manager.update_win32_app", mocks["update_app"])
+        )
+        stack.enter_context(
+            patch("napt.upload.manager.delete_mobile_app", mocks["delete_app"])
         )
         stack.enter_context(patch("napt.upload.manager.upload_to_azure_blob"))
         stack.enter_context(patch("napt.upload.manager.commit_content_version_file"))
@@ -676,10 +681,14 @@ def test_upload_adopts_committed_stamped_apps(
     assert state["deployed"]["intune_app_id"] == "existing-install"
 
 
-def test_upload_resumes_uncommitted_stamped_app(
+def test_upload_recreates_uncommitted_stamped_app(
     tmp_path: Path, monkeypatch, fake_metadata
 ) -> None:
-    """Tests that an uncommitted stamped app gets content without recreation."""
+    """Tests that an uncommitted stamped app is deleted and recreated.
+
+    Intune refuses new content versions for an app whose first content
+    version was never committed, so a resume-in-place is impossible.
+    """
     monkeypatch.chdir(tmp_path)
     make_package_dir(tmp_path, installer_sha256="a" * 64)
 
@@ -690,10 +699,13 @@ def test_upload_resumes_uncommitted_stamped_app(
         full_app={"committedContentVersion": None},
     )
 
-    mocks["create_app"].assert_not_called()
+    assert mocks["delete_app"].call_count == 2
+    assert mocks["delete_app"].call_args_list[0].args[1] == "existing-install"
+    assert mocks["delete_app"].call_args_list[1].args[1] == "existing-update"
+    assert mocks["create_app"].call_count == 2
     assert mocks["create_cv"].call_count == 2  # content uploaded to both entries
-    assert result.intune_app_id == "existing-install"
-    assert result.intune_update_app_id == "existing-update"
+    assert result.intune_app_id == "intune-app-123"
+    assert result.intune_update_app_id == "intune-update-456"
 
 
 def test_upload_different_hash_creates_new_apps(
@@ -745,6 +757,7 @@ def test_upload_force_reuploads_matched_apps(
         tmp_path,
         fake_metadata,
         existing_apps=_stamped_apps("a" * 64),
+        full_app={"committedContentVersion": "1"},
         force=True,
     )
 
@@ -753,6 +766,29 @@ def test_upload_force_reuploads_matched_apps(
     assert mocks["create_cv"].call_count == 2  # fresh content for both entries
     assert result.intune_app_id == "existing-install"
     assert result.intune_update_app_id == "existing-update"
+
+
+def test_upload_force_recreates_uncommitted_stamped_app(
+    tmp_path: Path, monkeypatch, fake_metadata
+) -> None:
+    """Tests that --force also deletes and recreates an uncommitted app
+    instead of re-uploading in place."""
+    monkeypatch.chdir(tmp_path)
+    make_package_dir(tmp_path, installer_sha256="a" * 64)
+
+    result, mocks = _run_upload(
+        tmp_path,
+        fake_metadata,
+        existing_apps=_stamped_apps("a" * 64),
+        full_app={"committedContentVersion": None},
+        force=True,
+    )
+
+    assert mocks["delete_app"].call_count == 2
+    assert mocks["create_app"].call_count == 2
+    mocks["update_app"].assert_not_called()  # fresh apps need no metadata patch
+    assert result.intune_app_id == "intune-app-123"
+    assert result.intune_update_app_id == "intune-update-456"
 
 
 def test_upload_force_without_match_creates_normally(


### PR DESCRIPTION
## What changed

Three fixes for failures found by end-to-end GitOps testing of the reference publish workflow on GitHub Actions (windows-latest, real Intune tenant):

1. **Build reads deployment state.** `_find_installer_file` and `_get_installer_version` now fall back to the pending release's `url`/`version` in committed deployment state. Previously both relied on the local discovery cache, which never exists on a CI runner that didn't run discover — every `web_scrape` recipe failed with "Cannot locate installer file" in the publish workflow, on both the cache-hit and `--stateless` re-download paths. The locator's error message claimed "state file URL" was tried; now it actually is.

2. **Blob uploads retry transient failures.** Azure Storage can reject a freshly issued SAS URI with HTTP 403 ("SAS identifier cannot be found") for a few seconds until the signature propagates. Block PUTs and the block-list commit now retry 403/408/429/5xx and connection errors with exponential backoff instead of failing the publish.

3. **Orphaned app records are recreated, not resumed.** Intune rejects a `contentVersions` POST for an app whose first content version was never committed, so an app left behind by a crash between creation and commit cannot be resumed in place (HTTP 400). Upload now deletes the stamped orphan and creates a fresh record. This also fixes the same latent failure in `--force`.

## Why

The publish workflow documented in common-tasks.md was broken for any non-`url_download` recipe, and a single mid-upload failure left the tenant in a state no re-run could recover from. All three fixes were validated against a live tenant: run 1 hit bug 1 and (after fixing it) bug 2, leaving a real orphan; the final run adopted the committed entry, recreated the orphan, and published successfully.