### PR TITLE
feat: Recover lost publication writebacks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Publication recovery** - `napt promote apply` (always) and
+    `napt promote plan --reconcile` (opt-in) record publications that are
+    fully committed in Intune but whose deployment state writeback was
+    lost (e.g. a CI runner uploaded successfully, then failed to push the
+    state commit). Recovery uses the same provenance-stamp evidence as
+    idempotent upload adoption, requires every entry of the release to
+    have committed content, and makes the recovered release promotable in
+    the same run. Partially published releases are warned about instead —
+    re-run `napt upload` to finish them
+
 ## [0.7.0] - 2026-07-07
 
 ### Added

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -1016,19 +1016,21 @@ jobs:
         with:
           python-version: "3.13"
       - run: pip install napt
-      - name: Plan promotions (with drift report)
-        run: napt promote plan --check-drift
+      - name: Plan promotions (with drift report and writeback recovery)
+        run: napt promote plan --check-drift --reconcile
       - name: Open or update the promotion PR
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # git status sees untracked files (a first-ever plan) too
-          [ -z "$(git status --porcelain -- state/plan.json)" ] && exit 0
+          # git status sees untracked files (a first-ever plan) too.
+          # Watch all of state/: --reconcile may have repaired a
+          # deployment state file whose publish writeback was lost.
+          [ -z "$(git status --porcelain -- state)" ] && exit 0
           git config user.name "napt-bot"
           git config user.email "napt-bot@users.noreply.github.com"
           git checkout -B napt/promotion-plan origin/main
-          git add state/plan.json
+          git add state
           git commit -m "feat: Plan ring promotions"
           git push -f origin napt/promotion-plan
           gh pr create --head napt/promotion-plan \
@@ -1082,6 +1084,11 @@ jobs:
 - All four workflows are idempotent — re-running any of them converges
   to the same result (upload adopts existing apps, apply skips
   already-applied actions).
+- A publish whose writeback push fails (branch protection, a crashed
+  runner) self-heals: the next plan run's `--reconcile` re-records the
+  publication from tenant evidence, the promotion PR carries the repair,
+  and the recovered release is planned for its first ring in the same
+  run. Re-running the failed publish also converges, just sooner.
 - `windows-latest` runners are required for `napt package`
   (IntuneWinAppUtil.exe is Windows-only). The discover workflow alone
   could run on Linux with `msitools` installed for MSI version

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -445,7 +445,8 @@ napt package recipes/Google/chrome.yaml --version 130.0.6723.116
 Plans and applies ring-based promotion of published apps. `promote plan`
 computes which releases enter or advance deployment rings (per
 `deployment.rings`) and writes `state/plan.json` when there is work; a
-stale plan file is removed when nothing is eligible. Read-only.
+stale plan file is removed when nothing is eligible. Read-only unless
+`--reconcile` is passed.
 
 `promote apply` executes the plan against Intune: assigns install entries,
 enters and advances rings, unassigns displaced releases, and retires them
@@ -464,9 +465,22 @@ state file references. Drift is warned about and never corrected. Apply
 checks automatically; plan checks with `--check-drift` (which needs Graph
 credentials — without the flag, plan stays fully offline).
 
+Both commands also recover **lost publication writebacks**: when an
+upload succeeded but the state commit recording it never landed (a CI
+push rejected by branch protection, a crashed runner), the tenant holds
+a fully published release that state still lists as pending. Recovery
+re-derives the deployed record from the same provenance-stamp evidence
+idempotent upload uses, and only when every entry of the release has
+committed content — a partially published release is warned about
+instead, since only a publish re-run can finish it. Apply reconciles
+automatically; plan reconciles with `--reconcile` (which needs Graph
+credentials and, unlike the rest of plan, writes deployment state).
+Reconciliation runs before planning, so a recovered release is
+promotable in the same run.
+
 ```bash
 napt promote plan [RECIPE_OR_DIR] [OPTIONS]
-napt promote plan --check-drift
+napt promote plan --check-drift --reconcile
 napt promote apply [RECIPE_OR_DIR] [OPTIONS]
 ```
 

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -101,14 +101,18 @@ from napt.exceptions import (
 from napt.logging import get_logger, set_global_logger
 from napt.promote import (
     apply_plan,
-    check_drift,
+    detect_drift,
+    load_recipe_configs,
     plan_path_for,
     plan_promotions,
+    reconcile_publications,
     resolve_state_dir,
     write_plan_file,
 )
 from napt.state import summarize_deployment_states
 from napt.upload import upload_package
+from napt.upload.auth import get_access_token
+from napt.upload.graph import list_mobile_apps
 from napt.validation import validate_recipe
 
 
@@ -674,8 +678,9 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
     Computes promotion actions for all recipes (or one recipe) as a pure
     function of deployment state, configuration, and the clock, and
     writes the plan file when there is work. Read-only with respect to
-    Intune and deployment state; the plan file is the only output. A
-    stale plan file is removed when no actions are eligible.
+    Intune, and — unless --reconcile recovers a lost publication
+    writeback first — to deployment state; a stale plan file is removed
+    when no actions are eligible.
 
     Args:
         args: Parsed command-line arguments containing the recipes path,
@@ -701,11 +706,25 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
             else resolve_state_dir(recipes)
         )
         plan_path = plan_path_for(state_dir)
+        recovered: list[dict[str, Any]] = []
+        drift: list[dict[str, Any]] = []
+        if args.reconcile or args.check_drift:
+            # One authenticated session serves both reconciliation and
+            # the drift check; drift runs second so it sees repaired
+            # state. Planning is offline and needs none of this.
+            configs = load_recipe_configs(recipes)
+            access_token = get_access_token()
+            existing_apps = list_mobile_apps(access_token)
+            if args.reconcile:
+                recovered = reconcile_publications(
+                    access_token, configs, state_dir / "deployment", existing_apps
+                )
+            if args.check_drift:
+                drift = detect_drift(
+                    access_token, configs, state_dir / "deployment", existing_apps
+                )
         actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
         write_plan_file(actions, plan_path)
-        drift = (
-            check_drift(recipes, state_dir / "deployment") if args.check_drift else []
-        )
     except AuthError as err:
         print(f"Authentication error: {err}")
         if args.verbose or args.debug:
@@ -743,6 +762,8 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
         print()
         print("[OK] Nothing to promote. No plan file needed.")
 
+    if args.reconcile:
+        _print_recovered(recovered)
     if args.check_drift:
         _print_drift(drift)
 
@@ -760,6 +781,21 @@ def _print_drift(drift: list[dict[str, Any]]) -> None:
             print(f"  [WARNING] {finding['app_id']}: {finding['detail']}")
     else:
         print("  No drift detected.")
+    print("=" * 70)
+
+
+def _print_recovered(recovered: list[dict[str, Any]]) -> None:
+    """Prints publication reconciliation findings as a section."""
+    print()
+    print("=" * 70)
+    print("PUBLICATION RECONCILIATION")
+    print("=" * 70)
+    if recovered:
+        for finding in recovered:
+            marker = "[OK]" if finding["kind"] == "recovered" else "[WARNING]"
+            print(f"  {marker} {finding['app_id']}: {finding['detail']}")
+    else:
+        print("  Nothing to recover.")
     print("=" * 70)
 
 
@@ -837,6 +873,8 @@ def cmd_promote_apply(args: argparse.Namespace) -> int:
         print(f"  [SKIP] {_describe_action(entry['action'])} ({entry['reason']})")
     print("=" * 70)
 
+    if summary.get("recovered"):
+        _print_recovered(summary["recovered"])
     if summary.get("drift"):
         _print_drift(summary["drift"])
 
@@ -1386,9 +1424,11 @@ def main() -> None:
         help="Compute eligible promotions and write the plan file",
         description=(
             "Compute which releases enter or advance deployment rings, and "
-            "write state/plan.json when there is work. Read-only: neither "
-            "Intune nor deployment state is modified. A stale plan file is "
-            "removed when nothing is eligible."
+            "write state/plan.json when there is work. Never modifies "
+            "Intune. Read-only for deployment state too, except that "
+            "--reconcile writes it when recovering a lost publication "
+            "writeback. A stale plan file is removed when nothing is "
+            "eligible."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1413,6 +1453,16 @@ def main() -> None:
         help=(
             "Also compare Intune assignments against deployment state "
             "(requires Graph credentials); findings are warnings only"
+        ),
+    )
+    parser_promote_plan.add_argument(
+        "--reconcile",
+        action="store_true",
+        help=(
+            "Before planning, record publications that are committed in "
+            "Intune but whose deployment state writeback was lost, so "
+            "they are promotable in this run (requires Graph credentials; "
+            "writes deployment state)"
         ),
     )
     parser_promote_plan.add_argument(

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -17,7 +17,7 @@
 Implements ring-based promotion of published apps: ``napt promote plan``
 computes which releases should enter or advance through the configured
 deployment rings and writes a reviewable plan file; ``napt promote apply``
-(upcoming) executes a plan against Intune.
+executes a plan against Intune.
 
 The core invariant: each ring holds at most one release of an app's Update
 entry — the newest release that has reached it. Promotion advances the
@@ -27,24 +27,31 @@ the ring's ``promote_after_days``.
 Assignment drift — differences between what deployment state says should
 be assigned and what Intune actually has — is detected on every apply and
 on ``plan --check-drift``, and is always reported, never corrected.
+
+Publications whose deployment state writeback was lost (e.g. a failed CI
+push after a successful upload) are recovered from tenant evidence on
+every apply and on ``plan --reconcile``.
 """
 
 from .applier import apply_plan, load_plan_file
-from .drift import check_drift, detect_drift
+from .drift import detect_drift
 from .planner import (
+    load_recipe_configs,
     plan_path_for,
     plan_promotions,
     resolve_state_dir,
     write_plan_file,
 )
+from .reconcile import reconcile_publications
 
 __all__ = [
     "apply_plan",
-    "check_drift",
     "detect_drift",
     "load_plan_file",
+    "load_recipe_configs",
     "plan_path_for",
     "plan_promotions",
+    "reconcile_publications",
     "resolve_state_dir",
     "write_plan_file",
 ]

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -44,16 +44,16 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt.config import load_effective_config
 from napt.exceptions import StateError
 from napt.logging import get_global_logger
 from napt.promote.drift import detect_drift
 from napt.promote.planner import (
     PLAN_SCHEMA_VERSION,
-    _collect_recipe_paths,
+    load_recipe_configs,
     plan_path_for,
     plan_promotions,
 )
+from napt.promote.reconcile import reconcile_publications
 from napt.state import (
     deployment_state_path,
     load_deployment_state,
@@ -438,7 +438,13 @@ def apply_plan(
 
     Assignment drift is checked on every run — including runs with
     nothing to apply, which therefore still authenticate — and reported
-    in the summary, never corrected.
+    in the summary, never corrected. Publications whose state writeback
+    was lost are recovered first (see
+    [reconcile_publications][napt.promote.reconcile.reconcile_publications]).
+    When planning fresh, recovery runs before the plan is computed, so a
+    recovered release is promotable in the same run; a pre-existing plan
+    file was computed earlier and gains nothing from the recovery — the
+    next plan run picks the release up.
 
     Args:
         recipes: A recipe YAML file, or a directory scanned recursively.
@@ -451,8 +457,8 @@ def apply_plan(
             Defaults to the current UTC time.
 
     Returns:
-        A summary dict with "applied" and "skipped" action lists and
-            "drift" findings.
+        A summary dict with "applied" and "skipped" action lists,
+            "drift" findings, and "recovered" reconciliation findings.
 
     Raises:
         AuthError: If authentication fails.
@@ -468,6 +474,20 @@ def apply_plan(
     plan_path = plan_file if plan_file is not None else plan_path_for(state_dir)
     deployment_dir = state_dir / "deployment"
 
+    configs = load_recipe_configs(recipes)
+
+    # Authenticate even when there is nothing to apply: the steady state
+    # (no eligible promotions) is exactly when out-of-band assignment
+    # changes accumulate, so drift is checked on every apply run.
+    access_token = get_access_token()
+    run = _ApplyRun(access_token, configs, deployment_dir, now)
+
+    # Recover lost publication writebacks before planning, so a
+    # recovered release is promotable in this same run.
+    recovered = reconcile_publications(
+        access_token, configs, deployment_dir, run.existing_apps
+    )
+
     from_file = plan_path.exists()
     if from_file:
         actions = load_plan_file(plan_path)
@@ -475,19 +495,6 @@ def apply_plan(
     else:
         actions = plan_promotions(recipes, state_dir=deployment_dir, now=now)
         logger.info("PROMOTE", "No plan file found; planning and applying")
-
-    configs = {
-        config["id"]: config
-        for config in (
-            load_effective_config(path) for path in _collect_recipe_paths(recipes)
-        )
-    }
-
-    # Authenticate even when there is nothing to apply: the steady state
-    # (no eligible promotions) is exactly when out-of-band assignment
-    # changes accumulate, so drift is checked on every apply run.
-    access_token = get_access_token()
-    run = _ApplyRun(access_token, configs, deployment_dir, now)
 
     for action in actions:
         if action["app_id"] not in configs:
@@ -506,4 +513,9 @@ def apply_plan(
     # are reflected. Findings are warnings only, never corrected.
     drift = detect_drift(access_token, configs, deployment_dir, run.existing_apps)
 
-    return {"applied": run.applied, "skipped": run.skipped, "drift": drift}
+    return {
+        "applied": run.applied,
+        "skipped": run.skipped,
+        "drift": drift,
+        "recovered": recovered,
+    }

--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -39,18 +39,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from napt.config import load_effective_config
-from napt.promote.planner import _collect_recipe_paths
 from napt.state import deployment_state_path, load_deployment_state
-from napt.upload.auth import get_access_token
 from napt.upload.graph import (
     get_app_assignments,
-    list_mobile_apps,
     resolve_assignment_target,
 )
 from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, parse_stamp
 
-__all__ = ["check_drift", "detect_drift"]
+__all__ = ["detect_drift"]
 
 
 def _target_key(target: dict[str, Any] | None) -> tuple[str, str]:
@@ -283,33 +279,3 @@ def detect_drift(
     return findings
 
 
-def check_drift(recipes: Path, deployment_dir: Path) -> list[dict[str, Any]]:
-    """Authenticates and detects drift for a recipe or directory of recipes.
-
-    Convenience wrapper for standalone drift checks (``napt promote plan
-    --check-drift``): loads the effective configurations, authenticates,
-    lists the tenant, and runs detect_drift.
-
-    Args:
-        recipes: A recipe YAML file, or a directory scanned recursively.
-        deployment_dir: Directory holding per-app deployment state files.
-
-    Returns:
-        Finding dicts from detect_drift.
-
-    Raises:
-        AuthError: If authentication fails.
-        ConfigError: On invalid recipes or unresolvable groups.
-        NetworkError: On Graph API failures.
-        StateError: On a corrupted deployment state file.
-
-    """
-    configs = {
-        config["id"]: config
-        for config in (
-            load_effective_config(path) for path in _collect_recipe_paths(recipes)
-        )
-    }
-    access_token = get_access_token()
-    existing_apps = list_mobile_apps(access_token)
-    return detect_drift(access_token, configs, deployment_dir, existing_apps)

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -52,6 +52,7 @@ from napt.logging import get_global_logger
 from napt.state import deployment_state_path, load_deployment_state
 
 __all__ = [
+    "load_recipe_configs",
     "plan_path_for",
     "plan_promotions",
     "resolve_state_dir",
@@ -237,6 +238,28 @@ def _collect_recipe_paths(recipes: Path) -> list[Path]:
             raise ConfigError(f"No recipe files found under {recipes}")
         return found
     raise ConfigError(f"Recipe path not found: {recipes}")
+
+
+def load_recipe_configs(recipes: Path) -> dict[str, dict[str, Any]]:
+    """Loads effective configurations for a recipe file or directory.
+
+    Args:
+        recipes: A recipe YAML file, or a directory scanned recursively.
+
+    Returns:
+        Effective configurations keyed by recipe id.
+
+    Raises:
+        ConfigError: If the path does not exist, contains no recipes, or
+            a recipe is invalid.
+
+    """
+    return {
+        config["id"]: config
+        for config in (
+            load_effective_config(path) for path in _collect_recipe_paths(recipes)
+        )
+    }
 
 
 def resolve_state_dir(recipes: Path) -> Path:

--- a/napt/promote/reconcile.py
+++ b/napt/promote/reconcile.py
@@ -1,0 +1,163 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Publication recovery for lost deployment state writebacks.
+
+A publish run records the pending-to-deployed transition in deployment
+state after uploading, but that record can be lost — most commonly when
+a CI runner uploads successfully and then fails to push the state commit
+(branch protection, network). The tenant then holds a fully published
+release that state still lists as pending, which blocks promotion
+planning and, if a newer discovery replaces the pending slot, orphans
+the published release permanently.
+
+Reconciliation closes that gap by re-deriving the record from tenant
+evidence: when every entry the app's ``build_types`` requires exists in
+Intune, stamped for the pending release's installer hash and with
+committed content, the publication demonstrably succeeded and
+``deployed`` is recorded exactly as the publish run would have. This
+trusts provenance stamps and committed content the same way idempotent
+upload adoption already does — no new trust is introduced.
+
+Unlike drift detection, which never corrects, reconciliation writes
+deployment state: it completes NAPT's own half-persisted transaction
+rather than overriding an admin's tenant change.
+
+Finding kinds:
+
+- ``recovered``: The publication was fully committed in the tenant and
+    has been recorded as deployed.
+- ``incomplete``: Some required entries are missing or their content was
+    never committed; nothing is recorded — re-run publish to finish.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from napt.logging import get_global_logger
+from napt.state import (
+    deployment_state_path,
+    load_deployment_state,
+    record_deployed,
+    save_deployment_state,
+)
+from napt.upload.graph import get_mobile_app
+from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
+
+__all__ = ["reconcile_publications"]
+
+_REQUIRED_ENTRIES = {
+    "both": (ENTRY_INSTALL, ENTRY_UPDATE),
+    "app_only": (ENTRY_INSTALL,),
+    "update_only": (ENTRY_UPDATE,),
+}
+
+
+def reconcile_publications(
+    access_token: str,
+    configs: dict[str, dict[str, Any]],
+    deployment_dir: Path,
+    existing_apps: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Records publications whose deployment state writeback was lost.
+
+    For each app with a pending release, checks the tenant for stamped
+    entries matching the pending installer hash. When every entry
+    required by the app's ``build_types`` exists with committed content,
+    records the release as deployed (clearing the pending slot) exactly
+    as the original publish run would have. Partial evidence — some
+    entries missing or uncommitted — is warned about but never recorded,
+    because only a publish re-run can finish the upload.
+
+    Apps whose pending release has no stamped entries at all are the
+    normal awaiting-publication case and produce no finding.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        configs: Effective configurations keyed by recipe id.
+        deployment_dir: Directory holding per-app deployment state files.
+        existing_apps: Mobile app dicts from list_mobile_apps.
+
+    Returns:
+        Finding dicts, each with "app_id", "kind" ("recovered" or
+            "incomplete"), and "detail" keys, sorted for deterministic
+            output. Empty when no pending release has tenant evidence.
+
+    Raises:
+        AuthError: On 401 or 403.
+        NetworkError: On Graph API failures.
+        StateError: On a corrupted deployment state file.
+
+    """
+    logger = get_global_logger()
+    findings: list[dict[str, Any]] = []
+
+    for app_id, config in configs.items():
+        state_path = deployment_state_path(deployment_dir, app_id)
+        state = load_deployment_state(state_path)
+        pending = state.get("pending")
+        if not pending:
+            continue
+
+        sha256 = pending["sha256"]
+        required = _REQUIRED_ENTRIES[config["intune"]["build_types"]]
+        matches = {
+            entry: find_stamped_app(existing_apps, app_id, entry, sha256)
+            for entry in required
+        }
+        if not any(matches.values()):
+            continue  # Never published; a normal pending release.
+
+        problems: list[str] = []
+        for entry, match in matches.items():
+            if match is None:
+                problems.append(f"no stamped {entry} entry exists")
+                continue
+            full_app = get_mobile_app(access_token, match["id"])
+            if not full_app.get("committedContentVersion"):
+                problems.append(f"the {entry} entry's content was never committed")
+
+        version = pending["version"]
+        if problems:
+            detail = (
+                f"pending release {version} ({sha256[:12]}) was partially "
+                f"published: {'; '.join(problems)} - re-run publish to finish"
+            )
+            logger.warning("PROMOTE", f"{app_id}: {detail}")
+            findings.append(
+                {"app_id": app_id, "kind": "incomplete", "detail": detail}
+            )
+            continue
+
+        install_match = matches.get(ENTRY_INSTALL)
+        update_match = matches.get(ENTRY_UPDATE)
+        record_deployed(
+            state,
+            version=version,
+            sha256=sha256,
+            intune_app_id=install_match["id"] if install_match else None,
+            intune_update_app_id=update_match["id"] if update_match else None,
+        )
+        save_deployment_state(state, state_path)
+        detail = (
+            f"recorded publication of {version} ({sha256[:12]}): all entries "
+            "are committed in the tenant but the deployed record was missing"
+        )
+        logger.info("PROMOTE", f"{app_id}: {detail}")
+        findings.append({"app_id": app_id, "kind": "recovered", "detail": detail})
+
+    findings.sort(key=lambda f: (f["app_id"], f["kind"], f["detail"]))
+    return findings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -750,7 +750,10 @@ class TestCmdPromotePlan:
         ):
             code = cmd_promote_plan(
                 _args(
-                    recipes="recipes", state_dir=tmp_path / "state", check_drift=False
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=False,
                 )
             )
         assert code == 0
@@ -767,7 +770,10 @@ class TestCmdPromotePlan:
         ):
             code = cmd_promote_plan(
                 _args(
-                    recipes="recipes", state_dir=tmp_path / "state", check_drift=False
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=False,
                 )
             )
         assert code == 0
@@ -779,7 +785,10 @@ class TestCmdPromotePlan:
         with patch("napt.cli.plan_promotions", side_effect=ConfigError("bad")):
             code = cmd_promote_plan(
                 _args(
-                    recipes="recipes", state_dir=tmp_path / "state", check_drift=False
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=False,
                 )
             )
         assert code == 1
@@ -946,13 +955,17 @@ class TestDriftOutput:
         with (
             patch("napt.cli.plan_promotions", return_value=[]),
             patch("napt.cli.write_plan_file", return_value=False),
-            patch("napt.cli.check_drift", return_value=[finding]),
+            patch("napt.cli.load_recipe_configs", return_value={}),
+            patch("napt.cli.get_access_token", return_value="tok"),
+            patch("napt.cli.list_mobile_apps", return_value=[]),
+            patch("napt.cli.detect_drift", return_value=[finding]),
         ):
             code = cmd_promote_plan(
                 _args(
                     recipes="recipes",
                     state_dir=tmp_path / "state",
                     check_drift=True,
+                    reconcile=False,
                 )
             )
         assert code == 0
@@ -981,3 +994,123 @@ class TestDriftOutput:
         out = capsys.readouterr().out
         assert "DRIFT CHECK" in out
         assert "[WARNING] test-app: stray app" in out
+
+
+# =============================================================================
+# reconciliation output
+# =============================================================================
+
+
+class TestReconcileOutput:
+    """Tests for publication reconciliation presentation."""
+
+    def test_plan_reconcile_prints_findings(self, tmp_path, capsys):
+        """Tests that --reconcile findings are printed with kind markers."""
+        findings = [
+            {
+                "app_id": "test-app",
+                "kind": "recovered",
+                "detail": "recorded publication of 2.0.0",
+            },
+            {
+                "app_id": "other-app",
+                "kind": "incomplete",
+                "detail": "partially published - re-run publish to finish",
+            },
+        ]
+        with (
+            patch("napt.cli.plan_promotions", return_value=[]),
+            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.load_recipe_configs", return_value={}),
+            patch("napt.cli.get_access_token", return_value="tok"),
+            patch("napt.cli.list_mobile_apps", return_value=[]),
+            patch("napt.cli.reconcile_publications", return_value=findings),
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=True,
+                )
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "PUBLICATION RECONCILIATION" in out
+        assert "[OK] test-app: recorded publication of 2.0.0" in out
+        assert "[WARNING] other-app:" in out
+
+    def test_plan_reconcile_runs_before_planning(self, tmp_path, capsys):
+        """Tests that reconciliation happens before the plan is computed."""
+        order: list[str] = []
+        with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
+            patch("napt.cli.get_access_token", return_value="tok"),
+            patch("napt.cli.list_mobile_apps", return_value=[]),
+            patch(
+                "napt.cli.reconcile_publications",
+                side_effect=lambda *a: order.append("reconcile") or [],
+            ),
+            patch(
+                "napt.cli.plan_promotions",
+                side_effect=lambda *a, **k: order.append("plan") or [],
+            ),
+            patch("napt.cli.write_plan_file", return_value=False),
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=True,
+                )
+            )
+        assert code == 0
+        assert order == ["reconcile", "plan"]
+
+    def test_plan_shares_one_session_for_reconcile_and_drift(self, tmp_path):
+        """Tests that --reconcile --check-drift together authenticate and
+        list the tenant only once."""
+        with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
+            patch("napt.cli.get_access_token", return_value="tok") as auth_mock,
+            patch("napt.cli.list_mobile_apps", return_value=[]) as list_mock,
+            patch("napt.cli.reconcile_publications", return_value=[]),
+            patch("napt.cli.detect_drift", return_value=[]),
+            patch("napt.cli.plan_promotions", return_value=[]),
+            patch("napt.cli.write_plan_file", return_value=False),
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=True,
+                    reconcile=True,
+                )
+            )
+        assert code == 0
+        assert auth_mock.call_count == 1
+        assert list_mock.call_count == 1
+
+    def test_apply_prints_recovered_from_summary(self, tmp_path, capsys):
+        """Tests that apply prints reconciliation findings from the summary."""
+        summary = {
+            "applied": [],
+            "skipped": [],
+            "drift": [],
+            "recovered": [
+                {
+                    "app_id": "test-app",
+                    "kind": "recovered",
+                    "detail": "recorded publication of 2.0.0",
+                }
+            ],
+        }
+        with patch("napt.cli.apply_plan", return_value=summary):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "PUBLICATION RECONCILIATION" in out
+        assert "[OK] test-app: recorded publication of 2.0.0" in out

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -190,6 +190,14 @@ def _run_apply(
                 return_value=drift_findings or [],
             )
         )
+        # Reconciliation's committed-content lookups; only reached when a
+        # test seeds a pending release with stamped tenant entries.
+        stack.enter_context(
+            patch(
+                "napt.promote.reconcile.get_mobile_app",
+                return_value={"committedContentVersion": "1"},
+            )
+        )
         summary = apply_plan(
             tmp_path / "recipes",
             state_dir=tmp_path / "state",
@@ -499,8 +507,39 @@ class TestApplyOrchestration:
 
         summary, mocks = _run_apply(tmp_path, existing_apps=[])
 
-        assert summary == {"applied": [], "skipped": [], "drift": []}
+        assert summary == {
+            "applied": [],
+            "skipped": [],
+            "drift": [],
+            "recovered": [],
+        }
         mocks["assign_app"].assert_not_called()
+
+    def test_recovers_lost_writeback_and_promotes_same_run(self, tmp_path):
+        """Tests that a publication whose writeback was lost is recovered
+        and enters the first ring in the same apply run."""
+        _write_recipe(tmp_path, rings=_RINGS)
+        # State still shows the release as pending: the publish run
+        # uploaded successfully but its state commit never landed.
+        state = create_default_deployment_state()
+        state["pending"] = {
+            "version": "2.0.0",
+            "sha256": "b" * 64,
+            "url": "https://example.com/app.msi",
+        }
+        state_path = deployment_state_path(
+            tmp_path / "state" / "deployment", "test-app"
+        )
+        save_deployment_state(state, state_path)
+
+        summary, _ = _run_apply(tmp_path, existing_apps=_tenant())
+
+        assert [f["kind"] for f in summary["recovered"]] == ["recovered"]
+        assert [a["type"] for a in summary["applied"]] == ["enter_ring"]
+        state = load_deployment_state(state_path)
+        assert state["pending"] is None
+        assert state["deployed"]["intune_app_id"] == "install-new"
+        assert state["rings"]["pilot"]["sha256"] == "b" * 64
 
     def test_unknown_app_in_plan_skipped(self, tmp_path):
         """Tests that a plan action without a matching recipe is skipped."""

--- a/tests/test_promote_reconcile.py
+++ b/tests/test_promote_reconcile.py
@@ -1,0 +1,193 @@
+"""Tests for napt.promote.reconcile."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from napt.promote.reconcile import reconcile_publications
+from napt.state import (
+    create_default_deployment_state,
+    deployment_state_path,
+    load_deployment_state,
+    save_deployment_state,
+)
+
+TOKEN = "fake-token"
+SHA = "b" * 64
+
+
+def _configs(app_id: str = "test-app", build_types: str = "both") -> dict[str, Any]:
+    return {app_id: {"id": app_id, "intune": {"build_types": build_types}}}
+
+
+def _write_pending(
+    deployment_dir: Path,
+    app_id: str = "test-app",
+    version: str = "2.0.0",
+    sha256: str = SHA,
+) -> Path:
+    state = create_default_deployment_state()
+    state["pending"] = {
+        "version": version,
+        "sha256": sha256,
+        "url": "https://vendor.com/app.msi",
+    }
+    path = deployment_state_path(deployment_dir, app_id)
+    save_deployment_state(state, path)
+    return path
+
+
+def _stamped(app_id: str, entry: str, sha256: str, graph_id: str) -> dict[str, Any]:
+    return {
+        "id": graph_id,
+        "displayName": app_id,
+        "notes": f"napt/v1 id={app_id} entry={entry} sha256={sha256}",
+    }
+
+
+def _committed(*_args) -> dict[str, Any]:
+    return {"committedContentVersion": "1"}
+
+
+class TestReconcilePublications:
+    """Tests for recovering lost publication writebacks."""
+
+    def test_recovers_fully_committed_publication(self, tmp_path):
+        """Tests that a pending release with all entries committed in the
+        tenant is recorded as deployed."""
+        state_path = _write_pending(tmp_path)
+        apps = [
+            _stamped("test-app", "install", SHA, "install-1"),
+            _stamped("test-app", "update", SHA, "update-1"),
+        ]
+
+        with patch(
+            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
+        ):
+            findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
+
+        assert [f["kind"] for f in findings] == ["recovered"]
+        state = load_deployment_state(state_path)
+        assert state["pending"] is None
+        assert state["deployed"] == {
+            "version": "2.0.0",
+            "sha256": SHA,
+            "intune_app_id": "install-1",
+            "intune_update_app_id": "update-1",
+        }
+
+    def test_app_only_requires_only_install_entry(self, tmp_path):
+        """Tests that build_types app_only recovers from the install entry
+        alone."""
+        state_path = _write_pending(tmp_path)
+        apps = [_stamped("test-app", "install", SHA, "install-1")]
+
+        with patch(
+            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
+        ):
+            findings = reconcile_publications(
+                TOKEN, _configs(build_types="app_only"), tmp_path, apps
+            )
+
+        assert [f["kind"] for f in findings] == ["recovered"]
+        state = load_deployment_state(state_path)
+        assert state["deployed"]["intune_app_id"] == "install-1"
+        assert state["deployed"]["intune_update_app_id"] is None
+
+    def test_update_only_requires_only_update_entry(self, tmp_path):
+        """Tests that build_types update_only recovers from the update entry
+        alone."""
+        state_path = _write_pending(tmp_path)
+        apps = [_stamped("test-app", "update", SHA, "update-1")]
+
+        with patch(
+            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
+        ):
+            findings = reconcile_publications(
+                TOKEN, _configs(build_types="update_only"), tmp_path, apps
+            )
+
+        assert [f["kind"] for f in findings] == ["recovered"]
+        state = load_deployment_state(state_path)
+        assert state["deployed"]["intune_app_id"] is None
+        assert state["deployed"]["intune_update_app_id"] == "update-1"
+
+    def test_missing_entry_warns_without_recording(self, tmp_path):
+        """Tests that a missing required entry reports incomplete and leaves
+        state untouched."""
+        state_path = _write_pending(tmp_path)
+        apps = [_stamped("test-app", "install", SHA, "install-1")]
+
+        with patch(
+            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
+        ):
+            findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
+
+        assert [f["kind"] for f in findings] == ["incomplete"]
+        assert "no stamped update entry" in findings[0]["detail"]
+        state = load_deployment_state(state_path)
+        assert state["deployed"] is None
+        assert state["pending"]["sha256"] == SHA
+
+    def test_uncommitted_content_warns_without_recording(self, tmp_path):
+        """Tests that an entry with uncommitted content reports incomplete
+        and leaves state untouched."""
+        state_path = _write_pending(tmp_path)
+        apps = [
+            _stamped("test-app", "install", SHA, "install-1"),
+            _stamped("test-app", "update", SHA, "update-1"),
+        ]
+
+        def by_id(_token: str, graph_id: str) -> dict[str, Any]:
+            if graph_id == "update-1":
+                return {"committedContentVersion": None}
+            return {"committedContentVersion": "1"}
+
+        with patch("napt.promote.reconcile.get_mobile_app", side_effect=by_id):
+            findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
+
+        assert [f["kind"] for f in findings] == ["incomplete"]
+        assert "never committed" in findings[0]["detail"]
+        state = load_deployment_state(state_path)
+        assert state["deployed"] is None
+        assert state["pending"]["sha256"] == SHA
+
+    def test_unpublished_pending_is_silent(self, tmp_path):
+        """Tests that a pending release with no stamped entries produces no
+        findings and no tenant lookups."""
+        _write_pending(tmp_path)
+        apps = [_stamped("test-app", "install", "c" * 64, "other-release")]
+
+        with patch("napt.promote.reconcile.get_mobile_app") as get_mock:
+            findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
+
+        assert findings == []
+        get_mock.assert_not_called()
+
+    def test_no_pending_is_silent(self, tmp_path):
+        """Tests that an app without a pending release produces no findings."""
+        state = create_default_deployment_state()
+        state["deployed"] = {
+            "version": "1.0.0",
+            "sha256": "a" * 64,
+            "intune_app_id": "i",
+            "intune_update_app_id": "u",
+        }
+        save_deployment_state(
+            state, deployment_state_path(tmp_path, "test-app")
+        )
+        apps = [_stamped("test-app", "install", "a" * 64, "install-1")]
+
+        with patch("napt.promote.reconcile.get_mobile_app") as get_mock:
+            findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
+
+        assert findings == []
+        get_mock.assert_not_called()
+
+    def test_missing_state_file_is_silent(self, tmp_path):
+        """Tests that an app with no state file produces no findings."""
+        findings = reconcile_publications(TOKEN, _configs(), tmp_path, [])
+
+        assert findings == []


### PR DESCRIPTION
## What changed

New `napt/promote/reconcile.py`: when a publish run uploads to Intune successfully but the writeback commit recording the pending-to-deployed transition never lands (a CI push rejected by branch protection, a crashed runner), deployment state still lists the release as pending while the tenant is fully published. Reconciliation re-derives the deployed record from tenant evidence and completes the transition.

- `napt promote apply` reconciles on every run, before planning, so a recovered release is promotable in the same run when planning fresh.
- `napt promote plan --reconcile` (new flag, opt-in) reconciles before computing the plan. It is deliberately separate from `--check-drift`: a flag named "check" must never write state, and drift's reported-never-corrected contract stays intact. Without either flag, plan remains fully offline.
- When both flags are passed, one authenticated session (token + tenant listing) serves reconciliation and the drift check.
- Evidence bar: every entry required by the app's `build_types` must exist, stamped for the pending release's installer hash, with committed content. Partial evidence (missing entry, uncommitted content) is warned about as `incomplete` and never recorded — only a publish re-run can finish an upload.
- The reference GitOps plan workflow now runs `--check-drift --reconcile` and stages all of `state/`, so the promotion PR visibly carries any repair.
- Removed the now-unused `check_drift` and `reconcile_recipes` wrappers (the CLI was their only caller; the `--check-drift` flag is unchanged).

## Why

Found during live GitOps testing: a publish run uploaded successfully, then branch protection rejected the writeback push, leaving committed state claiming `pending` while the tenant was deployed. In that window, `status` and `promote plan` report nothing deployed, drift is silent by construction (pending is a referenced sha), and if a scheduled discover replaces the pending slot (newest-wins), the published release becomes a permanent orphan.

Recovery trusts exactly the evidence idempotent upload adoption already trusts — provenance stamps plus `committedContentVersion` — so no new trust surface is introduced; the write lands in git where it is reviewable and revertible. This is completing NAPT's own half-persisted transaction, not correcting an admin's tenant change, which is why it does not violate the drift principle.