### PR TITLE
feat: Split promotion plans into per-app files

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: Per-app promotion plans** - `napt promote plan` now writes
+    one plan file per app (`state/plans/<app-id>.json`) instead of a
+    single batched `state/plan.json`, and `napt promote apply` consumes
+    each file independently
+    - One app's failure (unresolvable group, Graph error) keeps its plan
+        file for retry and no longer blocks the other apps' promotions;
+        failed apps are reported and fail the run after the others apply
+    - To hold one app's promotions during review, delete its plan file —
+        no more hand-editing action entries inside a shared JSON
+    - Plan actions now carry reviewer context: the app's display name,
+        and for ring advancement, when the release entered the ring it is
+        leaving and that ring's bake threshold
+    - Migration: none needed for state — plans are transient. Update
+        promotion workflows to watch `state/plans/**` instead of
+        `state/plan.json` (see the reference workflows in Common Tasks)
+
 ## [0.8.0] - 2026-07-12
 
 ### Added

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -702,8 +702,11 @@ release has proven itself.
 
    A newly uploaded release enters the first ring; a release that has held
    its ring for `promote_after_days` advances to the next.
-   Eligible actions are written to `state/plan.json`; review the file, or
-   commit it and gate the apply on a pull request.
+   Eligible actions are written per app to `state/plans/<app-id>.json`;
+   review the files, or commit them and gate the apply on a pull request.
+   Each action names the app, the release, the groups it will assign,
+   and — for advancement — when the release entered its current ring and
+   that ring's bake threshold, so the files read as the review record.
 
 3. **Apply** — execute the plan against Intune:
 
@@ -714,16 +717,18 @@ release has proven itself.
    Ring groups are assigned to the release's `[Update]` entry as required
    installs; the displaced older release is unassigned and retired per
    `deployment.retain_versions`.
+   Each app's plan file is consumed after that app applies fully, and one
+   app's failure keeps its plan file for retry without blocking the rest.
    Every apply also prints a drift check — discrepancies between
    deployment state and Intune (removed assignments, admin-made changes,
    stray apps) are warned about, never corrected.
    Use `napt promote plan --check-drift` for the same report without
    applying anything.
    Both commands also fail fast on a group typo or deleted Entra ID
-   group: an authenticated plan refuses to write a plan that names an
-   unresolvable group, and apply checks every group it is about to
-   assign before touching anything, so a bad group aborts with zero
-   changes instead of a half-applied plan.
+   group: an authenticated plan refuses to write plans that name an
+   unresolvable group, and apply checks every group an app's plan is
+   about to assign before touching that app, so a bad group fails that
+   app with zero changes instead of a half-applied plan.
    Run `napt status` to see where every app stands.
 
 Run plan and apply on a schedule and promotion becomes automatic: each
@@ -830,13 +835,14 @@ Adapt names, schedules, and branch rules to your org.
   that diff. Merging approves the release — a workflow builds, packages,
   and uploads it, with the hash gate guaranteeing the approved binary is
   exactly what ships.
-- **Promotion PRs** (one, batched): `napt promote plan` writes
-  `state/plan.json` when releases are eligible to enter or advance
-  rings; CI commits it to a branch and opens a PR. Merging approves the
-  promotions — a workflow runs `napt promote apply`, which executes the
-  plan as an allowlist.
-  To hold one promotion, delete its entry from the plan file in the PR;
-  the next scheduled plan will re-propose it.
+- **Promotion PRs** (one, batched): `napt promote plan` writes one
+  `state/plans/<id>.json` file per app with releases eligible to enter
+  or advance rings; CI commits them to a branch and opens a PR. Merging
+  approves the promotions — a workflow runs `napt promote apply`, which
+  executes each app's plan as an allowlist, independently.
+  To hold one app's promotions, delete its plan file in the PR; the
+  next scheduled plan will re-propose it, and the other apps merge and
+  apply unaffected.
 
 **Writeback commits.** After upload and apply, NAPT has recorded new
 facts (Intune app IDs, ring positions) in the working tree that must
@@ -1056,7 +1062,7 @@ jobs:
           git push -f origin napt/promotion-plan
           gh pr create --head napt/promotion-plan \
             --title "Promotion plan" \
-            --body "Merging approves these ring promotions. Delete an entry from state/plan.json to hold it." \
+            --body "Merging approves these ring promotions. To hold one app, delete its state/plans/ file." \
             || true  # PR already open; the force-push updated it
 ```
 
@@ -1067,7 +1073,7 @@ name: promote-apply
 on:
   push:
     branches: [main]
-    paths: ["state/plan.json"]
+    paths: ["state/plans/**"]
 # Own group (not shared with publish) - see the publish workflow's
 # concurrency comment.
 concurrency: napt-promote-apply
@@ -1086,9 +1092,14 @@ jobs:
         with:
           python-version: "3.13"
       - run: pip install napt
-      - name: Apply the approved plan
+      # Apply exits 1 when any app's plan fails, but other apps may
+      # have applied — continue so the writeback records their ring
+      # positions and consumed plans; a final step fails the run.
+      - name: Apply the approved plans
+        id: apply
+        continue-on-error: true
         run: napt promote apply
-      - name: Write back ring positions and consume the plan
+      - name: Write back ring positions and consume the plans
         shell: bash
         run: |
           git config user.name "napt-bot"
@@ -1102,12 +1113,19 @@ jobs:
             git pull --rebase origin main
           done
           git push
+      - name: Surface a failed apply
+        if: steps.apply.outcome == 'failure'
+        run: exit 1
 ```
 
 **Notes:**
 
 - Promotions merged but applied later are always safe: bake time only
   grows, and apply validates every entry against current state anyway.
+- Apply treats each app's plan file as an independent unit: a failure
+  (an unresolvable group, a Graph error) fails that app, keeps its plan
+  file on `main` for the next apply, and never blocks the other apps —
+  which is why the writeback above runs even when the apply step fails.
 - All four workflows are idempotent — re-running any of them converges
   to the same result (upload adopts existing apps, apply skips
   already-applied actions).

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -1126,6 +1126,18 @@ jobs:
   (an unresolvable group, a Graph error) fails that app, keeps its plan
   file on `main` for the next apply, and never blocks the other apps —
   which is why the writeback above runs even when the apply step fails.
+- Resolving a failed app depends on the failure class.
+  A transient Graph error needs no fix: re-run the apply workflow —
+  already-applied actions skip, the rest complete, and the plan file is
+  consumed.
+  An unresolvable group needs the configuration fixed (or the Entra ID
+  group restored) and then a re-plan, not just a re-run: plan files bake
+  in group names at plan time, so the fix reaches Intune when the next
+  scheduled plan regenerates the file and the promotion PR carries the
+  corrected plan.
+  Until then, apply keeps failing that one app — and only that one.
+  A corrupted state file restores from git history like any other
+  committed file.
 - All four workflows are idempotent — re-running any of them converges
   to the same result (upload adopts existing apps, apply skips
   already-applied actions).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -352,9 +352,9 @@ entry), displacing whatever release each ring held.
 
 - Each ring holds at most one release — the newest that has reached it;
   releases advance after `promote_after_days` in their current ring
-- Terraform-style plan/apply: `state/plan.json` is the reviewable
-  artifact and apply's allowlist; validate-then-act makes both safe to
-  re-run
+- Terraform-style plan/apply: per-app plan files
+  (`state/plans/<id>.json`) are the reviewable artifact and apply's
+  allowlist; validate-then-act makes both safe to re-run
 - Authoritative per-app deployment state
   (`state/deployment/<id>.json`, `schemaVersion` 1) split from the
   disposable discovery cache (`cache/discovery.json`)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -444,18 +444,23 @@ napt package recipes/Google/chrome.yaml --version 130.0.6723.116
 
 Plans and applies ring-based promotion of published apps. `promote plan`
 computes which releases enter or advance deployment rings (per
-`deployment.rings`) and writes `state/plan.json` when there is work; a
-stale plan file is removed when nothing is eligible. Read-only unless
-`--reconcile` is passed.
+`deployment.rings`) and writes one plan file per app with work
+(`state/plans/<app-id>.json`); an app's stale plan file is removed when
+nothing is eligible for it. Read-only unless `--reconcile` is passed.
+Besides the fields apply acts on, each action carries reviewer context:
+the app's display name and — for ring advancement — when the release
+entered the ring it is leaving and that ring's bake threshold.
 
-`promote apply` executes the plan against Intune: assigns install entries,
-enters and advances rings, unassigns displaced releases, and retires them
-per `deployment.retain_versions`. It consumes `state/plan.json` when one
-exists (removing it after a fully successful run) and plans fresh
-otherwise. Stale or already-applied actions are skipped with a warning, so
-re-running after a partial failure is safe. Assignments NAPT does not
-manage — admin-made groups, all-device targets, exclusions — are always
-preserved.
+`promote apply` executes the plans against Intune: assigns install
+entries, enters and advances rings, unassigns displaced releases, and
+retires them per `deployment.retain_versions`. It consumes every plan
+file in `state/plans/` when any exist (removing each after its app
+applies fully) and plans fresh otherwise. Each app's plan is an
+independent unit — one app's failure keeps its plan file for retry and
+never blocks the others. Stale or already-applied actions are skipped
+with a warning, so re-running after a partial failure is safe.
+Assignments NAPT does not manage — admin-made groups, all-device
+targets, exclusions — are always preserved.
 
 Both commands report **assignment drift**: every discrepancy between what
 deployment state says should be assigned and what Intune actually has —
@@ -472,14 +477,14 @@ credentials — without the flag, plan stays fully offline).
 
 Both commands also **validate plan groups**. Authenticated plan runs
 (`--check-drift` or `--reconcile`) resolve every group named in the
-computed plan and fail — writing no plan file — when one does not
+computed plan and fail — writing no plan files — when one does not
 resolve, so a plan with a group typo never becomes a reviewable
-promotion PR. Apply preflights every action it would execute the same
-way before executing anything, so an unresolvable group aborts the run
-with zero tenant mutations instead of stranding a half-applied plan;
-fix the configuration and re-plan. A dead group referenced only by
-stale or already-applied actions never blocks a run, so re-running
-after a partial failure stays safe. Offline plans skip validation —
+promotion PR. Apply preflights each app's actions the same way before
+executing any of them, so an unresolvable group fails that app with
+zero tenant mutations instead of stranding a half-applied plan; fix
+the configuration and re-plan. A dead group referenced only by stale
+or already-applied actions never blocks an app, so re-running after a
+partial failure stays safe. Offline plans skip validation —
 warning when they produce actions — and the apply preflight backstops
 whatever they produce.
 
@@ -680,21 +685,24 @@ A file holds four sections:
 `napt discover` records the pending candidate.
 Later pipeline stages consume it.
 
-### Promotion plan file
+### Promotion plan files
 
 `napt promote plan` evaluates ring eligibility as a pure function of
-deployment state, configuration, and the clock, and writes the result to
-`state/plan.json`.
-The plan file exists exactly when there are eligible actions: a plan run
-that finds nothing removes a stale plan file.
-Its git status is therefore the CI signal that a promotion review is
-needed — no special exit codes (`napt` always exits 0 on success, 1 on
-error).
+deployment state, configuration, and the clock, and writes the result as
+one file per app: `state/plans/<app-id>.json`.
+An app's plan file exists exactly when that app has eligible actions: a
+plan run that finds nothing for an app removes its stale plan file.
+Each file's git status is therefore the per-app CI signal that a
+promotion review is needed — no special exit codes (`napt` always exits
+0 on success, 1 on error).
 Plan output is deterministic, so re-running plan against unchanged state
-produces a byte-identical file.
-`napt promote apply` executes the plan as an allowlist — entries that no
+produces byte-identical files.
+`napt promote apply` executes each plan as an allowlist — entries that no
 longer validate against current state are skipped, never improvised — and
-removes the file after a fully successful run.
+removes each file after its app applies fully.
+To hold one app's promotions during review, delete its plan file; the
+other apps' plans are unaffected, and the next plan run re-proposes
+whatever is still eligible.
 
 ### Default Behavior (Stateful)
 
@@ -796,7 +804,7 @@ to its own:
 | `napt discover` | `--output-dir` | Where to save downloaded installers | `directories.discover` | `downloads` |
 | `napt discover` | `--cache-file` | Discovery cache file (`<dir>/discovery.json`) | `directories.cache` | `cache` |
 | `napt discover` | `--state-dir` | Per-app deployment state (`<dir>/deployment/`) | `directories.state` | `state` |
-| `napt promote` | `--state-dir` | Deployment state and plan.json | `directories.state` | `state` |
+| `napt promote` | `--state-dir` | Deployment state and plan files | `directories.state` | `state` |
 | `napt status` | `--state-dir` | Deployment state to summarize (no config lookup) | - | `state` |
 | `napt build` | `--downloads-dir` | Where to find the installer | `directories.discover` | `downloads` |
 | `napt build` | `--output-dir` | Where to save builds | `directories.build` | `builds` |

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -103,12 +103,12 @@ from napt.promote import (
     apply_plan,
     detect_drift,
     load_recipe_configs,
-    plan_path_for,
     plan_promotions,
+    plans_dir_for,
     reconcile_publications,
     resolve_state_dir,
     unresolvable_groups,
-    write_plan_file,
+    write_plan_files,
 )
 from napt.state import summarize_deployment_states
 from napt.upload import upload_package
@@ -678,10 +678,10 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
 
     Computes promotion actions for all recipes (or one recipe) as a pure
     function of deployment state, configuration, and the clock, and
-    writes the plan file when there is work. Read-only with respect to
+    writes one plan file per app with work. Read-only with respect to
     Intune, and — unless --reconcile recovers a lost publication
-    writeback first — to deployment state; a stale plan file is removed
-    when no actions are eligible.
+    writeback first — to deployment state; an app's stale plan file is
+    removed when none of its actions remain eligible.
 
     Args:
         args: Parsed command-line arguments containing the recipes path,
@@ -706,7 +706,7 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
             if args.state_dir is not None
             else resolve_state_dir(recipes)
         )
-        plan_path = plan_path_for(state_dir)
+        configs = load_recipe_configs(recipes)
         recovered: list[dict[str, Any]] = []
         drift: list[dict[str, Any]] = []
         if args.reconcile or args.check_drift:
@@ -714,7 +714,6 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
             # validation, and the drift check. Reconciliation runs
             # before planning so recovered releases are promotable this
             # run; drift runs after it so repaired state is compared.
-            configs = load_recipe_configs(recipes)
             access_token = get_access_token()
             existing_apps = list_mobile_apps(access_token)
             group_id_cache: dict[str, str] = {}
@@ -749,7 +748,7 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
                     "Plan groups not validated against Entra ID (offline "
                     "run); apply validates them before assigning.",
                 )
-        write_plan_file(actions, plan_path)
+        written = write_plan_files(actions, state_dir, configs)
     except AuthError as err:
         print(f"Authentication error: {err}")
         if args.verbose or args.debug:
@@ -780,12 +779,15 @@ def cmd_promote_plan(args: argparse.Namespace) -> int:
             print(f"  {_describe_action(action)}")
         print("=" * 70)
         print()
-        print(f"[OK] Plan written: {plan_path} ({len(actions)} action(s))")
+        print(
+            f"[OK] Plan written: {len(written)} file(s) in "
+            f"{plans_dir_for(state_dir)} ({len(actions)} action(s))"
+        )
     else:
         print("  No promotions eligible.")
         print("=" * 70)
         print()
-        print("[OK] Nothing to promote. No plan file needed.")
+        print("[OK] Nothing to promote. No plan files needed.")
 
     if args.reconcile:
         _print_recovered(recovered)
@@ -827,12 +829,14 @@ def _print_recovered(recovered: list[dict[str, Any]]) -> None:
 def cmd_promote_apply(args: argparse.Namespace) -> int:
     """Handler for 'napt promote apply' command.
 
-    Executes a promotion plan against Intune: assigns install entries,
+    Executes promotion plans against Intune: assigns install entries,
     enters and advances releases through rings, displaces superseded
-    releases, and retires them per the retention policy. Consumes the
-    plan file when one exists; otherwise plans fresh and applies
-    immediately. Stale or already-applied actions are skipped with a
-    warning, so re-running after a partial failure is safe.
+    releases, and retires them per the retention policy. Consumes each
+    per-app plan file after its app applies fully; otherwise plans
+    fresh and applies immediately. One app's failure keeps its plan
+    file for retry and never blocks the others, and stale or
+    already-applied actions are skipped with a warning, so re-running
+    after a partial failure is safe.
 
     Args:
         args: Parsed command-line arguments containing the recipes path,
@@ -840,7 +844,7 @@ def cmd_promote_apply(args: argparse.Namespace) -> int:
 
     Returns:
         Exit code (0 for success — including nothing to apply,
-        1 for failure).
+        1 for failure, including any app whose plan failed to apply).
 
     """
     logger = get_logger(verbose=args.verbose, debug=args.debug)
@@ -886,16 +890,19 @@ def cmd_promote_apply(args: argparse.Namespace) -> int:
 
     applied = summary["applied"]
     skipped = summary["skipped"]
+    failed = summary["failed"]
 
     print("=" * 70)
     print("PROMOTION APPLY")
     print("=" * 70)
-    if not applied and not skipped:
+    if not applied and not skipped and not failed:
         print("  Nothing to apply.")
     for action in applied:
         print(f"  [OK] {_describe_action(action)}")
     for entry in skipped:
         print(f"  [SKIP] {_describe_action(entry['action'])} ({entry['reason']})")
+    for entry in failed:
+        print(f"  [FAIL] {entry['app_id']}: {entry['error']}")
     print("=" * 70)
 
     if summary.get("recovered"):
@@ -904,6 +911,13 @@ def cmd_promote_apply(args: argparse.Namespace) -> int:
         _print_drift(summary["drift"])
 
     print()
+    if failed:
+        print(
+            f"[FAIL] Applied {len(applied)} action(s), skipped "
+            f"{len(skipped)}; {len(failed)} app(s) failed and kept "
+            "their plan files. Fix the errors and re-run."
+        )
+        return 1
     print(f"[SUCCESS] Applied {len(applied)} action(s), " f"skipped {len(skipped)}.")
 
     return 0
@@ -1446,16 +1460,17 @@ def main() -> None:
     )
     parser_promote_plan = promote_sub.add_parser(
         "plan",
-        help="Compute eligible promotions and write the plan file",
+        help="Compute eligible promotions and write per-app plan files",
         description=(
             "Compute which releases enter or advance deployment rings, and "
-            "write state/plan.json when there is work. Never modifies "
-            "Intune. Read-only for deployment state too, except that "
-            "--reconcile writes it when recovering a lost publication "
-            "writeback. With --check-drift or --reconcile, every group in "
-            "the plan is validated against Entra ID and an unresolvable "
-            "group fails the run without writing a plan. A stale plan "
-            "file is removed when nothing is eligible."
+            "write one state/plans/<app>.json file per app with work. "
+            "Never modifies Intune. Read-only for deployment state too, "
+            "except that --reconcile writes it when recovering a lost "
+            "publication writeback. With --check-drift or --reconcile, "
+            "every group in the plan is validated against Entra ID and an "
+            "unresolvable group fails the run without writing any plan. "
+            "An app's stale plan file is removed when nothing is eligible "
+            "for it."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1470,7 +1485,7 @@ def main() -> None:
         type=Path,
         default=None,
         help=(
-            "State directory holding deployment/ and plan.json "
+            "State directory holding deployment/ and plans/ "
             "(default: directories.state from config)"
         ),
     )
@@ -1508,14 +1523,15 @@ def main() -> None:
 
     parser_promote_apply = promote_sub.add_parser(
         "apply",
-        help="Execute a promotion plan against Intune",
+        help="Execute promotion plans against Intune",
         description=(
             "Execute promotion actions: assign install entries, enter and "
             "advance rings, displace superseded releases, and retire them "
-            "per deployment.retain_versions. Consumes state/plan.json when "
-            "it exists; otherwise plans fresh and applies immediately. "
-            "Stale or already-applied actions are skipped, so re-running "
-            "is safe."
+            "per deployment.retain_versions. Consumes each per-app plan "
+            "file in state/plans/ when any exist; otherwise plans fresh "
+            "and applies immediately. One app's failure keeps its plan "
+            "file and never blocks the others, and stale or "
+            "already-applied actions are skipped, so re-running is safe."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1530,7 +1546,7 @@ def main() -> None:
         type=Path,
         default=None,
         help=(
-            "State directory holding deployment/ and plan.json "
+            "State directory holding deployment/ and plans/ "
             "(default: directories.state from config)"
         ),
     )
@@ -1538,7 +1554,10 @@ def main() -> None:
         "--plan-file",
         type=Path,
         default=None,
-        help="Plan file to execute (default: <state-dir>/plan.json if present)",
+        help=(
+            "Single plan file to execute (default: every file in "
+            "<state-dir>/plans/ if any exist)"
+        ),
     )
     parser_promote_apply.add_argument(
         "-v",

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -16,8 +16,9 @@
 
 Implements ring-based promotion of published apps: ``napt promote plan``
 computes which releases should enter or advance through the configured
-deployment rings and writes a reviewable plan file; ``napt promote apply``
-executes a plan against Intune.
+deployment rings and writes one reviewable plan file per app;
+``napt promote apply`` executes each app's plan against Intune
+independently.
 
 The core invariant: each ring holds at most one release of an app's Update
 entry — the newest release that has reached it. Promotion advances the

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -39,8 +39,9 @@ from .planner import (
     load_recipe_configs,
     plan_path_for,
     plan_promotions,
+    plans_dir_for,
     resolve_state_dir,
-    write_plan_file,
+    write_plan_files,
 )
 from .preflight import unresolvable_groups
 from .reconcile import reconcile_publications
@@ -52,8 +53,9 @@ __all__ = [
     "load_recipe_configs",
     "plan_path_for",
     "plan_promotions",
+    "plans_dir_for",
     "reconcile_publications",
     "resolve_state_dir",
     "unresolvable_groups",
-    "write_plan_file",
+    "write_plan_files",
 ]

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -14,7 +14,7 @@
 
 """Promotion apply for NAPT deployment rings.
 
-Executes a promotion plan against Intune: assigns install entries,
+Executes promotion plans against Intune: assigns install entries,
 enters and advances releases through rings, displaces superseded
 releases, and retires them per the retention policy.
 
@@ -86,7 +86,7 @@ _RING_INTENT = "required"
 
 
 def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
-    """Loads planned actions from a plan file.
+    """Loads planned actions from a per-app plan file.
 
     Args:
         plan_path: Path to the plan file.
@@ -96,8 +96,9 @@ def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
 
     Raises:
         StateError: If the plan file contains invalid JSON, lacks an
-            actions list, or its schemaVersion is missing or
-            unsupported.
+            actions list, its schemaVersion is missing or unsupported,
+            or its actions do not all belong to the single app the file
+            declares.
 
     """
     try:
@@ -115,6 +116,20 @@ def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
             f"Unsupported plan schema version {found!r} in {plan_path} "
             f"(this NAPT release supports version {PLAN_SCHEMA_VERSION}). "
             "Re-run 'napt promote plan' to regenerate it."
+        )
+
+    # A plan file is one app's unit of work: apply's failure isolation
+    # and consume-after-success semantics attribute the whole file to a
+    # single app, so a file mixing apps cannot be applied faithfully.
+    action_app_ids = {action.get("app_id") for action in actions}
+    declared = data.get("app_id")
+    expected = {declared} if declared is not None else action_app_ids
+    if len(action_app_ids) > 1 or action_app_ids - expected:
+        raise StateError(
+            f"Plan file {plan_path} mixes actions for more than one app "
+            f"(declared app_id {declared!r}, actions reference "
+            f"{sorted(str(a) for a in action_app_ids)}). Plan files are "
+            "per-app. Re-run 'napt promote plan' to regenerate them."
         )
     return actions
 

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -18,6 +18,13 @@ Executes a promotion plan against Intune: assigns install entries,
 enters and advances releases through rings, displaces superseded
 releases, and retires them per the retention policy.
 
+Plans are applied per app: each ``state/plans/<app_id>.json`` file is
+an independent unit of work, preflighted, executed, and consumed on
+its own. A failure inside one app's plan records the failure, keeps
+that plan file for retry, and moves on to the next — one app's broken
+group or Graph error never strands the rest of the fleet's
+promotions.
+
 Every action is validated against current deployment state before
 executing (validate-then-act): stale actions — the deployed release
 changed since the plan was written, or the action already applied —
@@ -44,14 +51,14 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt.exceptions import ConfigError, StateError
+from napt.exceptions import ConfigError, NetworkError, StateError
 from napt.logging import get_global_logger
 from napt.promote.drift import detect_drift
 from napt.promote.planner import (
     PLAN_SCHEMA_VERSION,
     load_recipe_configs,
-    plan_path_for,
     plan_promotions,
+    plans_dir_for,
 )
 from napt.promote.preflight import unresolvable_groups
 from napt.promote.reconcile import reconcile_publications
@@ -456,17 +463,19 @@ def apply_plan(
     plan_file: Path | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    """Executes a promotion plan against Intune.
+    """Executes promotion plans against Intune.
 
-    Consumes the plan file when one exists (removing it after a fully
-    successful run); otherwise plans fresh and applies immediately.
-    Every group a non-skipped action will assign is resolved before any
-    action executes, so an unresolvable group aborts the run with zero
-    mutations rather than stranding a half-applied plan — while a dead
-    group referenced only by stale or already-applied actions never
-    blocks a run. Deployment state is saved after each applied action,
-    so a failed run resumes safely — already-applied actions validate
-    as no-ops.
+    Consumes per-app plan files from ``<state_dir>/plans/`` when any
+    exist (removing each after its app applies fully); otherwise plans
+    fresh and applies immediately. Each app's plan is an independent
+    unit: its groups are preflighted before any of its actions execute,
+    so an unresolvable group fails that app with zero mutations — and a
+    failure while applying one app records the failure, keeps its plan
+    file for retry, and continues with the remaining apps. A dead group
+    referenced only by stale or already-applied actions never blocks an
+    app. Deployment state is saved after each applied action, so a
+    failed run resumes safely — already-applied actions validate as
+    no-ops.
 
     Assignment drift is checked on every run — including runs with
     nothing to apply, which therefore still authenticate — and reported
@@ -481,21 +490,24 @@ def apply_plan(
     Args:
         recipes: A recipe YAML file, or a directory scanned recursively.
         state_dir: State directory holding ``deployment/`` and
-            ``plan.json``.
-        plan_file: Explicit plan file path. When omitted, the default
-            plan location is used if present, else a fresh plan is
-            computed and applied.
+            ``plans/``.
+        plan_file: Explicit path to a single plan file to apply. When
+            omitted, every file in the default plans directory is
+            applied if any exist, else a fresh plan is computed and
+            applied.
         now: Evaluation clock for ring timestamps and fresh planning.
             Defaults to the current UTC time.
 
     Returns:
         A summary dict with "applied" and "skipped" action lists,
+            "failed" per-app failure records (app_id and error),
             "drift" findings, and "recovered" reconciliation findings.
 
     Raises:
         AuthError: If authentication fails.
-        ConfigError: On invalid recipes or unresolvable groups.
-        NetworkError: On Graph API failures.
+        ConfigError: On invalid recipes.
+        NetworkError: On Graph API failures outside a per-app unit
+            (listing the tenant, reconciliation, the drift check).
         StateError: On corrupted deployment state or plan file.
 
     """
@@ -503,7 +515,6 @@ def apply_plan(
     if now is None:
         now = datetime.now(UTC)
 
-    plan_path = plan_file if plan_file is not None else plan_path_for(state_dir)
     deployment_dir = state_dir / "deployment"
 
     configs = load_recipe_configs(recipes)
@@ -520,45 +531,77 @@ def apply_plan(
         access_token, configs, deployment_dir, run.existing_apps
     )
 
-    from_file = plan_path.exists()
-    if from_file:
-        actions = load_plan_file(plan_path)
-        logger.info("PROMOTE", f"Applying plan file: {plan_path}")
+    # Each unit is one app's plan: (plan file to consume, its actions).
+    # A fresh plan has no files to consume but keeps the per-app split
+    # so failure isolation behaves identically in both modes.
+    units: list[tuple[Path | None, list[dict[str, Any]]]]
+    if plan_file is not None:
+        units = [(plan_file, load_plan_file(plan_file))]
+        logger.info("PROMOTE", f"Applying plan file: {plan_file}")
     else:
-        actions = plan_promotions(recipes, state_dir=deployment_dir, now=now)
-        logger.info("PROMOTE", "No plan file found; planning and applying")
-
-    # Preflight: every group a live action will touch must resolve
-    # before anything is applied, so an unresolvable group aborts with
-    # zero mutations instead of stranding a half-applied plan. Skipped
-    # actions are excluded — a dead group referenced only by a stale or
-    # already-applied action never blocks a run, preserving the
-    # resume-after-partial-failure guarantee. Resolutions are cached for
-    # the action loop below.
-    live = [a for a in actions if _action_skip_reason(run, a) is None]
-    problems = unresolvable_groups(access_token, live, run.group_id_cache)
-    if problems:
-        raise ConfigError(
-            "Plan preflight failed; nothing was applied. Unresolvable "
-            "groups:\n  "
-            + "\n  ".join(problems)
-            + "\nFix the group configuration and re-plan, or correct the "
-            "plan file, then re-run."
-        )
-
-    for action in actions:
-        reason = _action_skip_reason(run, action)
-        if reason is not None:
-            run.skip(action, reason)
-            continue
-        if action["type"] == "assign_install":
-            _apply_install_action(run, action)
+        plan_paths = sorted(plans_dir_for(state_dir).glob("*.json"))
+        if plan_paths:
+            units = [(path, load_plan_file(path)) for path in plan_paths]
+            logger.info(
+                "PROMOTE",
+                f"Applying {len(plan_paths)} plan file(s) from "
+                f"{plans_dir_for(state_dir)}",
+            )
         else:
-            _apply_ring_action(run, action)
+            fresh = plan_promotions(recipes, state_dir=deployment_dir, now=now)
+            by_app: dict[str, list[dict[str, Any]]] = {}
+            for action in fresh:
+                by_app.setdefault(action["app_id"], []).append(action)
+            units = [(None, app_actions) for _, app_actions in sorted(by_app.items())]
+            logger.info("PROMOTE", "No plan files found; planning and applying")
 
-    if from_file:
-        plan_path.unlink()
-        logger.verbose("PROMOTE", f"Consumed plan file: {plan_path}")
+    failed: list[dict[str, Any]] = []
+    for plan_path, actions in units:
+        if plan_path is not None and not actions:
+            plan_path.unlink()  # An empty plan file holds no decisions.
+            continue
+        unit_id = actions[0]["app_id"] if actions else "?"
+
+        # Preflight: every group a live action of this app will touch
+        # must resolve before any of its actions execute, so an
+        # unresolvable group fails this app with zero mutations instead
+        # of stranding a half-applied plan. Skipped actions are excluded
+        # — a dead group referenced only by a stale or already-applied
+        # action never blocks the app. Resolutions are cached for the
+        # action loop below.
+        live = [a for a in actions if _action_skip_reason(run, a) is None]
+        problems = unresolvable_groups(access_token, live, run.group_id_cache)
+        if problems:
+            reason = "unresolvable groups: " + "; ".join(problems)
+            logger.warning(
+                "PROMOTE",
+                f"{unit_id}: preflight failed, nothing applied for this "
+                f"app; plan kept for retry ({reason})",
+            )
+            failed.append({"app_id": unit_id, "error": reason})
+            continue
+
+        try:
+            for action in actions:
+                reason = _action_skip_reason(run, action)
+                if reason is not None:
+                    run.skip(action, reason)
+                    continue
+                if action["type"] == "assign_install":
+                    _apply_install_action(run, action)
+                else:
+                    _apply_ring_action(run, action)
+        except (ConfigError, NetworkError, StateError) as err:
+            logger.warning(
+                "PROMOTE",
+                f"{unit_id}: apply failed, plan kept for retry: {err}",
+            )
+            failed.append({"app_id": unit_id, "error": str(err)})
+            continue
+
+        if plan_path is not None:
+            plan_path.unlink()
+            logger.verbose("PROMOTE", f"Consumed plan file: {plan_path}")
 
     # Drift is checked after the actions so freshly applied assignments
     # are reflected. Findings are warnings only, never corrected.
@@ -573,6 +616,7 @@ def apply_plan(
     return {
         "applied": run.applied,
         "skipped": run.skipped,
+        "failed": failed,
         "drift": drift,
         "recovered": recovered,
     }

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -33,14 +33,16 @@ A ring without ``promote_after_days`` never advances automatically —
 releases hold it until the configuration changes (the natural terminal
 ring, or a deliberate manual gate).
 
-The plan file (default ``state/plan.json``) is written only when actions
-exist; a stale plan file is removed when a plan run finds none. Exit
+Plans are written per app (default ``state/plans/<app_id>.json``), and
+an app's plan file exists exactly when that app has eligible actions; a
+stale plan file is removed when a plan run finds none for its app. Exit
 codes follow NAPT's uniform contract (0 success, 1 error) — CI detects
-pending work from the plan file's git status, not from exit codes.
+pending work from the plan files' git status, not from exit codes.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 import json
 from pathlib import Path
@@ -55,8 +57,9 @@ __all__ = [
     "load_recipe_configs",
     "plan_path_for",
     "plan_promotions",
+    "plans_dir_for",
     "resolve_state_dir",
-    "write_plan_file",
+    "write_plan_files",
 ]
 
 # Deterministic ordering of action types within one app's actions.
@@ -67,17 +70,31 @@ _ACTION_ORDER = {"assign_install": 0, "enter_ring": 1, "advance_ring": 2}
 PLAN_SCHEMA_VERSION = 1
 
 
-def plan_path_for(state_dir: Path) -> Path:
-    """Returns the plan file path for a state directory.
+def plans_dir_for(state_dir: Path) -> Path:
+    """Returns the plans directory for a state directory.
 
     Args:
         state_dir: The configured state directory (``directories.state``).
 
     Returns:
-        Path to the plan file (``<state_dir>/plan.json``).
+        Path to the plans directory (``<state_dir>/plans``).
 
     """
-    return state_dir / "plan.json"
+    return state_dir / "plans"
+
+
+def plan_path_for(state_dir: Path, app_id: str) -> Path:
+    """Returns an app's plan file path.
+
+    Args:
+        state_dir: The configured state directory (``directories.state``).
+        app_id: Recipe identifier the plan belongs to.
+
+    Returns:
+        Path to the app's plan file (``<state_dir>/plans/<app_id>.json``).
+
+    """
+    return plans_dir_for(state_dir) / f"{app_id}.json"
 
 
 def _parse_entered_at(value: str, context: str) -> datetime:
@@ -113,6 +130,13 @@ def _plan_app_actions(
 ) -> list[dict[str, Any]]:
     """Computes promotion actions for one app.
 
+    Besides the fields apply keys on (app id, sha256, ring), every
+    action carries informational fields for reviewers: the recipe's
+    display ``name``, and — for ``advance_ring`` — when the release
+    entered the ring it is leaving and that ring's bake threshold. Only
+    values stable across runs are included (never clock-derived ones),
+    preserving byte-identical plans for unchanged inputs.
+
     Args:
         config: Effective configuration for the app's recipe.
         state: The app's deployment state.
@@ -124,6 +148,7 @@ def _plan_app_actions(
 
     """
     app_id: str = config["id"]
+    name: str = config["name"]
     deployment: dict[str, Any] = config["deployment"]
     deployed = state.get("deployed")
 
@@ -149,6 +174,7 @@ def _plan_app_actions(
             {
                 "type": "assign_install",
                 "app_id": app_id,
+                "name": name,
                 "version": version,
                 "sha256": sha256,
                 "intent": install_cfg["intent"],
@@ -175,6 +201,7 @@ def _plan_app_actions(
             {
                 "type": "enter_ring",
                 "app_id": app_id,
+                "name": name,
                 "version": version,
                 "sha256": sha256,
                 "ring": first["name"],
@@ -204,9 +231,12 @@ def _plan_app_actions(
         {
             "type": "advance_ring",
             "app_id": app_id,
+            "name": name,
             "version": version,
             "sha256": sha256,
             "from_ring": held_ring_name,
+            "from_ring_entered_at": rings_state[held_ring_name]["entered_at"],
+            "promote_after_days": days,
             "ring": next_ring["name"],
             "groups": list(next_ring["groups"]),
         }
@@ -340,34 +370,55 @@ def plan_promotions(
     return actions
 
 
-def write_plan_file(actions: list[dict[str, Any]], plan_path: Path) -> bool:
-    """Writes the plan file, or removes a stale one when there is no work.
+def write_plan_files(
+    actions: list[dict[str, Any]],
+    state_dir: Path,
+    app_ids: Iterable[str],
+) -> list[Path]:
+    """Writes one plan file per app, removing stale files for apps without work.
 
-    The plan file exists exactly when there are planned actions, so its
-    git status is the signal that a promotion review is needed. Output is
-    deterministic (sorted keys, fixed indentation, no timestamps).
+    An app's plan file exists exactly when that app has planned actions,
+    so each file's git status is the per-app signal that a promotion
+    review is needed. Only apps covered by this run (``app_ids``) are
+    written or cleaned up — plan files for apps outside the run are left
+    untouched, so planning a single recipe never clobbers the rest of
+    the fleet's plans. Output is deterministic (sorted keys, fixed
+    indentation, no clock-derived values).
 
     Args:
         actions: Planned actions from plan_promotions.
-        plan_path: Path to the plan file.
+        state_dir: The configured state directory; plan files live in
+            its ``plans/`` subdirectory.
+        app_ids: Recipe ids covered by this plan run.
 
     Returns:
-        True when a plan file exists after the call, False when there
-            was no work (and any stale plan file was removed).
+        Paths of the plan files written, sorted by app id.
 
     """
-    if not actions:
-        if plan_path.exists():
-            plan_path.unlink()
-        return False
+    by_app: dict[str, list[dict[str, Any]]] = {}
+    for action in actions:
+        by_app.setdefault(action["app_id"], []).append(action)
 
-    plan_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(plan_path, "w", encoding="utf-8") as f:
-        json.dump(
-            {"schemaVersion": PLAN_SCHEMA_VERSION, "actions": actions},
-            f,
-            indent=2,
-            sort_keys=True,
-        )
-        f.write("\n")  # Trailing newline for git
-    return True
+    written: list[Path] = []
+    for app_id in sorted(set(app_ids) | set(by_app)):
+        plan_path = plan_path_for(state_dir, app_id)
+        app_actions = by_app.get(app_id)
+        if not app_actions:
+            if plan_path.exists():
+                plan_path.unlink()
+            continue
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(plan_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "schemaVersion": PLAN_SCHEMA_VERSION,
+                    "app_id": app_id,
+                    "actions": app_actions,
+                },
+                f,
+                indent=2,
+                sort_keys=True,
+            )
+            f.write("\n")  # Trailing newline for git
+        written.append(plan_path)
+    return written

--- a/napt/promote/preflight.py
+++ b/napt/promote/preflight.py
@@ -18,13 +18,14 @@ A planned action names its assignment groups, so an unresolvable group —
 a typo in ring configuration, a deleted Entra ID group — is knowable
 before anything mutates the tenant. Checking up front turns what would
 be a mid-run abort (leaving a half-applied plan) into either a failed
-plan that never reaches review, or an apply that refuses to start.
+plan that never reaches review, or an apply that refuses to start that
+app's plan.
 
 Used by the authenticated ``napt promote plan`` modes (a plan with an
 unresolvable group fails instead of becoming a reviewable promotion PR)
-and by ``napt promote apply`` as a preflight before executing any
-action. Offline plans skip validation — the apply preflight is the
-backstop for anything they produce.
+and by ``napt promote apply`` as a per-app preflight before executing
+any of that app's actions. Offline plans skip validation — the apply
+preflight is the backstop for anything they produce.
 """
 
 from __future__ import annotations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -745,8 +745,9 @@ class TestCmdPromotePlan:
             }
         ]
         with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
             patch("napt.cli.plan_promotions", return_value=actions),
-            patch("napt.cli.write_plan_file", return_value=True) as write_mock,
+            patch("napt.cli.write_plan_files", return_value=["p"]) as write_mock,
         ):
             code = cmd_promote_plan(
                 _args(
@@ -765,8 +766,9 @@ class TestCmdPromotePlan:
     def test_no_actions_returns_zero(self, tmp_path, capsys):
         """Tests that an empty plan reports nothing to promote."""
         with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
             patch("napt.cli.plan_promotions", return_value=[]),
-            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.write_plan_files", return_value=[]),
         ):
             code = cmd_promote_plan(
                 _args(
@@ -782,7 +784,10 @@ class TestCmdPromotePlan:
 
     def test_config_error_returns_one(self, tmp_path, capsys):
         """Tests that ConfigError is caught and returns 1."""
-        with patch("napt.cli.plan_promotions", side_effect=ConfigError("bad")):
+        with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
+            patch("napt.cli.plan_promotions", side_effect=ConfigError("bad")),
+        ):
             code = cmd_promote_plan(
                 _args(
                     recipes="recipes",
@@ -895,6 +900,7 @@ class TestCmdPromoteApply:
                     "reason": "already applied",
                 }
             ],
+            "failed": [],
         }
         with patch("napt.cli.apply_plan", return_value=summary):
             code = cmd_promote_apply(
@@ -909,12 +915,34 @@ class TestCmdPromoteApply:
 
     def test_nothing_to_apply_returns_zero(self, tmp_path, capsys):
         """Tests that an empty summary reports cleanly."""
-        with patch("napt.cli.apply_plan", return_value={"applied": [], "skipped": []}):
+        summary = {"applied": [], "skipped": [], "failed": []}
+        with patch("napt.cli.apply_plan", return_value=summary):
             code = cmd_promote_apply(
                 _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
             )
         assert code == 0
         assert "Nothing to apply" in capsys.readouterr().out
+
+    def test_failed_apps_print_and_return_one(self, tmp_path, capsys):
+        """Tests that per-app failures are printed and fail the run."""
+        summary = {
+            "applied": [],
+            "skipped": [],
+            "failed": [
+                {
+                    "app_id": "test-app",
+                    "error": "unresolvable groups: ghost-group",
+                }
+            ],
+        }
+        with patch("napt.cli.apply_plan", return_value=summary):
+            code = cmd_promote_apply(
+                _args(recipes="recipes", state_dir=tmp_path, plan_file=None)
+            )
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "[FAIL] test-app: unresolvable groups: ghost-group" in out
+        assert "1 app(s) failed" in out
 
     def test_auth_error_returns_one(self, tmp_path, capsys):
         """Tests that AuthError is caught and returns 1."""
@@ -954,7 +982,7 @@ class TestDriftOutput:
         }
         with (
             patch("napt.cli.plan_promotions", return_value=[]),
-            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.write_plan_files", return_value=[]),
             patch("napt.cli.load_recipe_configs", return_value={}),
             patch("napt.cli.get_access_token", return_value="tok"),
             patch("napt.cli.list_mobile_apps", return_value=[]),
@@ -978,6 +1006,7 @@ class TestDriftOutput:
         summary = {
             "applied": [],
             "skipped": [],
+            "failed": [],
             "drift": [
                 {
                     "app_id": "test-app",
@@ -1020,7 +1049,7 @@ class TestReconcileOutput:
         ]
         with (
             patch("napt.cli.plan_promotions", return_value=[]),
-            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.write_plan_files", return_value=[]),
             patch("napt.cli.load_recipe_configs", return_value={}),
             patch("napt.cli.get_access_token", return_value="tok"),
             patch("napt.cli.list_mobile_apps", return_value=[]),
@@ -1055,7 +1084,7 @@ class TestReconcileOutput:
                 "napt.cli.plan_promotions",
                 side_effect=lambda *a, **k: order.append("plan") or [],
             ),
-            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.write_plan_files", return_value=[]),
         ):
             code = cmd_promote_plan(
                 _args(
@@ -1093,7 +1122,7 @@ class TestReconcileOutput:
                     "No Entra ID group found with displayName 'ghost-group'."
                 ],
             ),
-            patch("napt.cli.write_plan_file") as write_mock,
+            patch("napt.cli.write_plan_files") as write_mock,
         ):
             code = cmd_promote_plan(
                 _args(
@@ -1113,8 +1142,9 @@ class TestReconcileOutput:
         """Tests that a plan without tenant flags never validates groups
         and that an empty plan draws no unvalidated warning."""
         with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
             patch("napt.cli.plan_promotions", return_value=[]),
-            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.write_plan_files", return_value=[]),
             patch("napt.cli.unresolvable_groups") as validate_mock,
         ):
             code = cmd_promote_plan(
@@ -1143,8 +1173,9 @@ class TestReconcileOutput:
             }
         ]
         with (
+            patch("napt.cli.load_recipe_configs", return_value={}),
             patch("napt.cli.plan_promotions", return_value=actions),
-            patch("napt.cli.write_plan_file", return_value=True),
+            patch("napt.cli.write_plan_files", return_value=["p"]),
         ):
             code = cmd_promote_plan(
                 _args(
@@ -1168,7 +1199,7 @@ class TestReconcileOutput:
             patch("napt.cli.reconcile_publications", return_value=[]),
             patch("napt.cli.detect_drift", return_value=[]),
             patch("napt.cli.plan_promotions", return_value=[]),
-            patch("napt.cli.write_plan_file", return_value=False),
+            patch("napt.cli.write_plan_files", return_value=[]),
         ):
             code = cmd_promote_plan(
                 _args(
@@ -1187,6 +1218,7 @@ class TestReconcileOutput:
         summary = {
             "applied": [],
             "skipped": [],
+            "failed": [],
             "drift": [],
             "recovered": [
                 {

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -15,7 +15,7 @@ from napt.promote import (
     plan_path_for,
     plan_promotions,
     resolve_state_dir,
-    write_plan_file,
+    write_plan_files,
 )
 from napt.state import (
     create_default_deployment_state,
@@ -136,6 +136,7 @@ class TestPlanPromotions:
             {
                 "type": "enter_ring",
                 "app_id": "test-app",
+                "name": "App test-app",
                 "version": "1.0.0",
                 "sha256": "a" * 64,
                 "ring": "pilot",
@@ -154,6 +155,7 @@ class TestPlanPromotions:
             {
                 "type": "assign_install",
                 "app_id": "test-app",
+                "name": "App test-app",
                 "version": "1.0.0",
                 "sha256": "a" * 64,
                 "intent": "available",
@@ -229,9 +231,12 @@ class TestPlanPromotions:
             {
                 "type": "advance_ring",
                 "app_id": "test-app",
+                "name": "App test-app",
                 "version": "1.0.0",
                 "sha256": "a" * 64,
                 "from_ring": "pilot",
+                "from_ring_entered_at": "2026-07-06T12:00:00+00:00",
+                "promote_after_days": 2,
                 "ring": "broad",
                 "groups": ["sg-broad"],
             }
@@ -383,47 +388,82 @@ class TestResolveStateDir:
         assert resolve_state_dir(recipe) == Path("state")
 
 
-class TestWritePlanFile:
-    """Tests for plan file lifecycle."""
+def _action(app_id: str = "a") -> dict[str, Any]:
+    return {
+        "type": "enter_ring",
+        "app_id": app_id,
+        "name": f"App {app_id}",
+        "version": "1.0",
+        "sha256": "x",
+        "ring": "pilot",
+        "groups": ["g"],
+    }
+
+
+class TestWritePlanFiles:
+    """Tests for per-app plan file lifecycle."""
 
     def test_writes_deterministic_plan(self, tmp_path):
         """Tests that identical actions produce byte-identical plan files."""
-        plan_path = plan_path_for(tmp_path / "state")
-        actions = [
-            {
-                "type": "enter_ring",
-                "app_id": "a",
-                "version": "1.0",
-                "sha256": "x",
-                "ring": "pilot",
-                "groups": ["g"],
-            }
+        state_dir = tmp_path / "state"
+        actions = [_action()]
+
+        assert write_plan_files(actions, state_dir, ["a"]) == [
+            plan_path_for(state_dir, "a")
+        ]
+        first = plan_path_for(state_dir, "a").read_bytes()
+        assert write_plan_files(actions, state_dir, ["a"]) == [
+            plan_path_for(state_dir, "a")
         ]
 
-        assert write_plan_file(actions, plan_path) is True
-        first = plan_path.read_bytes()
-        assert write_plan_file(actions, plan_path) is True
-
-        assert plan_path.read_bytes() == first
+        assert plan_path_for(state_dir, "a").read_bytes() == first
         assert json.loads(first.decode("utf-8")) == {
             "actions": actions,
+            "app_id": "a",
             "schemaVersion": 1,
         }
 
+    def test_splits_actions_per_app(self, tmp_path):
+        """Tests that each app's actions land in that app's plan file."""
+        state_dir = tmp_path / "state"
+        actions = [_action("a"), _action("b"), _action("a")]
+
+        written = write_plan_files(actions, state_dir, ["a", "b"])
+
+        assert written == [
+            plan_path_for(state_dir, "a"),
+            plan_path_for(state_dir, "b"),
+        ]
+        plan_a = json.loads(written[0].read_text(encoding="utf-8"))
+        plan_b = json.loads(written[1].read_text(encoding="utf-8"))
+        assert len(plan_a["actions"]) == 2
+        assert len(plan_b["actions"]) == 1
+        assert all(a["app_id"] == "a" for a in plan_a["actions"])
+
     def test_no_actions_removes_stale_plan(self, tmp_path):
-        """Tests that an empty plan removes an existing plan file."""
-        plan_path = plan_path_for(tmp_path / "state")
-        plan_path.parent.mkdir(parents=True)
-        plan_path.write_text('{"actions": []}', encoding="utf-8")
+        """Tests that an app with no work has its stale plan file removed."""
+        state_dir = tmp_path / "state"
+        write_plan_files([_action("a")], state_dir, ["a"])
 
-        assert write_plan_file([], plan_path) is False
+        assert write_plan_files([], state_dir, ["a"]) == []
 
-        assert not plan_path.exists()
+        assert not plan_path_for(state_dir, "a").exists()
+
+    def test_stale_removal_scoped_to_run(self, tmp_path):
+        """Tests that apps outside the run keep their plan files."""
+        state_dir = tmp_path / "state"
+        write_plan_files([_action("a"), _action("b")], state_dir, ["a", "b"])
+
+        # A single-recipe run covering only "a" with no work for it.
+        assert write_plan_files([], state_dir, ["a"]) == []
+
+        assert not plan_path_for(state_dir, "a").exists()
+        assert plan_path_for(state_dir, "b").exists()
 
     def test_no_actions_no_file_is_noop(self, tmp_path):
-        """Tests that an empty plan with no existing file writes nothing."""
-        plan_path = plan_path_for(tmp_path / "state")
+        """Tests that an empty plan with no existing files writes nothing."""
+        state_dir = tmp_path / "state"
 
-        assert write_plan_file([], plan_path) is False
+        assert write_plan_files([], state_dir, ["a"]) == []
 
-        assert not plan_path.exists()
+        assert not plan_path_for(state_dir, "a").exists()

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -424,8 +424,7 @@ class TestApplyRingActions:
         mocks["assign_app"].assert_not_called()
 
     def test_failure_keeps_plan_file(self, tmp_path):
-        """Tests that a Graph failure records the app as failed and
-        leaves its plan file for retry."""
+        """Tests that a Graph failure fails the app and keeps its plan file."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed())
         plan_path = _write_plan(tmp_path, [_enter_ring_action()])
@@ -563,8 +562,7 @@ class TestApplyOrchestration:
         assert state["rings"]["pilot"]["sha256"] == "b" * 64
 
     def test_preflight_fails_app_with_zero_mutations(self, tmp_path):
-        """Tests that an unresolvable group anywhere in an app's plan
-        fails that app before any of its actions mutate the tenant."""
+        """Tests that an unresolvable group fails the app with zero mutations."""
         from napt.exceptions import ConfigError
 
         _write_recipe(tmp_path, rings=_RINGS)
@@ -649,8 +647,7 @@ class TestApplyOrchestration:
         ]
 
     def test_failed_app_does_not_block_others(self, tmp_path):
-        """Tests that one app's preflight failure keeps its plan file
-        while the other app's plan still applies and is consumed."""
+        """Tests that one app's preflight failure does not block another app."""
         from napt.exceptions import ConfigError
 
         _write_recipe(tmp_path, app_id="app-bad", rings=_RINGS)
@@ -690,8 +687,7 @@ class TestApplyOrchestration:
         assert state["rings"]["pilot"]["sha256"] == "b" * 64
 
     def test_graph_failure_isolated_to_one_app(self, tmp_path):
-        """Tests that a Graph failure applying one app keeps its plan
-        file while the remaining apps still apply."""
+        """Tests that a Graph failure applying one app spares the others."""
         _write_recipe(tmp_path, app_id="app-bad", rings=_RINGS)
         _write_recipe(tmp_path, app_id="app-good", rings=_RINGS)
         _write_state(tmp_path, app_id="app-bad", deployed=_deployed())
@@ -753,6 +749,42 @@ class TestLoadPlanFile:
         plan_path.write_text('{"other": []}', encoding="utf-8")
 
         with pytest.raises(StateError, match="Corrupted plan file"):
+            load_plan_file(plan_path)
+
+    def test_mixed_app_plan_raises(self, tmp_path):
+        """Tests that a plan file mixing apps is rejected."""
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "actions": [
+                        _enter_ring_action(),
+                        {**_enter_ring_action(), "app_id": "other-app"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(StateError, match="per-app"):
+            load_plan_file(plan_path)
+
+    def test_declared_app_id_mismatch_raises(self, tmp_path):
+        """Tests that actions disagreeing with the declared app are rejected."""
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "app_id": "other-app",
+                    "actions": [_enter_ring_action()],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(StateError, match="per-app"):
             load_plan_file(plan_path)
 
     def test_unsupported_plan_schema_version_raises(self, tmp_path):

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -221,10 +221,15 @@ def _run_apply(
 
 
 def _write_plan(tmp_path: Path, actions: list[dict[str, Any]]) -> Path:
-    plan_path = plan_path_for(tmp_path / "state")
+    app_id = actions[0]["app_id"]
+    plan_path = plan_path_for(tmp_path / "state", app_id)
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     plan_path.write_text(
-        json.dumps({"schemaVersion": 1, "actions": actions}, indent=2, sort_keys=True),
+        json.dumps(
+            {"schemaVersion": 1, "app_id": app_id, "actions": actions},
+            indent=2,
+            sort_keys=True,
+        ),
         encoding="utf-8",
     )
     return plan_path
@@ -419,19 +424,21 @@ class TestApplyRingActions:
         mocks["assign_app"].assert_not_called()
 
     def test_failure_keeps_plan_file(self, tmp_path):
-        """Tests that a Graph failure leaves the plan file for retry."""
+        """Tests that a Graph failure records the app as failed and
+        leaves its plan file for retry."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed())
         plan_path = _write_plan(tmp_path, [_enter_ring_action()])
 
-        with pytest.raises(NetworkError):
-            _run_apply(
-                tmp_path,
-                existing_apps=_tenant(),
-                assign_side_effect=NetworkError("Graph down"),
-            )
+        summary, _ = _run_apply(
+            tmp_path,
+            existing_apps=_tenant(),
+            assign_side_effect=NetworkError("Graph down"),
+        )
 
         assert plan_path.exists()
+        assert [f["app_id"] for f in summary["failed"]] == ["test-app"]
+        assert "Graph down" in summary["failed"][0]["error"]
 
 
 class TestApplyInstallActions:
@@ -523,6 +530,7 @@ class TestApplyOrchestration:
         assert summary == {
             "applied": [],
             "skipped": [],
+            "failed": [],
             "drift": [],
             "recovered": [],
         }
@@ -554,9 +562,9 @@ class TestApplyOrchestration:
         assert state["deployed"]["intune_app_id"] == "install-new"
         assert state["rings"]["pilot"]["sha256"] == "b" * 64
 
-    def test_preflight_aborts_with_zero_mutations(self, tmp_path):
-        """Tests that an unresolvable group anywhere in the plan aborts
-        before any action mutates the tenant."""
+    def test_preflight_fails_app_with_zero_mutations(self, tmp_path):
+        """Tests that an unresolvable group anywhere in an app's plan
+        fails that app before any of its actions mutate the tenant."""
         from napt.exceptions import ConfigError
 
         _write_recipe(tmp_path, rings=_RINGS)
@@ -584,13 +592,16 @@ class TestApplyOrchestration:
                 )
             return _fake_resolve_target(token, group, cache)
 
-        with pytest.raises(ConfigError, match="nothing was applied"):
-            _run_apply(
-                tmp_path,
-                existing_apps=_tenant(),
-                resolve_side_effect=_resolve,
-            )
+        summary, mocks = _run_apply(
+            tmp_path,
+            existing_apps=_tenant(),
+            resolve_side_effect=_resolve,
+        )
 
+        assert summary["applied"] == []
+        assert [f["app_id"] for f in summary["failed"]] == ["test-app"]
+        assert "missing-group" in summary["failed"][0]["error"]
+        mocks["assign_app"].assert_not_called()
         state = load_deployment_state(state_path)
         assert state["rings"] == {}  # the resolvable action did not apply
         assert plan_path.exists()  # plan not consumed
@@ -636,6 +647,80 @@ class TestApplyOrchestration:
         assert [s["reason"] for s in summary["skipped"]] == [
             "stale action - the deployed release has changed"
         ]
+
+    def test_failed_app_does_not_block_others(self, tmp_path):
+        """Tests that one app's preflight failure keeps its plan file
+        while the other app's plan still applies and is consumed."""
+        from napt.exceptions import ConfigError
+
+        _write_recipe(tmp_path, app_id="app-bad", rings=_RINGS)
+        _write_recipe(tmp_path, app_id="app-good", rings=_RINGS)
+        _write_state(tmp_path, app_id="app-bad", deployed=_deployed())
+        good_state = _write_state(tmp_path, app_id="app-good", deployed=_deployed())
+        bad_action = _enter_ring_action()
+        bad_action["app_id"] = "app-bad"
+        bad_action["groups"] = ["missing-group"]
+        good_action = _enter_ring_action()
+        good_action["app_id"] = "app-good"
+        bad_plan = _write_plan(tmp_path, [bad_action])
+        good_plan = _write_plan(tmp_path, [good_action])
+        tenant = [
+            _stamped("app-bad", "update", "b" * 64, "update-bad"),
+            _stamped("app-good", "update", "b" * 64, "update-good"),
+        ]
+
+        def _resolve(token, group, cache=None):
+            if group == "missing-group":
+                raise ConfigError(
+                    f"No Entra ID group found with displayName '{group}'."
+                )
+            return _fake_resolve_target(token, group, cache)
+
+        summary, _ = _run_apply(
+            tmp_path,
+            existing_apps=tenant,
+            resolve_side_effect=_resolve,
+        )
+
+        assert [a["app_id"] for a in summary["applied"]] == ["app-good"]
+        assert [f["app_id"] for f in summary["failed"]] == ["app-bad"]
+        assert bad_plan.exists()
+        assert not good_plan.exists()
+        state = load_deployment_state(good_state)
+        assert state["rings"]["pilot"]["sha256"] == "b" * 64
+
+    def test_graph_failure_isolated_to_one_app(self, tmp_path):
+        """Tests that a Graph failure applying one app keeps its plan
+        file while the remaining apps still apply."""
+        _write_recipe(tmp_path, app_id="app-bad", rings=_RINGS)
+        _write_recipe(tmp_path, app_id="app-good", rings=_RINGS)
+        _write_state(tmp_path, app_id="app-bad", deployed=_deployed())
+        _write_state(tmp_path, app_id="app-good", deployed=_deployed())
+        bad_action = _enter_ring_action()
+        bad_action["app_id"] = "app-bad"
+        good_action = _enter_ring_action()
+        good_action["app_id"] = "app-good"
+        bad_plan = _write_plan(tmp_path, [bad_action])
+        good_plan = _write_plan(tmp_path, [good_action])
+        tenant = [
+            _stamped("app-bad", "update", "b" * 64, "update-bad"),
+            _stamped("app-good", "update", "b" * 64, "update-good"),
+        ]
+
+        def _assign(token, app_id, assignments):
+            if app_id == "update-bad":
+                raise NetworkError("Graph down")
+
+        summary, _ = _run_apply(
+            tmp_path,
+            existing_apps=tenant,
+            assign_side_effect=_assign,
+        )
+
+        assert [a["app_id"] for a in summary["applied"]] == ["app-good"]
+        assert [f["app_id"] for f in summary["failed"]] == ["app-bad"]
+        assert bad_plan.exists()
+        assert not good_plan.exists()
 
     def test_unknown_app_in_plan_skipped(self, tmp_path):
         """Tests that a plan action without a matching recipe is skipped."""


### PR DESCRIPTION
## Description
`napt promote plan` now writes one plan file per app (`state/plans/<app-id>.json`) instead of a single batched `state/plan.json`, and `napt promote apply` executes each file as an independent unit. Plan actions carry reviewer context: the app''s display name on every action, plus when the release entered the ring it is leaving and that ring''s bake threshold on advancement actions.

## Motivation
The batched plan file was the last shared file in the system and it coupled unrelated apps: one app''s bad group or Graph error aborted every other app''s promotion, and holding a single promotion meant hand-editing action entries inside a shared JSON diff. Per-app files match the per-app deployment state design, make "hold one app" a two-click file deletion in the promotion PR, isolate failures to the app that caused them, and fix a latent bug where planning a single recipe clobbered the fleet''s plan. The informational fields let the plan diff itself answer a reviewer''s questions (which app, why eligible now) without opening deployment state.

## Changes
- **BREAKING:** `promote plan` writes `state/plans/<app-id>.json` per app with work; an app''s stale file is removed when nothing is eligible for it, scoped to the run''s recipes
- **BREAKING:** `promote apply` consumes each plan file independently: per-app group preflight, failures recorded in a new `failed` summary list with the plan file kept for retry, file consumed only after its app fully applies; exit 1 when any app failed (after the others apply)
- Plan actions gain `name`, and advancement actions gain `from_ring_entered_at` and `promote_after_days` — run-stable values only, so plans stay byte-deterministic
- `load_plan_file` rejects files mixing apps or disagreeing with their declared `app_id`
- Reference promote workflows: apply triggers on `state/plans/**`, and the apply step is `continue-on-error` with writeback-then-fail so successful apps'' progress reaches `main` even when one app fails
- Docs: promote sections in user-guide and common-tasks, GitOps model description, failed-apply resolution playbook, roadmap design bullet, changelog

## Testing
How was this tested?
- [x] Unit tests added/updated
    - Per-app writer lifecycle (split, deterministic output, stale removal scoped to the run), two apply isolation tests (preflight failure and Graph failure each spare the other app), mixed-app plan rejection, CLI failed-exit path — 713 passing
- [ ] Integration tests added/updated
- [x] Manual testing performed
    - Scratch-project smoke: two recipes, `promote plan` produced two per-app files with the reviewer-context fields, byte-identical on re-run; `mkdocs build --strict` passes; pyright and ruff clean
    - Live GitOps validation in napt-gitops-test planned immediately after merge

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors