### PR TITLE
docs: Harden reference GitOps workflows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     
 ### Fixed
 
+- Fixed three defects in the reference GitHub Actions workflows: the
+    `publish` and `promote-apply` writeback pushes now rebase and retry
+    instead of failing when `main` advanced mid-run; the two workflows
+    no longer share a concurrency group, which cancelled one of them
+    when a single merge triggered both; and `publish` now fails fast
+    with a clear error when the vendor no longer serves an approved
+    installer, instead of failing minutes later at the upload hash gate
 - Fixed `napt upload` failing with HTTP 400 (`The mobile app content
     cannot be updated before the first content version is committed`)
     when re-running after a crash between app creation and content

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -921,7 +921,11 @@ on:
   push:
     branches: [main]
     paths: ["state/deployment/**"]
-concurrency: napt-writeback
+# Serializes publish runs (bursts of merges dedupe to the newest run).
+# Deliberately NOT shared with promote-apply: a merge that touches both
+# deployment state and the plan file triggers both workflows, and runs
+# sharing a group cancel each other instead of queueing.
+concurrency: napt-publish
 permissions:
   contents: write
 jobs:
@@ -959,6 +963,12 @@ jobs:
             psha=$(python -c "import json, sys; print(json.load(open(sys.argv[1], encoding='utf-8'))['pending']['sha256'])" "$state")
             if ! sha256sum "downloads/$id/"* 2>/dev/null | grep -q "^$psha "; then
               napt discover "$recipe" --stateless
+              # Fail fast when the vendor no longer serves the approved
+              # binary (the upload hash gate would refuse it anyway).
+              sha256sum "downloads/$id/"* 2>/dev/null | grep -q "^$psha " || {
+                echo "::error::$id: vendor no longer serves the approved release ($psha); the approval is stranded until a new discover PR supersedes it"
+                exit 1
+              }
             fi
             napt build "$recipe"
             napt package "$recipe"
@@ -970,10 +980,16 @@ jobs:
           git config user.name "napt-bot"
           git config user.email "napt-bot@users.noreply.github.com"
           git add state/deployment
-          git diff --cached --quiet || {
-            git commit -m "chore: Record published releases [skip ci]"
-            git push
-          }
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: Record published releases [skip ci]"
+          # main may have advanced while this run published (more merges,
+          # another workflow's writeback). State files are per-app, so a
+          # rebase cannot conflict.
+          for attempt in 1 2 3; do
+            git push && exit 0
+            git pull --rebase origin main
+          done
+          git push
 ```
 
 **Why the installer cache steps matter.**
@@ -1047,7 +1063,9 @@ on:
   push:
     branches: [main]
     paths: ["state/plan.json"]
-concurrency: napt-writeback
+# Own group (not shared with publish) - see the publish workflow's
+# concurrency comment.
+concurrency: napt-promote-apply
 permissions:
   contents: write
 jobs:
@@ -1071,10 +1089,14 @@ jobs:
           git config user.name "napt-bot"
           git config user.email "napt-bot@users.noreply.github.com"
           git add state
-          git diff --cached --quiet || {
-            git commit -m "chore: Record applied promotions [skip ci]"
-            git push
-          }
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: Record applied promotions [skip ci]"
+          # Same rebase-and-retry as the publish writeback.
+          for attempt in 1 2 3; do
+            git push && exit 0
+            git pull --rebase origin main
+          done
+          git push
 ```
 
 **Notes:**


### PR DESCRIPTION
## Description
Fixes three defects in the reference GitHub Actions workflows in common-tasks.md, all observed while driving the documented GitOps flow against a live tenant.

## Motivation
Three publish-PR merges 36 seconds apart produced: a writeback push rejected with `fetch first` (main advanced while the run published), the approved plan's `promote-apply` run cancelled by its sibling publish run (shared concurrency group), and later a Chrome binary rotation that surfaced as a generic hash-gate failure minutes into a run instead of a clear early error.

## Changes
- `publish` and `promote-apply` get separate concurrency groups (`napt-publish`, `napt-promote-apply`): runs in a shared group cancel each other rather than queue, and a promotion-PR merge triggers both workflows off one commit
- Both writeback steps now `git pull --rebase` and retry (3 attempts) before giving up; per-app state files make the rebase conflict-free
- The publish loop re-checks the installer hash immediately after a `discover --stateless` re-fetch and fails fast with an error naming the stranded approval and its remedy; the upload hash gate remains the enforcement boundary
- Changelog entry under Unreleased

## Testing
- [ ] Unit tests added/updated (docs-only change; no code paths)
- [ ] Integration tests added/updated (n/a)
- [x] Manual testing performed — equivalent changes mirrored into the napt-gitops-test repo's workflows, where the failure modes were originally reproduced

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass (`mkdocs build --strict` clean)
- [x] No linting errors