### PR TITLE
chore: Prepare release 0.8.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-12
+
 ### Added
 
 - **Plan group validation** - Every group named in a promotion plan is
@@ -410,6 +412,7 @@ Initial internal release.
 
 
 [Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.7.0...HEAD
+[0.8.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.0...0.5.1

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.7.0"
+version = "0.8.0"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description
Release PR for NAPT 0.8.0. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[0.8.0]`, and adds a fresh empty `[Unreleased]` section.

## Motivation
Cuts the 0.8.0 release.

## Changes
- Bump `pyproject.toml` version to 0.8.0
- Bump `napt/__init__.py` `__version__` to 0.8.0
- Promote `[Unreleased]` to `[0.8.0] - 2026-07-12` in `docs/changelog.md`, covering:
    - Added: plan group validation (authenticated plan fails on unresolvable groups; apply preflights with zero-mutation abort)
    - Added: publication recovery (`promote apply` always, `promote plan --reconcile` opt-in)
    - Changed: drift findings reclassified with epistemic wording (`unrecorded_assignment` vs `unexpected_assignment`)
    - Fixed: reference GitOps workflow defects (writeback rebase/retry, split concurrency groups, fail-fast on rotated vendor binaries)
    - Fixed: upload recovery of orphaned app records with uncommitted content
    - Fixed: transient Azure Blob 403 retries during upload
    - Fixed: build locating installers and versions from committed deployment state on CI runners
- Add comparison link `[0.8.0]: ...compare/0.7.0...0.8.0`

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (run via `pytest tests/` — 721 passed)
- [x] Manual testing performed (every 0.8.0 change validated end-to-end against a live Intune tenant in the napt-gitops-test repo)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (changelog promoted)
- [x] Tests pass
- [x] No linting errors