### PR TITLE
chore: Post-0.8.0 follow-ups and discover cache reuse

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -84,7 +84,7 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
    Release PR for NAPT X.Y.Z. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[X.Y.Z]`, and adds a fresh empty `[Unreleased]` section.
 
    ## Motivation
-   Cuts the X.Y.Z release. Squash-merge this PR, then `/release X.Y.Z` again to tag and publish.
+   Cuts the X.Y.Z release.
 
    ## Changes
    - Bump `pyproject.toml` version to X.Y.Z
@@ -106,7 +106,7 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
    )"
    ```
 
-   Substitute `X.Y.Z` with the real version and `YYYY-MM-DD` with today's date in the heredoc before running. Pull the bullet content for the **Changes** section from the actual `[X.Y.Z]` changelog block — replace the boilerplate above with one line per real bullet if there are notable user-facing changes worth surfacing in the PR body.
+   Substitute `X.Y.Z` with the real version and `YYYY-MM-DD` with today's date in the heredoc before running. Pull the bullet content for the **Changes** section from the actual `[X.Y.Z]` changelog block — replace the boilerplate above with one line per real bullet if there are notable user-facing changes worth surfacing in the PR body. The PR body describes what changed and why only — no workflow instructions (e.g. "squash-merge this, then run X"); those belong in your report to the user, not the PR.
 
 9. **Report PR URL.** Tell the user to squash-merge, then re-run `/release X.Y.Z` for Phase 2.
 

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -879,7 +879,7 @@ jobs:
         with:
           python-version: "3.13"
       - run: pip install napt
-      - name: Restore installers and download cache from the last run
+      - name: Restore installers and discovery cache from the last run
         uses: actions/cache/restore@v4
         with:
           path: |

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -846,9 +846,6 @@ Two consequences to set up once:
 - The workflow identity needs permission to push to `main` — either
   allow the Actions bot through branch protection or use a bot/app
   token with bypass rights.
-  Note that GitHub only allows the Actions app as a ruleset bypass
-  actor on organization-owned repos; on a personal repo, use a PAT or
-  bot token for the writeback pushes instead.
 - `[skip ci]` keeps the writeback from re-triggering workflows.
 
 **Secrets.** `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -846,6 +846,9 @@ Two consequences to set up once:
 - The workflow identity needs permission to push to `main` — either
   allow the Actions bot through branch protection or use a bot/app
   token with bypass rights.
+  Note that GitHub only allows the Actions app as a ruleset bypass
+  actor on organization-owned repos; on a personal repo, use a PAT or
+  bot token for the writeback pushes instead.
 - `[skip ci]` keeps the writeback from re-triggering workflows.
 
 **Secrets.** `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -879,16 +879,26 @@ jobs:
         with:
           python-version: "3.13"
       - run: pip install napt
+      - name: Restore installers and download cache from the last run
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            downloads
+            cache
+          key: installers-
+          restore-keys: installers-
       - name: Discover all recipes
         shell: bash
         run: |
           git ls-files 'recipes/*.yaml' 'recipes/**/*.yaml' | while read -r recipe; do
             napt discover "$recipe"
           done
-      - name: Cache installers for the publish workflow
+      - name: Cache installers for publish and the next discover
         uses: actions/cache/save@v4
         with:
-          path: downloads
+          path: |
+            downloads
+            cache
           key: installers-${{ github.run_id }}
       - name: Open one PR per app with a new pending release
         shell: bash
@@ -949,7 +959,9 @@ jobs:
       - name: Restore cached installers
         uses: actions/cache/restore@v4
         with:
-          path: downloads
+          path: |
+            downloads
+            cache
           key: installers-
           restore-keys: installers-
       - name: Publish every app with an approved pending release
@@ -1008,6 +1020,21 @@ when the cache is stale or evicted (GitHub evicts caches unused for
 about a week), so the flow degrades gracefully.
 This is safe by construction — the upload hash gate validates whatever
 binary the runner provides, so a cache can never ship the wrong bytes.
+
+The restore step in the discover workflow serves a second purpose:
+bandwidth.
+`napt discover` records each vendor's `ETag`/`Last-Modified` headers in
+`cache/discovery.json` and sends them as conditional request headers on
+the next run; when the vendor answers HTTP 304, the previously
+downloaded installer is reused without transferring a byte.
+A fresh runner starts with neither the header cache nor the files, so
+restoring `cache/` and `downloads/` from the last run is what lets the
+scheduled discover skip re-downloading installers that have not changed
+— which adds up quickly for recipe sets full of large installers.
+Keep the `path` lists of the save and restore steps identical:
+`actions/cache` makes the path list part of the cache version, so a
+mismatched list reads as a silent cache miss.
+
 For long-lived archival — including installers for retained releases the
 vendor no longer serves — replace the cache steps with an object store
 (S3, Azure Blob) or a self-hosted runner with a persistent `downloads/`

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -223,7 +223,7 @@ apiVersion: napt/v1
 #   # entry matching the package (records what review approved).
 #   require_pending: false
 #
-#   # Deployment rings for update promotion (used by upcoming napt promote).
+#   # Deployment rings for update promotion (used by napt promote).
 #   # Each ring assigns the [Update] entry to Entra ID groups; a version
 #   # becomes eligible for the next ring after promote_after_days.
 #   rings:


### PR DESCRIPTION
## Description
Post-0.8.0 follow-ups plus a bandwidth improvement to the reference GitOps workflows: the discover workflow now round-trips `downloads/` and `cache/` through the Actions cache so unchanged installers are reused instead of re-downloaded.

## Motivation
The org.yaml template still described deployment rings as "used by upcoming napt promote," but `napt promote` shipped in 0.7.0. Separately, the reference discover workflow started every scheduled run on a fresh runner with no HTTP cache, so `napt discover` re-downloaded every installer daily even when vendors had not changed them — the ETag/Last-Modified conditional-request path never fired in CI. For orgs with many recipes pointing at large installers, that bandwidth adds up.

## Changes
- Remove the stale "upcoming" qualifier from the rings comment in `ORG_YAML_TEMPLATE`
- Reference discover workflow restores `downloads/` and `cache/` from the previous run and saves both back, so unchanged installers are reused via HTTP 304 instead of re-downloaded
- Aligned the publish workflow restore path list to match (actions/cache treats the path list as part of the cache version; a mismatch is a silent miss) and documented that constraint
- Release skill: keep workflow instructions out of release PR bodies

A planned note claiming GitHub restricts the Actions app as a ruleset bypass actor to org-owned repos was dropped — the restriction could not be verified against GitHub documentation.

## Testing
How was this tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
    - Live-validated in napt-gitops-test: first dispatch after the change was the expected one-time cache miss; the second dispatch and the next two scheduled runs restored the prior run''s cache — 7-Zip resolved via "version unchanged, using cached file" and Chrome via HTTP 304, with zero vendor downloads
    - `mkdocs build --strict` passes

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors