### PR TITLE
feat: Validate plan groups before acting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Plan group validation** - Every group named in a promotion plan is
+    now resolved against Entra ID before anything can act on it:
+    authenticated `napt promote plan` runs (`--check-drift` or
+    `--reconcile`) fail without writing a plan when a group does not
+    resolve, so a broken plan never becomes a reviewable promotion PR,
+    and `napt promote apply` preflights every action it would execute
+    before executing any, so an unresolvable group aborts with zero
+    tenant mutations instead of stranding a half-applied plan (a dead
+    group referenced only by stale or already-applied actions never
+    blocks a run). Offline plans (no flags) skip validation; the apply
+    preflight is their backstop
 - **Publication recovery** - `napt promote apply` (always) and
     `napt promote plan --reconcile` (opt-in) record publications that are
     fully committed in Intune but whose deployment state writeback was
@@ -19,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the same run. Partially published releases are warned about instead —
     re-run `napt upload` to finish them
     
+### Changed
+
+- **Drift findings state what NAPT knows, not what it guesses** - An
+    assignment NAPT has no record of making is now classified by
+    evidence: `unrecorded_assignment` when it matches a currently
+    configured target (either a lost apply writeback, which a later
+    apply converges, or an admin pre-empting configured policy) and
+    `unexpected_assignment` when it matches no configured target. The
+    old `unexpected_assignment` message asserted "was not made by NAPT",
+    which drift cannot actually know — Intune assignments carry no
+    authorship, so state records are the only memory
+
 ### Fixed
 
 - Fixed `napt upload` failing with HTTP 400 (`The mobile app content

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     before executing any, so an unresolvable group aborts with zero
     tenant mutations instead of stranding a half-applied plan (a dead
     group referenced only by stale or already-applied actions never
-    blocks a run). Offline plans (no flags) skip validation; the apply
-    preflight is their backstop
+    blocks a run). Offline plans (no flags) skip validation and warn
+    when they produce actions; the apply preflight is their backstop
 - **Publication recovery** - `napt promote apply` (always) and
     `napt promote plan --reconcile` (opt-in) record publications that are
     fully committed in Intune but whose deployment state writeback was

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -719,6 +719,11 @@ release has proven itself.
    stray apps) are warned about, never corrected.
    Use `napt promote plan --check-drift` for the same report without
    applying anything.
+   Both commands also fail fast on a group typo or deleted Entra ID
+   group: an authenticated plan refuses to write a plan that names an
+   unresolvable group, and apply checks every group it is about to
+   assign before touching anything, so a bad group aborts with zero
+   changes instead of a half-applied plan.
    Run `napt status` to see where every app stands.
 
 Run plan and apply on a schedule and promotion becomes automatic: each

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -479,8 +479,9 @@ way before executing anything, so an unresolvable group aborts the run
 with zero tenant mutations instead of stranding a half-applied plan;
 fix the configuration and re-plan. A dead group referenced only by
 stale or already-applied actions never blocks a run, so re-running
-after a partial failure stays safe. Offline plans skip validation, and
-the apply preflight backstops whatever they produce.
+after a partial failure stays safe. Offline plans skip validation —
+warning when they produce actions — and the apply preflight backstops
+whatever they produce.
 
 Both commands also recover **lost publication writebacks**: when an
 upload succeeded but the state commit recording it never landed (a CI

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -459,11 +459,28 @@ preserved.
 
 Both commands report **assignment drift**: every discrepancy between what
 deployment state says should be assigned and what Intune actually has —
-removed or changed NAPT assignments, admin-made assignments on
-NAPT-managed apps, releases missing from the tenant, and stamped apps no
-state file references. Drift is warned about and never corrected. Apply
-checks automatically; plan checks with `--check-drift` (which needs Graph
+removed or changed NAPT assignments, unrecorded or foreign assignments
+on NAPT-managed apps, releases missing from the tenant, and stamped apps
+no state file references. An assignment NAPT has no record of making is
+classified by evidence: one that matches a currently configured target
+is reported as *unrecorded* (a lost apply writeback, which a later apply
+converges, or an admin pre-empting configured policy), while one
+matching no configured target is reported as *unexpected* (typically
+admin-made). Drift is warned about and never corrected. Apply checks
+automatically; plan checks with `--check-drift` (which needs Graph
 credentials — without the flag, plan stays fully offline).
+
+Both commands also **validate plan groups**. Authenticated plan runs
+(`--check-drift` or `--reconcile`) resolve every group named in the
+computed plan and fail — writing no plan file — when one does not
+resolve, so a plan with a group typo never becomes a reviewable
+promotion PR. Apply preflights every action it would execute the same
+way before executing anything, so an unresolvable group aborts the run
+with zero tenant mutations instead of stranding a half-applied plan;
+fix the configuration and re-plan. A dead group referenced only by
+stale or already-applied actions never blocks a run, so re-running
+after a partial failure stays safe. Offline plans skip validation, and
+the apply preflight backstops whatever they produce.
 
 Both commands also recover **lost publication writebacks**: when an
 upload succeeded but the state commit recording it never landed (a CI

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -107,6 +107,7 @@ from napt.promote import (
     plan_promotions,
     reconcile_publications,
     resolve_state_dir,
+    unresolvable_groups,
     write_plan_file,
 )
 from napt.state import summarize_deployment_states
@@ -709,21 +710,39 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
         recovered: list[dict[str, Any]] = []
         drift: list[dict[str, Any]] = []
         if args.reconcile or args.check_drift:
-            # One authenticated session serves both reconciliation and
-            # the drift check; drift runs second so it sees repaired
-            # state. Planning is offline and needs none of this.
+            # One authenticated session serves reconciliation, plan
+            # validation, and the drift check. Reconciliation runs
+            # before planning so recovered releases are promotable this
+            # run; drift runs after it so repaired state is compared.
             configs = load_recipe_configs(recipes)
             access_token = get_access_token()
             existing_apps = list_mobile_apps(access_token)
+            group_id_cache: dict[str, str] = {}
             if args.reconcile:
                 recovered = reconcile_publications(
                     access_token, configs, state_dir / "deployment", existing_apps
                 )
+            actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
+            # A plan with an unresolvable group must never become a
+            # reviewable promotion PR: fail hard instead of writing it.
+            problems = unresolvable_groups(access_token, actions, group_id_cache)
+            if problems:
+                raise ConfigError(
+                    "Plan validation failed; no plan was written. "
+                    "Unresolvable groups:\n  "
+                    + "\n  ".join(problems)
+                    + "\nFix the group configuration and re-run."
+                )
             if args.check_drift:
                 drift = detect_drift(
-                    access_token, configs, state_dir / "deployment", existing_apps
+                    access_token,
+                    configs,
+                    state_dir / "deployment",
+                    existing_apps,
+                    group_id_cache=group_id_cache,
                 )
-        actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
+        else:
+            actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
         write_plan_file(actions, plan_path)
     except AuthError as err:
         print(f"Authentication error: {err}")
@@ -1427,8 +1446,10 @@ def main() -> None:
             "write state/plan.json when there is work. Never modifies "
             "Intune. Read-only for deployment state too, except that "
             "--reconcile writes it when recovering a lost publication "
-            "writeback. A stale plan file is removed when nothing is "
-            "eligible."
+            "writeback. With --check-drift or --reconcile, every group in "
+            "the plan is validated against Entra ID and an unresolvable "
+            "group fails the run without writing a plan. A stale plan "
+            "file is removed when nothing is eligible."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -743,6 +743,12 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
                 )
         else:
             actions = plan_promotions(recipes, state_dir=state_dir / "deployment")
+            if actions:
+                logger.warning(
+                    "PROMOTE",
+                    "Plan groups not validated against Entra ID (offline "
+                    "run); apply validates them before assigning.",
+                )
         write_plan_file(actions, plan_path)
     except AuthError as err:
         print(f"Authentication error: {err}")

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -42,6 +42,7 @@ from .planner import (
     resolve_state_dir,
     write_plan_file,
 )
+from .preflight import unresolvable_groups
 from .reconcile import reconcile_publications
 
 __all__ = [
@@ -53,5 +54,6 @@ __all__ = [
     "plan_promotions",
     "reconcile_publications",
     "resolve_state_dir",
+    "unresolvable_groups",
     "write_plan_file",
 ]

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -44,7 +44,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt.exceptions import StateError
+from napt.exceptions import ConfigError, StateError
 from napt.logging import get_global_logger
 from napt.promote.drift import detect_drift
 from napt.promote.planner import (
@@ -53,6 +53,7 @@ from napt.promote.planner import (
     plan_path_for,
     plan_promotions,
 )
+from napt.promote.preflight import unresolvable_groups
 from napt.promote.reconcile import reconcile_publications
 from napt.state import (
     deployment_state_path,
@@ -207,7 +208,7 @@ class _ApplyRun:
         self.now = now
         self.existing_apps = list_mobile_apps(access_token)
         self._states: dict[str, dict[str, Any]] = {}
-        self._group_ids: dict[str, str] = {}
+        self.group_id_cache: dict[str, str] = {}
         self.applied: list[dict[str, Any]] = []
         self.skipped: list[dict[str, Any]] = []
 
@@ -234,7 +235,7 @@ class _ApplyRun:
         group target.
         """
         return [
-            resolve_assignment_target(self.access_token, group, self._group_ids)
+            resolve_assignment_target(self.access_token, group, self.group_id_cache)
             for group in groups
         ]
 
@@ -300,39 +301,74 @@ def _retire_release(run: _ApplyRun, app_id: str, version: str, sha256: str) -> N
                 )
 
 
-def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
-    """Applies an enter_ring or advance_ring action.
+def _action_skip_reason(run: _ApplyRun, action: dict[str, Any]) -> str | None:
+    """Decides whether a planned action would be skipped instead of applied.
+
+    The single authority for skip semantics: the apply loop records the
+    returned reason, and the group preflight validates only actions this
+    function clears — so a group referenced solely by a stale or
+    already-applied action can never block a run. All checks are local
+    (state files, cached tenant listing); nothing calls Graph.
 
     Args:
         run: The apply run context.
         action: The planned action.
 
     Returns:
-        True when applied, False when skipped.
+        The skip reason, or None when the action should execute.
+
+    """
+    app_id: str = action["app_id"]
+    sha256: str = action["sha256"]
+    if app_id not in run.configs:
+        return "no recipe found for this app"
+
+    state = run.state_for(app_id)
+    deployed = state.get("deployed") or {}
+    if deployed.get("sha256") != sha256:
+        return "stale action - the deployed release has changed"
+
+    if action["type"] == "assign_install":
+        previous = state.get("install_assigned") or {}
+        if previous.get("sha256") == sha256:
+            return "already applied"
+        if find_stamped_app(run.existing_apps, app_id, ENTRY_INSTALL, sha256) is None:
+            return "no stamped install entry found in the tenant"
+        return None
+
+    ring: str = action["ring"]
+    ring_names = [r["name"] for r in run.configs[app_id]["deployment"]["rings"]]
+    if ring not in ring_names:
+        return f"ring '{ring}' is no longer configured"
+    if (state.get("rings") or {}).get(ring, {}).get("sha256") == sha256:
+        return "already applied"
+    if find_stamped_app(run.existing_apps, app_id, ENTRY_UPDATE, sha256) is None:
+        return "no stamped update entry found in the tenant"
+    return None
+
+
+def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> None:
+    """Applies an enter_ring or advance_ring action.
+
+    Assumes the action was cleared by
+    [_action_skip_reason][napt.promote.applier._action_skip_reason];
+    in particular a stamped update entry for the release exists.
+
+    Args:
+        run: The apply run context.
+        action: The planned action.
 
     """
     app_id: str = action["app_id"]
     sha256: str = action["sha256"]
     ring: str = action["ring"]
     state = run.state_for(app_id)
-    deployed = state.get("deployed") or {}
-
-    if deployed.get("sha256") != sha256:
-        run.skip(action, "stale action - the deployed release has changed")
-        return False
-    ring_names = [r["name"] for r in run.configs[app_id]["deployment"]["rings"]]
-    if ring not in ring_names:
-        run.skip(action, f"ring '{ring}' is no longer configured")
-        return False
     rings_state: dict[str, Any] = state.setdefault("rings", {})
-    if rings_state.get(ring, {}).get("sha256") == sha256:
-        run.skip(action, "already applied")
-        return False
 
     update_app = find_stamped_app(run.existing_apps, app_id, ENTRY_UPDATE, sha256)
-    if update_app is None:
+    if update_app is None:  # cleared by _action_skip_reason
         run.skip(action, "no stamped update entry found in the tenant")
-        return False
+        return
 
     targets = run.resolve_targets(action["groups"])
     _add_assignments(run.access_token, update_app["id"], targets, _RING_INTENT)
@@ -366,37 +402,29 @@ def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
 
     run.save_state(app_id)
     run.applied.append(action)
-    return True
 
 
-def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
+def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> None:
     """Applies an assign_install action.
+
+    Assumes the action was cleared by
+    [_action_skip_reason][napt.promote.applier._action_skip_reason];
+    in particular a stamped install entry for the release exists.
 
     Args:
         run: The apply run context.
         action: The planned action.
 
-    Returns:
-        True when applied, False when skipped.
-
     """
     app_id: str = action["app_id"]
     sha256: str = action["sha256"]
     state = run.state_for(app_id)
-    deployed = state.get("deployed") or {}
-
-    if deployed.get("sha256") != sha256:
-        run.skip(action, "stale action - the deployed release has changed")
-        return False
     previous = state.get("install_assigned") or {}
-    if previous.get("sha256") == sha256:
-        run.skip(action, "already applied")
-        return False
 
     install_app = find_stamped_app(run.existing_apps, app_id, ENTRY_INSTALL, sha256)
-    if install_app is None:
+    if install_app is None:  # cleared by _action_skip_reason
         run.skip(action, "no stamped install entry found in the tenant")
-        return False
+        return
 
     targets = run.resolve_targets(action["groups"])
     _add_assignments(run.access_token, install_app["id"], targets, action["intent"])
@@ -420,7 +448,6 @@ def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> bool:
     }
     run.save_state(app_id)
     run.applied.append(action)
-    return True
 
 
 def apply_plan(
@@ -433,8 +460,13 @@ def apply_plan(
 
     Consumes the plan file when one exists (removing it after a fully
     successful run); otherwise plans fresh and applies immediately.
-    Deployment state is saved after each applied action, so a failed run
-    resumes safely — already-applied actions validate as no-ops.
+    Every group a non-skipped action will assign is resolved before any
+    action executes, so an unresolvable group aborts the run with zero
+    mutations rather than stranding a half-applied plan — while a dead
+    group referenced only by stale or already-applied actions never
+    blocks a run. Deployment state is saved after each applied action,
+    so a failed run resumes safely — already-applied actions validate
+    as no-ops.
 
     Assignment drift is checked on every run — including runs with
     nothing to apply, which therefore still authenticate — and reported
@@ -496,9 +528,28 @@ def apply_plan(
         actions = plan_promotions(recipes, state_dir=deployment_dir, now=now)
         logger.info("PROMOTE", "No plan file found; planning and applying")
 
+    # Preflight: every group a live action will touch must resolve
+    # before anything is applied, so an unresolvable group aborts with
+    # zero mutations instead of stranding a half-applied plan. Skipped
+    # actions are excluded — a dead group referenced only by a stale or
+    # already-applied action never blocks a run, preserving the
+    # resume-after-partial-failure guarantee. Resolutions are cached for
+    # the action loop below.
+    live = [a for a in actions if _action_skip_reason(run, a) is None]
+    problems = unresolvable_groups(access_token, live, run.group_id_cache)
+    if problems:
+        raise ConfigError(
+            "Plan preflight failed; nothing was applied. Unresolvable "
+            "groups:\n  "
+            + "\n  ".join(problems)
+            + "\nFix the group configuration and re-plan, or correct the "
+            "plan file, then re-run."
+        )
+
     for action in actions:
-        if action["app_id"] not in configs:
-            run.skip(action, "no recipe found for this app")
+        reason = _action_skip_reason(run, action)
+        if reason is not None:
+            run.skip(action, reason)
             continue
         if action["type"] == "assign_install":
             _apply_install_action(run, action)
@@ -511,7 +562,13 @@ def apply_plan(
 
     # Drift is checked after the actions so freshly applied assignments
     # are reflected. Findings are warnings only, never corrected.
-    drift = detect_drift(access_token, configs, deployment_dir, run.existing_apps)
+    drift = detect_drift(
+        access_token,
+        configs,
+        deployment_dir,
+        run.existing_apps,
+        group_id_cache=run.group_id_cache,
+    )
 
     return {
         "applied": run.applied,

--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -27,11 +27,20 @@ Finding kinds:
     install group) is no longer present.
 - ``intent_mismatch``: An expected assignment exists with a different
     intent.
+- ``unrecorded_assignment``: A NAPT-stamped app carries an assignment
+    that matches a currently configured target, but NAPT has no record
+    of making it — either an apply writeback was lost (a later apply
+    converges it) or it was made outside NAPT. Left alone.
 - ``unexpected_assignment``: A NAPT-stamped app carries an assignment
-    NAPT did not make (typically admin-made; left alone).
+    NAPT has no record of making and that matches no configured target
+    (typically admin-made; left alone).
 - ``orphaned_release``: A stamped app exists for a release that no state
     file references (e.g., a crashed run replaced by newest-wins).
 - ``unknown_app``: A stamped app references a recipe id with no recipe.
+
+Authorship is always inferred, never known: Graph assignments carry no
+provenance field, so deployment state records are the only memory of
+what NAPT assigned — and a lost writeback loses that memory.
 """
 
 from __future__ import annotations
@@ -39,6 +48,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from napt.exceptions import ConfigError
 from napt.state import deployment_state_path, load_deployment_state
 from napt.upload.graph import (
     get_app_assignments,
@@ -136,11 +146,67 @@ def _expected_assignments(
     return expected
 
 
+def _configured_targets(
+    access_token: str,
+    config: dict[str, Any],
+    group_id_cache: dict[str, str],
+    names: dict,
+) -> dict[str, dict[tuple[str, str], str]]:
+    """Builds the target map the current configuration would assign.
+
+    Used to distinguish an unrecorded NAPT assignment (matches a
+    configured target) from a genuinely foreign one. Configured groups
+    that do not resolve are skipped: they cannot match an assignment
+    that actually exists in the tenant.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        config: The app's effective configuration.
+        group_id_cache: Shared cache for group name resolution.
+        names: Target-key to configured-name map, filled as a side
+            effect for readable findings.
+
+    Returns:
+        A map of entry type to a map of target key to configured intent.
+
+    """
+    deployment = config["deployment"]
+    configured: dict[str, dict[tuple[str, str], str]] = {
+        ENTRY_INSTALL: {},
+        ENTRY_UPDATE: {},
+    }
+
+    install_cfg = deployment["install"]
+    for group in install_cfg["groups"]:
+        try:
+            target = resolve_assignment_target(access_token, group, group_id_cache)
+        except ConfigError:
+            continue
+        key = _target_key(target)
+        names[key] = group
+        configured[ENTRY_INSTALL][key] = install_cfg["intent"]
+
+    for ring in deployment["rings"]:
+        for group in ring["groups"]:
+            try:
+                target = resolve_assignment_target(
+                    access_token, group, group_id_cache
+                )
+            except ConfigError:
+                continue
+            key = _target_key(target)
+            names[key] = group
+            configured[ENTRY_UPDATE][key] = "required"
+
+    return configured
+
+
 def detect_drift(
     access_token: str,
     configs: dict[str, dict[str, Any]],
     deployment_dir: Path,
     existing_apps: list[dict[str, Any]],
+    group_id_cache: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     """Detects assignment drift between deployment state and Intune.
 
@@ -149,6 +215,9 @@ def detect_drift(
         configs: Effective configurations keyed by recipe id.
         deployment_dir: Directory holding per-app deployment state files.
         existing_apps: Mobile app dicts from list_mobile_apps.
+        group_id_cache: Shared cache for group name resolution, so a
+            caller that already resolved groups (apply, plan validation)
+            re-resolves nothing. A new cache is used when omitted.
 
     Returns:
         Finding dicts, each with "app_id", "kind", and "detail" keys,
@@ -163,7 +232,8 @@ def detect_drift(
 
     """
     findings: list[dict[str, Any]] = []
-    group_id_cache: dict[str, str] = {}
+    if group_id_cache is None:
+        group_id_cache = {}
     names: dict = {}
 
     stamped_by_recipe: dict[str, list[tuple[dict, dict]]] = {}
@@ -191,6 +261,8 @@ def detect_drift(
         expected = _expected_assignments(
             access_token, config, state, group_id_cache, names
         )
+        # Built lazily: only an unaccounted-for assignment needs it.
+        configured: dict[str, dict[tuple[str, str], str]] | None = None
         referenced = _referenced_shas(state)
         stamped = stamped_by_recipe.get(app_id, [])
         stamped_keys = {(s["entry"], s["sha256"]) for s, _ in stamped}
@@ -261,16 +333,40 @@ def detect_drift(
                     )
 
             for key, assignment in actual.items():
-                if key not in expected_targets:
+                if key in expected_targets:
+                    continue
+                if configured is None:
+                    configured = _configured_targets(
+                        access_token, config, group_id_cache, names
+                    )
+                target_name = _describe_target(assignment.get("target"), names)
+                intent = assignment.get("intent")
+                if configured[entry].get(key) == intent:
+                    findings.append(
+                        {
+                            "app_id": app_id,
+                            "kind": "unrecorded_assignment",
+                            "detail": (
+                                f"{entry} entry for {sha[:12]}: assignment "
+                                f"'{target_name}' ({intent}) matches the "
+                                "configured target but NAPT has no record "
+                                "of making it - either an apply writeback "
+                                "was lost (a later apply converges it) or "
+                                "it was made outside NAPT - leaving it "
+                                "alone"
+                            ),
+                        }
+                    )
+                else:
                     findings.append(
                         {
                             "app_id": app_id,
                             "kind": "unexpected_assignment",
                             "detail": (
-                                f"{entry} entry for {sha[:12]}: assignment "
-                                f"'{_describe_target(assignment.get('target'), names)}' "
-                                f"({assignment.get('intent')}) was not made "
-                                "by NAPT - leaving it alone"
+                                f"{entry} entry for {sha[:12]}: NAPT has no "
+                                f"record of making assignment "
+                                f"'{target_name}' ({intent}) and it matches "
+                                "no configured target - leaving it alone"
                             ),
                         }
                     )

--- a/napt/promote/preflight.py
+++ b/napt/promote/preflight.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Group validation for promotion plans.
+
+A planned action names its assignment groups, so an unresolvable group —
+a typo in ring configuration, a deleted Entra ID group — is knowable
+before anything mutates the tenant. Checking up front turns what would
+be a mid-run abort (leaving a half-applied plan) into either a failed
+plan that never reaches review, or an apply that refuses to start.
+
+Used by the authenticated ``napt promote plan`` modes (a plan with an
+unresolvable group fails instead of becoming a reviewable promotion PR)
+and by ``napt promote apply`` as a preflight before executing any
+action. Offline plans skip validation — the apply preflight is the
+backstop for anything they produce.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from napt.exceptions import ConfigError
+from napt.upload.graph import resolve_assignment_target
+
+__all__ = ["unresolvable_groups"]
+
+
+def unresolvable_groups(
+    access_token: str,
+    actions: list[dict[str, Any]],
+    group_id_cache: dict[str, str] | None = None,
+) -> list[str]:
+    """Resolves every group named in the actions, collecting failures.
+
+    Each distinct group is resolved once. Successful resolutions land in
+    the shared cache, so a subsequent apply pass re-resolves nothing.
+
+    Args:
+        access_token: Bearer token for Graph API.
+        actions: Planned action dicts (each may carry a "groups" list).
+        group_id_cache: Shared cache for group name resolution. A new
+            cache is used when omitted.
+
+    Returns:
+        One failure description per unresolvable group, sorted for
+            deterministic output. Empty when every group resolves.
+
+    Raises:
+        AuthError: On 401 or 403.
+        NetworkError: On Graph API failures.
+
+    """
+    cache = group_id_cache if group_id_cache is not None else {}
+    failures: list[str] = []
+    seen: set[str] = set()
+
+    for action in actions:
+        for group in action.get("groups", []):
+            if group in seen:
+                continue
+            seen.add(group)
+            try:
+                resolve_assignment_target(access_token, group, cache)
+            except ConfigError as err:
+                failures.append(str(err))
+
+    failures.sort()
+    return failures

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1109,8 +1109,9 @@ class TestReconcileOutput:
         assert "ghost-group" in out
         write_mock.assert_not_called()
 
-    def test_offline_plan_skips_validation(self, tmp_path):
-        """Tests that a plan without tenant flags never validates groups."""
+    def test_offline_plan_skips_validation(self, tmp_path, capsys):
+        """Tests that a plan without tenant flags never validates groups
+        and that an empty plan draws no unvalidated warning."""
         with (
             patch("napt.cli.plan_promotions", return_value=[]),
             patch("napt.cli.write_plan_file", return_value=False),
@@ -1126,6 +1127,36 @@ class TestReconcileOutput:
             )
         assert code == 0
         validate_mock.assert_not_called()
+        assert "not validated" not in capsys.readouterr().out
+
+    def test_offline_plan_with_actions_warns_unvalidated(self, tmp_path, capsys):
+        """Tests that an offline plan producing actions warns that its
+        groups were not validated."""
+        actions = [
+            {
+                "type": "enter_ring",
+                "app_id": "test-app",
+                "version": "1.0.0",
+                "sha256": "a" * 64,
+                "ring": "pilot",
+                "groups": ["sg-pilot"],
+            }
+        ]
+        with (
+            patch("napt.cli.plan_promotions", return_value=actions),
+            patch("napt.cli.write_plan_file", return_value=True),
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=False,
+                )
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Plan groups not validated against Entra ID" in out
 
     def test_plan_shares_one_session_for_reconcile_and_drift(self, tmp_path):
         """Tests that --reconcile --check-drift together authenticate and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1068,6 +1068,65 @@ class TestReconcileOutput:
         assert code == 0
         assert order == ["reconcile", "plan"]
 
+    def test_plan_validation_failure_writes_no_plan(self, tmp_path, capsys):
+        """Tests that an unresolvable group fails the authenticated plan
+        without writing a plan file."""
+        actions = [
+            {
+                "type": "enter_ring",
+                "app_id": "test-app",
+                "version": "1.0.0",
+                "sha256": "a" * 64,
+                "ring": "pilot",
+                "groups": ["ghost-group"],
+            }
+        ]
+        with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
+            patch("napt.cli.get_access_token", return_value="tok"),
+            patch("napt.cli.list_mobile_apps", return_value=[]),
+            patch("napt.cli.detect_drift", return_value=[]),
+            patch("napt.cli.plan_promotions", return_value=actions),
+            patch(
+                "napt.cli.unresolvable_groups",
+                return_value=[
+                    "No Entra ID group found with displayName 'ghost-group'."
+                ],
+            ),
+            patch("napt.cli.write_plan_file") as write_mock,
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=True,
+                    reconcile=False,
+                )
+            )
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "Plan validation failed" in out
+        assert "ghost-group" in out
+        write_mock.assert_not_called()
+
+    def test_offline_plan_skips_validation(self, tmp_path):
+        """Tests that a plan without tenant flags never validates groups."""
+        with (
+            patch("napt.cli.plan_promotions", return_value=[]),
+            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.unresolvable_groups") as validate_mock,
+        ):
+            code = cmd_promote_plan(
+                _args(
+                    recipes="recipes",
+                    state_dir=tmp_path / "state",
+                    check_drift=False,
+                    reconcile=False,
+                )
+            )
+        assert code == 0
+        validate_mock.assert_not_called()
+
     def test_plan_shares_one_session_for_reconcile_and_drift(self, tmp_path):
         """Tests that --reconcile --check-drift together authenticate and
         list the tenant only once."""

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -148,6 +148,7 @@ def _run_apply(
     assignments: dict[str, list[dict[str, Any]]] | None = None,
     assign_side_effect: Any = None,
     drift_findings: list[dict[str, Any]] | None = None,
+    resolve_side_effect: Any = None,
 ) -> tuple[dict[str, Any], dict[str, MagicMock]]:
     """Runs apply_plan with all Graph calls mocked.
 
@@ -157,6 +158,9 @@ def _run_apply(
         assignments: Map of app graph ID to current assignment list
             (default empty for every app).
         assign_side_effect: Optional side effect for assign_app.
+        drift_findings: detect_drift return value.
+        resolve_side_effect: Overrides the group resolution fake (shared
+            by the preflight and the action loop).
 
     Returns:
         A tuple of (summary, mocks).
@@ -169,7 +173,9 @@ def _run_apply(
         "get_app_assignments": MagicMock(
             side_effect=lambda token, app_id: list(assignments.get(app_id, []))
         ),
-        "resolve_assignment_target": MagicMock(side_effect=_fake_resolve_target),
+        "resolve_assignment_target": MagicMock(
+            side_effect=resolve_side_effect or _fake_resolve_target
+        ),
     }
 
     with ExitStack() as stack:
@@ -184,6 +190,13 @@ def _run_apply(
         )
         for name, mock in mocks.items():
             stack.enter_context(patch(f"napt.promote.applier.{name}", mock))
+        # The apply preflight resolves groups through its own module.
+        stack.enter_context(
+            patch(
+                "napt.promote.preflight.resolve_assignment_target",
+                mocks["resolve_assignment_target"],
+            )
+        )
         stack.enter_context(
             patch(
                 "napt.promote.applier.detect_drift",
@@ -540,6 +553,89 @@ class TestApplyOrchestration:
         assert state["pending"] is None
         assert state["deployed"]["intune_app_id"] == "install-new"
         assert state["rings"]["pilot"]["sha256"] == "b" * 64
+
+    def test_preflight_aborts_with_zero_mutations(self, tmp_path):
+        """Tests that an unresolvable group anywhere in the plan aborts
+        before any action mutates the tenant."""
+        from napt.exceptions import ConfigError
+
+        _write_recipe(tmp_path, rings=_RINGS)
+        state_path = _write_state(tmp_path, deployed=_deployed())
+        plan_path = _write_plan(
+            tmp_path,
+            [
+                _enter_ring_action(),  # resolvable: Pilot Devices
+                {
+                    "type": "advance_ring",
+                    "app_id": "test-app",
+                    "version": "2.0.0",
+                    "sha256": "b" * 64,
+                    "from_ring": "pilot",
+                    "ring": "broad",
+                    "groups": ["missing-group"],
+                },
+            ],
+        )
+
+        def _resolve(token, group, cache=None):
+            if group == "missing-group":
+                raise ConfigError(
+                    f"No Entra ID group found with displayName '{group}'."
+                )
+            return _fake_resolve_target(token, group, cache)
+
+        with pytest.raises(ConfigError, match="nothing was applied"):
+            _run_apply(
+                tmp_path,
+                existing_apps=_tenant(),
+                resolve_side_effect=_resolve,
+            )
+
+        state = load_deployment_state(state_path)
+        assert state["rings"] == {}  # the resolvable action did not apply
+        assert plan_path.exists()  # plan not consumed
+
+    def test_preflight_ignores_dead_group_on_stale_action(self, tmp_path):
+        """Tests that an unresolvable group referenced only by a stale
+        action is never resolved, preserving resume safety."""
+        from napt.exceptions import ConfigError
+
+        _write_recipe(tmp_path, rings=_RINGS)
+        _write_state(tmp_path, deployed=_deployed())  # deployed is b*64
+        _write_plan(
+            tmp_path,
+            [
+                _enter_ring_action(),  # live: Pilot Devices
+                # Stale: sha no longer deployed; its group was deleted
+                # after the action originally applied.
+                {
+                    "type": "enter_ring",
+                    "app_id": "test-app",
+                    "version": "1.0.0",
+                    "sha256": "a" * 64,
+                    "ring": "pilot",
+                    "groups": ["deleted-group"],
+                },
+            ],
+        )
+
+        def _resolve(token, group, cache=None):
+            if group == "deleted-group":
+                raise ConfigError(
+                    f"No Entra ID group found with displayName '{group}'."
+                )
+            return _fake_resolve_target(token, group, cache)
+
+        summary, _ = _run_apply(
+            tmp_path,
+            existing_apps=_tenant(),
+            resolve_side_effect=_resolve,
+        )
+
+        assert [a["type"] for a in summary["applied"]] == ["enter_ring"]
+        assert [s["reason"] for s in summary["skipped"]] == [
+            "stale action - the deployed release has changed"
+        ]
 
     def test_unknown_app_in_plan_skipped(self, tmp_path):
         """Tests that a plan action without a matching recipe is skipped."""

--- a/tests/test_promote_drift.py
+++ b/tests/test_promote_drift.py
@@ -221,7 +221,74 @@ class TestDetectDrift:
         )
 
         assert [f["kind"] for f in findings] == ["unexpected_assignment"]
+        assert "NAPT has no record" in findings[0]["detail"]
         assert "leaving it alone" in findings[0]["detail"]
+
+    def test_unrecorded_install_assignment_reported(self, tmp_path):
+        """Tests that an unrecorded assignment matching the configured
+        install target is classified as unrecorded, not unexpected."""
+        config = _config(install_groups=["Pilot Devices"])
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            # No install_assigned record: the apply writeback was lost.
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "install", "a" * 64, "install-1")],
+            assignments={
+                "install-1": [_assignment("Pilot Devices", intent="available")]
+            },
+        )
+
+        assert [f["kind"] for f in findings] == ["unrecorded_assignment"]
+        assert "matches the configured target" in findings[0]["detail"]
+        assert "NAPT has no record" in findings[0]["detail"]
+
+    def test_unrecorded_ring_assignment_reported(self, tmp_path):
+        """Tests that an unrecorded assignment matching a configured ring
+        group is classified as unrecorded."""
+        config = _config(rings=_RINGS)
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+            # No ring record: the apply writeback was lost.
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "update", "a" * 64, "update-1")],
+            assignments={"update-1": [_assignment("Pilot Devices")]},
+        )
+
+        assert [f["kind"] for f in findings] == ["unrecorded_assignment"]
+
+    def test_intent_mismatch_with_config_stays_unexpected(self, tmp_path):
+        """Tests that an unrecorded assignment whose intent differs from
+        the configured target stays unexpected."""
+        config = _config(install_groups=["Pilot Devices"])
+        deployment_dir = _write_state(
+            tmp_path,
+            deployed={"version": "1.0.0", "sha256": "a" * 64},
+        )
+
+        findings = _detect(
+            tmp_path,
+            config,
+            deployment_dir,
+            [_stamped("test-app", "install", "a" * 64, "install-1")],
+            assignments={
+                # Config says available; this assignment is required.
+                "install-1": [_assignment("Pilot Devices", intent="required")]
+            },
+        )
+
+        assert [f["kind"] for f in findings] == ["unexpected_assignment"]
 
     def test_missing_app_reported(self, tmp_path):
         """Tests that a state-referenced release missing from Intune reports."""

--- a/tests/test_promote_preflight.py
+++ b/tests/test_promote_preflight.py
@@ -1,0 +1,85 @@
+"""Tests for napt.promote.preflight."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from napt.exceptions import ConfigError
+from napt.promote.preflight import unresolvable_groups
+
+TOKEN = "tok"
+
+
+def _resolve_or_raise(token, group, cache=None):
+    """Resolves any group except ones containing 'missing'."""
+    if "missing" in group:
+        raise ConfigError(f"No Entra ID group found with displayName '{group}'.")
+    return {
+        "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+        "groupId": f"gid-{group}",
+    }
+
+
+def _actions(*group_lists: list[str]) -> list[dict]:
+    return [
+        {"type": "enter_ring", "app_id": f"app-{i}", "groups": groups}
+        for i, groups in enumerate(group_lists)
+    ]
+
+
+class TestUnresolvableGroups:
+    """Tests for plan group validation."""
+
+    def test_all_groups_resolve(self):
+        """Tests that a plan whose groups all resolve reports no failures."""
+        with patch(
+            "napt.promote.preflight.resolve_assignment_target",
+            side_effect=_resolve_or_raise,
+        ):
+            failures = unresolvable_groups(
+                TOKEN, _actions(["Pilot Devices"], ["Broad Devices"])
+            )
+
+        assert failures == []
+
+    def test_unresolvable_group_reported_once(self):
+        """Tests that a group used by several actions is resolved and
+        reported only once."""
+        with patch(
+            "napt.promote.preflight.resolve_assignment_target",
+            side_effect=_resolve_or_raise,
+        ) as resolve_mock:
+            failures = unresolvable_groups(
+                TOKEN, _actions(["missing-group"], ["missing-group"], ["Real"])
+            )
+
+        assert len(failures) == 1
+        assert "missing-group" in failures[0]
+        assert resolve_mock.call_count == 2  # one per distinct group
+
+    def test_successful_resolutions_fill_shared_cache(self):
+        """Tests that resolutions land in the caller's cache for reuse."""
+        cache: dict[str, str] = {}
+
+        def _resolve(token, group, group_id_cache=None):
+            group_id_cache[group] = f"gid-{group}"
+            return {"@odata.type": "#t", "groupId": f"gid-{group}"}
+
+        with patch(
+            "napt.promote.preflight.resolve_assignment_target",
+            side_effect=_resolve,
+        ):
+            failures = unresolvable_groups(TOKEN, _actions(["Pilot Devices"]), cache)
+
+        assert failures == []
+        assert cache == {"Pilot Devices": "gid-Pilot Devices"}
+
+    def test_actions_without_groups_are_skipped(self):
+        """Tests that actions with no groups key produce no lookups."""
+        with patch(
+            "napt.promote.preflight.resolve_assignment_target"
+        ) as resolve_mock:
+            failures = unresolvable_groups(TOKEN, [{"type": "odd_action"}])
+
+        assert failures == []
+        resolve_mock.assert_not_called()


### PR DESCRIPTION
## Description
Adds Terraform-style fail-before-mutate validation of promotion plan groups, and reclassifies drift findings about unrecorded assignments to state what NAPT knows rather than what it guesses.

## Motivation
Live GitOps testing hit two half-applied plans in one week: an apply run aborted mid-plan on an unresolvable group, leaving one app's install assignment applied but unrecorded and five healthy actions stranded. The follow-up drift check then reported that assignment as "was not made by NAPT" — an assertion drift cannot actually make, since Graph assignments carry no authorship and deployment state records are the only memory of what NAPT assigned.

## Changes
- New `napt/promote/preflight.py`: `unresolvable_groups()` resolves every distinct group named in a set of actions, collecting failures
- Authenticated `napt promote plan` runs (`--check-drift`/`--reconcile`) validate the computed plan and fail without writing a plan file when a group does not resolve, so a broken plan never becomes a reviewable promotion PR; offline plans skip validation by design
- `napt promote apply` preflights every action it would execute before executing any, so an unresolvable group aborts with zero tenant mutations; groups referenced only by stale or already-applied actions are excluded, preserving the resume-after-partial-failure guarantee
- Skip semantics extracted into `_action_skip_reason()` as the single authority shared by the apply loop and the preflight filter
- Drift now distinguishes `unrecorded_assignment` (matches a currently configured target — a lost apply writeback that a later apply converges, or an admin pre-empting configured policy) from `unexpected_assignment` (matches no configured target), with epistemic wording throughout
- Offline plans that produce actions warn that their groups were not validated (mirrors upload's missing-pending warning); empty plans stay quiet
- One authenticated plan session shares a single group-resolution cache across validation and the drift check (`detect_drift` gains an optional `group_id_cache` parameter)

## Testing
- [x] Unit tests added/updated — 706 pass; new coverage: preflight helper (dedup, cache sharing, no-group actions), apply zero-mutation abort, stale-action-with-dead-group resume safety, drift classification matrix, CLI fail-without-writing-plan, offline-skip, and offline-warning paths
- [ ] Integration tests added/updated (n/a — Graph interactions mocked, to be live-validated in the napt-gitops-test repo before release)
- [x] Manual testing performed — behavior derived from failures reproduced in the live test tenant

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (user-guide, common-tasks, changelog)
- [x] Tests pass
- [x] No linting errors (ruff, pyright, mkdocs --strict all clean)