### PR TITLE
feat: Retry transient Graph API failures

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -279,6 +279,14 @@ Examples:
 - `"Downloading PSADT 4.1.7..."` → `info` (network action the user should see)
 - `"Copying file: PSAppDeployToolkit/"` → `verbose` (internal file operation)
 
+**Prefixes:** The prefix names the pipeline stage the message belongs to
+(`DISCOVERY`, `BUILD`, `PACKAGE`, `UPLOAD`, `PROMOTE`, `INIT`). Shared
+infrastructure modules log under their domain instead — `HTTP` for
+transport (requests, retries), `FILE`, `CACHE`, `CONFIG`, `STATE`,
+`DETECTION` — so the same module reads consistently regardless of which
+stage called it. Don't invent a new prefix when a message fits an
+existing one.
+
 ---
 
 ## Console Output

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Migration: none needed for state — plans are transient. Update
         promotion workflows to watch `state/plans/**` instead of
         `state/plan.json` (see the reference workflows in Common Tasks)
+- **Graph API calls retry transient failures** - Throttling (HTTP 429,
+    honoring Retry-After) and transient server or connection errors now
+    retry with bounded exponential backoff across upload, promotion, and
+    drift operations, so a momentary Graph hiccup no longer fails a
+    publish or marks an app's promotion as failed
 
 ## [0.8.0] - 2026-07-12
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,11 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Migration: none needed for state — plans are transient. Update
         promotion workflows to watch `state/plans/**` instead of
         `state/plan.json` (see the reference workflows in Common Tasks)
-- **Graph API calls retry transient failures** - Throttling (HTTP 429,
-    honoring Retry-After) and transient server or connection errors now
-    retry with bounded exponential backoff across upload, promotion, and
-    drift operations, so a momentary Graph hiccup no longer fails a
-    publish or marks an app's promotion as failed
+- **Graph API calls retry transient failures** - Throttling (HTTP
+    429/503/509, honoring Retry-After) and transient server or
+    connection errors now retry with bounded exponential backoff across
+    upload, promotion, and drift operations, so a momentary Graph hiccup
+    no longer fails a publish or marks an app's promotion as failed
+    - Resource-creating calls retry only unambiguous throttling
+        responses, so a reply lost after a processed create can never
+        duplicate an Intune app; re-running converges via upload's
+        stamp adoption
+    - Every Graph request carries a `client-request-id` for Microsoft
+        support correlation
 
 ## [0.8.0] - 2026-07-12
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         stamp adoption
     - Every Graph request carries a `client-request-id` for Microsoft
         support correlation
+    - All remaining HTTP calls — GitHub release lookups (PSADT,
+        IntuneWinAppUtil, `api_github` discovery), vendor page and API
+        fetches (`web_scrape`, `api_json`), and tool downloads — now
+        share the installer download layer's retrying session instead
+        of being single-shot
 
 ## [0.8.0] - 2026-07-12
 

--- a/napt/build/packager.py
+++ b/napt/build/packager.py
@@ -46,6 +46,7 @@ import subprocess
 
 import requests
 
+from napt.download import make_session
 from napt.exceptions import ConfigError, NetworkError, PackagingError
 from napt.results import PackageResult
 
@@ -96,7 +97,8 @@ def fetch_latest_intunewin_version() -> str:
         headers["Authorization"] = f"Bearer {token}"
 
     try:
-        response = requests.get(INTUNEWIN_GITHUB_API, headers=headers, timeout=30)
+        with make_session() as session:
+            response = session.get(INTUNEWIN_GITHUB_API, headers=headers, timeout=30)
         response.raise_for_status()
         data = response.json()
     except requests.RequestException as err:
@@ -182,19 +184,20 @@ def _get_intunewin_tool(cache_dir: Path, release: str) -> Path:
     # The repo uses inconsistent tag formats (e.g. "v1.8.6" and "1.8.3"),
     # so try both and use whichever resolves.
     response = None
-    for tag in [f"v{version}", version]:
-        url = INTUNEWIN_DOWNLOAD_URL.format(tag=tag)
-        try:
-            r = requests.get(url, timeout=60)
-            if r.status_code == 404:
-                continue
-            r.raise_for_status()
-            response = r
-            break
-        except requests.RequestException as err:
-            raise NetworkError(
-                f"Failed to download IntuneWinAppUtil.exe {version}: {err}"
-            ) from err
+    with make_session() as session:
+        for tag in [f"v{version}", version]:
+            url = INTUNEWIN_DOWNLOAD_URL.format(tag=tag)
+            try:
+                r = session.get(url, timeout=60)
+                if r.status_code == 404:
+                    continue
+                r.raise_for_status()
+                response = r
+                break
+            except requests.RequestException as err:
+                raise NetworkError(
+                    f"Failed to download IntuneWinAppUtil.exe {version}: {err}"
+                ) from err
 
     if response is None:
         raise NetworkError(

--- a/napt/discovery/api_github.py
+++ b/napt/discovery/api_github.py
@@ -61,6 +61,7 @@ from typing import Any
 import requests
 
 from napt.discovery.base import RemoteVersion
+from napt.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy
@@ -158,7 +159,8 @@ class ApiGithubStrategy:
         logger.verbose("DISCOVERY", f"Fetching release from: {api_url}")
 
         try:
-            response = requests.get(api_url, headers=headers, timeout=30)
+            with make_session() as session:
+                response = session.get(api_url, headers=headers, timeout=30)
         except requests.exceptions.RequestException as err:
             raise NetworkError(f"Failed to fetch GitHub release: {err}") from err
 

--- a/napt/discovery/api_json.py
+++ b/napt/discovery/api_json.py
@@ -76,6 +76,7 @@ from jsonpath_ng import parse as jsonpath_parse
 import requests
 
 from napt.discovery.base import RemoteVersion
+from napt.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy
@@ -173,13 +174,16 @@ class ApiJsonStrategy:
         # Make API request
         logger.verbose("DISCOVERY", f"Calling API: {method} {api_url}")
         try:
-            response = requests.request(
-                method,
-                api_url,
-                headers=expanded_headers,
-                json=body if method == "POST" else None,
-                timeout=timeout,
-            )
+            # GETs retry transient failures through the shared session;
+            # POSTs are sent once (a vendor API's idempotency is unknown).
+            with make_session() as session:
+                response = session.request(
+                    method,
+                    api_url,
+                    headers=expanded_headers,
+                    json=body if method == "POST" else None,
+                    timeout=timeout,
+                )
         except requests.exceptions.RequestException as err:
             raise NetworkError(f"Failed to call API: {err}") from err
 

--- a/napt/discovery/web_scrape.py
+++ b/napt/discovery/web_scrape.py
@@ -79,6 +79,7 @@ from bs4 import BeautifulSoup
 import requests
 
 from napt.discovery.base import RemoteVersion
+from napt.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy
@@ -153,7 +154,8 @@ class WebScrapeStrategy:
         # Download the HTML page
         logger.verbose("DISCOVERY", f"Fetching page: {page_url}")
         try:
-            response = requests.get(page_url, timeout=30)
+            with make_session() as session:
+                response = session.get(page_url, timeout=30)
         except requests.exceptions.RequestException as err:
             raise NetworkError(f"Failed to fetch page: {err}") from err
 

--- a/napt/download/__init__.py
+++ b/napt/download/__init__.py
@@ -34,6 +34,6 @@ Example:
 
 from napt.exceptions import NotModifiedError
 
-from .download import download_file
+from .download import download_file, make_session
 
-__all__ = ["download_file", "NotModifiedError"]
+__all__ = ["download_file", "make_session", "NotModifiedError"]

--- a/napt/download/download.py
+++ b/napt/download/download.py
@@ -148,11 +148,15 @@ def _filename_from_url(url: str) -> str:
     return name or "download.bin"
 
 
-def _make_session() -> requests.Session:
-    """Create a requests.Session with retry/backoff defaults.
+def make_session() -> requests.Session:
+    """Creates a requests.Session with retry/backoff defaults.
 
-    Retries on common transient status codes, applies exponential backoff,
-    and sets a User-Agent header identifying NAPT.
+    Retries on common transient status codes (429, 500, 502, 503, 504 —
+    honoring Retry-After) and connection failures, applies exponential
+    backoff, and sets a User-Agent header identifying NAPT. Retries only
+    GET and HEAD; other methods are sent once. The shared transport
+    layer for every NAPT HTTP call outside Microsoft Graph (which has
+    its own retry tuned to Graph's error contract).
 
     Note:
         Forces Accept-Encoding: identity to request raw (uncompressed) bytes.
@@ -247,7 +251,7 @@ def download_file(
     logger.verbose("HTTP", f"GET {url}")
 
     started_at = time.time()
-    with _make_session() as session:
+    with make_session() as session:
         # Stream response so we can hash while writing.
         resp = session.get(
             url, stream=True, allow_redirects=True, timeout=timeout, headers=headers

--- a/napt/psadt/release.py
+++ b/napt/psadt/release.py
@@ -58,6 +58,7 @@ import zipfile
 
 import requests
 
+from napt.download import make_session
 from napt.exceptions import NetworkError, PackagingError
 
 PSADT_REPO = "PSAppDeployToolkit/PSAppDeployToolkit"
@@ -101,7 +102,8 @@ def fetch_latest_psadt_version() -> str:
             "X-GitHub-Api-Version": "2022-11-28",
         }
 
-        response = requests.get(PSADT_GITHUB_API, headers=headers, timeout=30)
+        with make_session() as session:
+            response = session.get(PSADT_GITHUB_API, headers=headers, timeout=30)
         response.raise_for_status()
     except requests.RequestException as err:
         raise NetworkError(
@@ -229,7 +231,8 @@ def get_psadt_release(release_spec: str, cache_dir: Path) -> Path:
             "X-GitHub-Api-Version": "2022-11-28",
         }
 
-        response = requests.get(release_url, headers=headers, timeout=30)
+        with make_session() as session:
+            response = session.get(release_url, headers=headers, timeout=30)
         response.raise_for_status()
     except requests.RequestException as err:
         raise NetworkError(
@@ -271,7 +274,8 @@ def get_psadt_release(release_spec: str, cache_dir: Path) -> Path:
 
     # Download the .zip file
     try:
-        zip_response = requests.get(download_url, timeout=300)
+        with make_session() as session:
+            zip_response = session.get(download_url, timeout=300)
         zip_response.raise_for_status()
     except requests.RequestException as err:
         raise NetworkError(f"Failed to download PSADT release: {err}") from err

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -31,6 +31,11 @@ assign_app) used by deployment promotion.
 All functions take an access_token as the first argument. Obtain one via
 napt.upload.auth.get_access_token().
 
+Graph calls retry transient failures — HTTP 429 (honoring Retry-After),
+transient server errors, and connection drops — with bounded exponential
+backoff before raising. Azure Blob PUTs carry their own retry tuned for
+SAS-propagation 403s.
+
 Example:
     Full upload flow:
         ```python
@@ -153,6 +158,117 @@ def _check_response(response: requests.Response, context: str) -> dict:
     return response.json()
 
 
+# Microsoft Graph throttles the Intune endpoints (HTTP 429 with a
+# Retry-After header, per app per tenant) and sheds load with transient
+# server errors. Every Graph call NAPT makes is idempotent — reads,
+# full-set assignment writes, PATCHes and DELETEs by id — so transient
+# failures retry with backoff instead of surfacing immediately.
+_GRAPH_RETRY_STATUS = (429, 500, 502, 503, 504)
+_GRAPH_RETRY_ATTEMPTS = 5
+_GRAPH_RETRY_INITIAL_DELAY = 2.0
+# Ceiling for a wait taken from Retry-After; anything longer is served
+# by the normal failure path rather than a stalled run.
+_GRAPH_RETRY_MAX_WAIT = 300.0
+
+
+def _retry_wait(response: requests.Response | None, fallback: float) -> float:
+    """Returns the wait before the next retry attempt.
+
+    Honors a numeric ``Retry-After`` header when the response carries one
+    (Graph throttling responses do), capped at a ceiling; otherwise the
+    exponential-backoff fallback applies.
+
+    Args:
+        response: The throttled or failed response, or None for a
+            connection-level failure.
+        fallback: Current exponential backoff delay in seconds.
+
+    Returns:
+        Seconds to wait before the next attempt.
+
+    """
+    if response is not None:
+        retry_after = response.headers.get("Retry-After", "")
+        if retry_after.strip().isdigit():
+            return min(float(retry_after), _GRAPH_RETRY_MAX_WAIT)
+    return fallback
+
+
+def _graph_request(
+    method: str,
+    url: str,
+    context: str,
+    headers: dict[str, str],
+    json: dict | None = None,
+    ok_statuses: tuple[int, ...] = (),
+) -> dict:
+    """Issues a Graph API request, retrying transient failures.
+
+    HTTP 429 (honoring ``Retry-After``) and transient server errors
+    retry with exponential backoff, as do connection-level failures.
+    Every other response goes straight to
+    [_check_response][napt.upload.graph._check_response], so
+    permission and validation errors surface immediately. The last
+    attempt's failure is raised with full response detail.
+
+    Args:
+        method: HTTP method name.
+        url: Full request URL.
+        context: Short description of the operation for error messages.
+        headers: Request headers, including authorization.
+        json: Optional JSON body.
+        ok_statuses: Statuses to treat as success with an empty body
+            (e.g. 404 for an idempotent delete).
+
+    Returns:
+        Parsed JSON body as a dict, or empty dict for empty responses
+            and ``ok_statuses`` matches.
+
+    Raises:
+        AuthError: On 401 or 403.
+        ConfigError: On 400.
+        NetworkError: On any other non-2xx status once retries are
+            exhausted, or on a connection failure that outlasts them.
+
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    delay = _GRAPH_RETRY_INITIAL_DELAY
+    for attempt in range(1, _GRAPH_RETRY_ATTEMPTS + 1):
+        err: Exception | None = None
+        resp: requests.Response | None = None
+        try:
+            resp = requests.request(method, url, headers=headers, json=json, timeout=30)
+        except requests.RequestException as exc:
+            err = exc
+            detail = str(exc)
+        else:
+            if resp.status_code in ok_statuses:
+                return {}
+            if resp.status_code not in _GRAPH_RETRY_STATUS:
+                return _check_response(resp, context)
+            detail = f"HTTP {resp.status_code}"
+
+        if attempt == _GRAPH_RETRY_ATTEMPTS:
+            if resp is not None:
+                return _check_response(resp, context)
+            raise NetworkError(
+                f"{context} after {_GRAPH_RETRY_ATTEMPTS} attempts: {detail}"
+            ) from err
+
+        wait = _retry_wait(resp, delay)
+        logger.warning(
+            "GRAPH",
+            f"{context}: transient failure ({detail}); retrying in "
+            f"{wait:.0f}s (attempt {attempt}/{_GRAPH_RETRY_ATTEMPTS})",
+        )
+        time.sleep(wait)
+        delay *= 2
+
+    raise NetworkError(f"{context}: retry attempts exhausted")  # pragma: no cover
+
+
 def _poll(
     access_token: str,
     poll_url: str,
@@ -177,8 +293,9 @@ def _poll(
     """
     deadline = time.monotonic() + POLL_MAX_SECONDS
     while time.monotonic() < deadline:
-        resp = requests.get(poll_url, headers=_auth_headers(access_token), timeout=30)
-        data = _check_response(resp, context)
+        data = _graph_request(
+            "GET", poll_url, context, headers=_auth_headers(access_token)
+        )
         state: str = data.get("uploadState", "")
         if state == success_state:
             return data
@@ -227,8 +344,9 @@ def resolve_group_id(access_token: str, group: str) -> str:
         f"{GRAPH_BASE}/groups"
         f"?$filter=displayName eq '{escaped}'&$select=id,displayName"
     )
-    resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
-    body = _check_response(resp, "resolve_group_id")
+    body = _graph_request(
+        "GET", url, "resolve_group_id", headers=_auth_headers(access_token)
+    )
     matches: list[dict] = body.get("value", [])
 
     if not matches:
@@ -299,8 +417,9 @@ def get_app_assignments(access_token: str, app_id: str) -> list[dict]:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}/assignments"
-    resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
-    body = _check_response(resp, "get_app_assignments")
+    body = _graph_request(
+        "GET", url, "get_app_assignments", headers=_auth_headers(access_token)
+    )
     return body.get("value", [])
 
 
@@ -371,10 +490,9 @@ def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}/assign"
     body = {"mobileAppAssignments": assignments}
-    resp = requests.post(
-        url, headers=_json_headers(access_token), json=body, timeout=30
+    _graph_request(
+        "POST", url, "assign_app", headers=_json_headers(access_token), json=body
     )
-    _check_response(resp, "assign_app")
 
 
 def list_mobile_apps(access_token: str) -> list[dict]:
@@ -399,8 +517,9 @@ def list_mobile_apps(access_token: str) -> list[dict]:
     )
     apps: list[dict] = []
     while url:
-        resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
-        body = _check_response(resp, "list_mobile_apps")
+        body = _graph_request(
+            "GET", url, "list_mobile_apps", headers=_auth_headers(access_token)
+        )
         apps.extend(body.get("value", []))
         url = body.get("@odata.nextLink")
     return apps
@@ -422,10 +541,13 @@ def delete_mobile_app(access_token: str, app_id: str) -> None:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
-    resp = requests.delete(url, headers=_auth_headers(access_token), timeout=30)
-    if resp.status_code == 404:
-        return
-    _check_response(resp, "delete_mobile_app")
+    _graph_request(
+        "DELETE",
+        url,
+        "delete_mobile_app",
+        headers=_auth_headers(access_token),
+        ok_statuses=(404,),
+    )
 
 
 def get_mobile_app(access_token: str, app_id: str) -> dict:
@@ -447,8 +569,9 @@ def get_mobile_app(access_token: str, app_id: str) -> dict:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
-    resp = requests.get(url, headers=_auth_headers(access_token), timeout=30)
-    return _check_response(resp, "get_mobile_app")
+    return _graph_request(
+        "GET", url, "get_mobile_app", headers=_auth_headers(access_token)
+    )
 
 
 def create_win32_app(access_token: str, app_metadata: dict) -> str:
@@ -469,10 +592,13 @@ def create_win32_app(access_token: str, app_metadata: dict) -> str:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps"
-    resp = requests.post(
-        url, headers=_json_headers(access_token), json=app_metadata, timeout=30
+    body = _graph_request(
+        "POST",
+        url,
+        "create_win32_app",
+        headers=_json_headers(access_token),
+        json=app_metadata,
     )
-    body = _check_response(resp, "create_win32_app")
     return body["id"]
 
 
@@ -491,10 +617,13 @@ def update_win32_app(access_token: str, app_id: str, app_metadata: dict) -> None
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
-    resp = requests.patch(
-        url, headers=_json_headers(access_token), json=app_metadata, timeout=30
+    _graph_request(
+        "PATCH",
+        url,
+        "update_win32_app",
+        headers=_json_headers(access_token),
+        json=app_metadata,
     )
-    _check_response(resp, "update_win32_app")
 
 
 def create_content_version(access_token: str, app_id: str) -> str:
@@ -516,8 +645,9 @@ def create_content_version(access_token: str, app_id: str) -> str:
         f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
         f"/microsoft.graph.win32LobApp/contentVersions"
     )
-    resp = requests.post(url, headers=_json_headers(access_token), json={}, timeout=30)
-    body = _check_response(resp, "create_content_version")
+    body = _graph_request(
+        "POST", url, "create_content_version", headers=_json_headers(access_token), json={}
+    )
     return body["id"]
 
 
@@ -559,10 +689,13 @@ def create_content_version_file(
         "manifest": None,
         "isDependency": False,
     }
-    resp = requests.post(
-        base_url, headers=_json_headers(access_token), json=body, timeout=30
+    file_body = _graph_request(
+        "POST",
+        base_url,
+        "create_content_version_file",
+        headers=_json_headers(access_token),
+        json=body,
     )
-    file_body = _check_response(resp, "create_content_version_file")
     file_id: str = file_body["id"]
 
     poll_url = f"{base_url}/{file_id}"
@@ -768,11 +901,13 @@ def commit_content_version_file(
             "fileDigestAlgorithm": metadata.file_digest_algorithm,
         }
     }
-    resp = requests.post(
-        commit_url, headers=_json_headers(access_token), json=body, timeout=30
+    _graph_request(
+        "POST",
+        commit_url,
+        "commit_content_version_file",
+        headers=_json_headers(access_token),
+        json=body,
     )
-    # Graph API returns 200 for this call
-    _check_response(resp, "commit_content_version_file")
 
     poll_url = (
         f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
@@ -807,7 +942,10 @@ def commit_content_version(access_token: str, app_id: str, cv_id: str) -> None:
         "@odata.type": WIN32_LOB_APP_TYPE,
         "committedContentVersion": cv_id,
     }
-    resp = requests.patch(
-        url, headers=_json_headers(access_token), json=body, timeout=30
+    _graph_request(
+        "PATCH",
+        url,
+        "commit_content_version",
+        headers=_json_headers(access_token),
+        json=body,
     )
-    _check_response(resp, "commit_content_version")

--- a/napt/upload/graph.py
+++ b/napt/upload/graph.py
@@ -33,8 +33,10 @@ napt.upload.auth.get_access_token().
 
 Graph calls retry transient failures — HTTP 429 (honoring Retry-After),
 transient server errors, and connection drops — with bounded exponential
-backoff before raising. Azure Blob PUTs carry their own retry tuned for
-SAS-propagation 403s.
+backoff before raising. Resource-creating POSTs retry only unambiguous
+throttling responses, so a lost reply to a processed create is never
+resubmitted as a duplicate. Azure Blob PUTs carry their own retry tuned
+for SAS-propagation 403s.
 
 Example:
     Full upload flow:
@@ -66,6 +68,7 @@ import base64
 from pathlib import Path
 import re
 import time
+import uuid
 
 import requests
 
@@ -160,10 +163,17 @@ def _check_response(response: requests.Response, context: str) -> dict:
 
 # Microsoft Graph throttles the Intune endpoints (HTTP 429 with a
 # Retry-After header, per app per tenant) and sheds load with transient
-# server errors. Every Graph call NAPT makes is idempotent — reads,
-# full-set assignment writes, PATCHes and DELETEs by id — so transient
-# failures retry with backoff instead of surfacing immediately.
-_GRAPH_RETRY_STATUS = (429, 500, 502, 503, 504)
+# server errors. Most Graph calls NAPT makes are idempotent — reads,
+# full-set assignment writes, PATCHes and DELETEs by id — and retry the
+# full transient set. Resource-creating POSTs are not: a connection
+# drop or gateway error (500/502/504) can hide a create that actually
+# succeeded, and resubmitting would duplicate the resource, so they
+# retry only responses that guarantee the request was shed before
+# processing (429/503/509 per the Graph error contract). A surfaced
+# ambiguous failure converges on re-run through the upload flow's
+# provenance-stamp adoption.
+_GRAPH_RETRY_STATUS = (429, 500, 502, 503, 504, 509)
+_GRAPH_RETRY_STATUS_UNAMBIGUOUS = (429, 503, 509)
 _GRAPH_RETRY_ATTEMPTS = 5
 _GRAPH_RETRY_INITIAL_DELAY = 2.0
 # Ceiling for a wait taken from Retry-After; anything longer is served
@@ -201,15 +211,22 @@ def _graph_request(
     headers: dict[str, str],
     json: dict | None = None,
     ok_statuses: tuple[int, ...] = (),
+    idempotent: bool = True,
+    deadline: float | None = None,
 ) -> dict:
     """Issues a Graph API request, retrying transient failures.
 
     HTTP 429 (honoring ``Retry-After``) and transient server errors
     retry with exponential backoff, as do connection-level failures.
-    Every other response goes straight to
+    Non-idempotent calls (resource-creating POSTs) retry only statuses
+    that guarantee the request was shed before processing, and never
+    connection failures — a lost reply to a processed create must not
+    be resubmitted. Every other response goes straight to
     [_check_response][napt.upload.graph._check_response], so
     permission and validation errors surface immediately. The last
-    attempt's failure is raised with full response detail.
+    attempt's failure is raised with full response detail. Each request
+    carries a fresh ``client-request-id`` header for Microsoft support
+    correlation.
 
     Args:
         method: HTTP method name.
@@ -219,34 +236,50 @@ def _graph_request(
         json: Optional JSON body.
         ok_statuses: Statuses to treat as success with an empty body
             (e.g. 404 for an idempotent delete).
+        idempotent: Whether resubmitting this request is always safe.
+            False restricts retries to unambiguous throttling responses.
+        deadline: Optional ``time.monotonic()`` budget; a retry wait
+            that would run past it surfaces the failure instead.
 
     Returns:
         Parsed JSON body as a dict, or empty dict for empty responses
-            and ``ok_statuses`` matches.
+        and ``ok_statuses`` matches.
 
     Raises:
         AuthError: On 401 or 403.
         ConfigError: On 400.
         NetworkError: On any other non-2xx status once retries are
-            exhausted, or on a connection failure that outlasts them.
+            exhausted, or on a connection failure.
 
     """
     from napt.logging import get_global_logger
 
     logger = get_global_logger()
+    retry_statuses = (
+        _GRAPH_RETRY_STATUS if idempotent else _GRAPH_RETRY_STATUS_UNAMBIGUOUS
+    )
     delay = _GRAPH_RETRY_INITIAL_DELAY
     for attempt in range(1, _GRAPH_RETRY_ATTEMPTS + 1):
         err: Exception | None = None
         resp: requests.Response | None = None
+        request_headers = {**headers, "client-request-id": str(uuid.uuid4())}
         try:
-            resp = requests.request(method, url, headers=headers, json=json, timeout=30)
+            resp = requests.request(
+                method, url, headers=request_headers, json=json, timeout=30
+            )
         except requests.RequestException as exc:
+            if not idempotent:
+                # The request may have been processed before the
+                # connection died; resubmitting could duplicate the
+                # resource. Surface it — re-running converges through
+                # the flow-level stamp adoption.
+                raise NetworkError(f"{context}: {exc}") from exc
             err = exc
             detail = str(exc)
         else:
             if resp.status_code in ok_statuses:
                 return {}
-            if resp.status_code not in _GRAPH_RETRY_STATUS:
+            if resp.status_code not in retry_statuses:
                 return _check_response(resp, context)
             detail = f"HTTP {resp.status_code}"
 
@@ -258,8 +291,13 @@ def _graph_request(
             ) from err
 
         wait = _retry_wait(resp, delay)
+        if deadline is not None and time.monotonic() + wait >= deadline:
+            # No budget left for another attempt; surface this failure.
+            if resp is not None:
+                return _check_response(resp, context)
+            raise NetworkError(f"{context}: {detail}") from err
         logger.warning(
-            "GRAPH",
+            "HTTP",
             f"{context}: transient failure ({detail}); retrying in "
             f"{wait:.0f}s (attempt {attempt}/{_GRAPH_RETRY_ATTEMPTS})",
         )
@@ -288,13 +326,19 @@ def _poll(
 
     Raises:
         NetworkError: If the state transitions to an error state, or if the
-            poll times out after POLL_MAX_SECONDS.
+            poll times out after POLL_MAX_SECONDS. The deadline covers
+            transient-failure retry waits too, so throttling during the
+            poll cannot stretch it indefinitely.
 
     """
     deadline = time.monotonic() + POLL_MAX_SECONDS
     while time.monotonic() < deadline:
         data = _graph_request(
-            "GET", poll_url, context, headers=_auth_headers(access_token)
+            "GET",
+            poll_url,
+            context,
+            headers=_auth_headers(access_token),
+            deadline=deadline,
         )
         state: str = data.get("uploadState", "")
         if state == success_state:
@@ -598,6 +642,7 @@ def create_win32_app(access_token: str, app_metadata: dict) -> str:
         "create_win32_app",
         headers=_json_headers(access_token),
         json=app_metadata,
+        idempotent=False,
     )
     return body["id"]
 
@@ -646,7 +691,12 @@ def create_content_version(access_token: str, app_id: str) -> str:
         f"/microsoft.graph.win32LobApp/contentVersions"
     )
     body = _graph_request(
-        "POST", url, "create_content_version", headers=_json_headers(access_token), json={}
+        "POST",
+        url,
+        "create_content_version",
+        headers=_json_headers(access_token),
+        json={},
+        idempotent=False,
     )
     return body["id"]
 
@@ -695,6 +745,7 @@ def create_content_version_file(
         "create_content_version_file",
         headers=_json_headers(access_token),
         json=body,
+        idempotent=False,
     )
     file_id: str = file_body["id"]
 
@@ -764,7 +815,7 @@ def _blob_put_with_retry(
             ) from err
 
         logger.warning(
-            "UPLOAD",
+            "HTTP",
             f"{context} ({detail.splitlines()[0]}); "
             f"retrying in {delay:.0f}s (attempt {attempt}/{_BLOB_RETRY_ATTEMPTS})",
         )
@@ -883,6 +934,9 @@ def commit_content_version_file(
     Raises:
         AuthError: On 401 or 403.
         NetworkError: On 5xx, connection error, or if commit times out.
+
+    Note:
+        Graph returns 200 (not 201) for the commit POST.
 
     """
     commit_url = (

--- a/tests/upload/test_graph.py
+++ b/tests/upload/test_graph.py
@@ -75,11 +75,12 @@ def test_create_content_version_returns_cv_id() -> None:
 
 
 def test_create_content_version_500_raises_network_error() -> None:
-    """Tests that a 500 response raises NetworkError."""
+    """Tests that a persistent 500 raises NetworkError after retries."""
     with req_mock.Mocker() as m:
         m.post(_CV_URL, json={}, status_code=500)
-        with pytest.raises(NetworkError):
-            create_content_version(TOKEN, APP_ID)
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError):
+                create_content_version(TOKEN, APP_ID)
 
 
 # --- create_content_version_file ---
@@ -249,11 +250,101 @@ def test_commit_content_version_patches_app() -> None:
 
 
 def test_commit_content_version_500_raises_network_error() -> None:
-    """Tests that a 500 from commit_content_version raises NetworkError."""
+    """Tests that a persistent 500 raises NetworkError after retries."""
     with req_mock.Mocker() as m:
         m.patch(_APP_URL, json={}, status_code=500)
-        with pytest.raises(NetworkError):
-            commit_content_version(TOKEN, APP_ID, CV_ID)
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError):
+                commit_content_version(TOKEN, APP_ID, CV_ID)
+
+
+# --- _graph_request retry behavior ---
+
+
+def test_graph_request_retries_429_honoring_retry_after() -> None:
+    """Tests that a throttled call waits per Retry-After and succeeds."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(
+            _APP_URL,
+            [
+                {"status_code": 429, "headers": {"Retry-After": "7"}},
+                {"json": body, "status_code": 200},
+            ],
+        )
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            result = get_mobile_app(TOKEN, APP_ID)
+
+    assert result == body
+    assert len(m.request_history) == 2
+    assert sleep_mock.call_args.args[0] == 7.0
+
+
+def test_graph_request_retries_transient_500() -> None:
+    """Tests that a transient 500 retries with backoff and succeeds."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, [{"status_code": 503}, {"json": body, "status_code": 200}])
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            result = get_mobile_app(TOKEN, APP_ID)
+
+    assert result == body
+    assert sleep_mock.call_args.args[0] == 2.0  # initial backoff, no Retry-After
+
+
+def test_graph_request_exhausts_attempts() -> None:
+    """Tests that persistent throttling raises after bounded attempts."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, status_code=429)
+        with patch("napt.upload.graph.time.sleep"):
+            with pytest.raises(NetworkError):
+                get_mobile_app(TOKEN, APP_ID)
+
+    assert len(m.request_history) == 5
+
+
+def test_graph_request_non_retryable_fails_fast() -> None:
+    """Tests that a 400 raises immediately without retrying."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, json={"error": "bad"}, status_code=400)
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            with pytest.raises(ConfigError):
+                create_win32_app(TOKEN, {})
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_graph_request_retries_connection_error() -> None:
+    """Tests that a connection-level failure retries and succeeds."""
+    import requests as requests_lib
+
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(
+            _APP_URL,
+            [
+                {"exc": requests_lib.exceptions.ConnectionError},
+                {"json": body, "status_code": 200},
+            ],
+        )
+        with patch("napt.upload.graph.time.sleep"):
+            result = get_mobile_app(TOKEN, APP_ID)
+
+    assert result == body
+
+
+def test_delete_mobile_app_tolerates_404() -> None:
+    """Tests that deleting an already-gone app is a no-op, not a retry."""
+    from napt.upload.graph import delete_mobile_app
+
+    with req_mock.Mocker() as m:
+        m.delete(_APP_URL, status_code=404)
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            delete_mobile_app(TOKEN, APP_ID)
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
 
 
 # --- list_mobile_apps / get_mobile_app ---

--- a/tests/upload/test_graph.py
+++ b/tests/upload/test_graph.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+import time
 from unittest.mock import patch
 
 import pytest
+import requests
 import requests_mock as req_mock
 
 from napt.exceptions import ConfigError, NetworkError
 from napt.upload.graph import (
     GRAPH_BASE,
+    _auth_headers,
+    _graph_request,
     assign_app,
     build_group_assignment,
     commit_content_version,
@@ -18,6 +22,7 @@ from napt.upload.graph import (
     create_content_version,
     create_content_version_file,
     create_win32_app,
+    delete_mobile_app,
     get_app_assignments,
     get_mobile_app,
     list_mobile_apps,
@@ -317,14 +322,12 @@ def test_graph_request_non_retryable_fails_fast() -> None:
 
 def test_graph_request_retries_connection_error() -> None:
     """Tests that a connection-level failure retries and succeeds."""
-    import requests as requests_lib
-
     body = {"id": APP_ID}
     with req_mock.Mocker() as m:
         m.get(
             _APP_URL,
             [
-                {"exc": requests_lib.exceptions.ConnectionError},
+                {"exc": requests.exceptions.ConnectionError},
                 {"json": body, "status_code": 200},
             ],
         )
@@ -334,14 +337,91 @@ def test_graph_request_retries_connection_error() -> None:
     assert result == body
 
 
+def test_graph_request_retries_509_bandwidth_throttle() -> None:
+    """Tests that a 509 bandwidth throttle is retried."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, [{"status_code": 509}, {"json": body, "status_code": 200}])
+        with patch("napt.upload.graph.time.sleep"):
+            result = get_mobile_app(TOKEN, APP_ID)
+
+    assert result == body
+
+
+def test_graph_request_sends_client_request_id() -> None:
+    """Tests that every request carries a client-request-id header."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, json={"id": APP_ID})
+        get_mobile_app(TOKEN, APP_ID)
+
+    assert m.request_history[0].headers["client-request-id"]
+
+
 def test_delete_mobile_app_tolerates_404() -> None:
     """Tests that deleting an already-gone app is a no-op, not a retry."""
-    from napt.upload.graph import delete_mobile_app
-
     with req_mock.Mocker() as m:
         m.delete(_APP_URL, status_code=404)
         with patch("napt.upload.graph.time.sleep") as sleep_mock:
             delete_mobile_app(TOKEN, APP_ID)
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_create_connection_error_fails_fast() -> None:
+    """Tests that a create POST never retries a connection failure."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, exc=requests.exceptions.ConnectionError)
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            with pytest.raises(NetworkError):
+                create_win32_app(TOKEN, {"displayName": "Test App"})
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_create_ambiguous_gateway_error_fails_fast() -> None:
+    """Tests that a create POST never retries an ambiguous 502."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, status_code=502)
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            with pytest.raises(NetworkError):
+                create_win32_app(TOKEN, {"displayName": "Test App"})
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_create_retries_throttle() -> None:
+    """Tests that a create POST retries an unambiguous 429 throttle."""
+    with req_mock.Mocker() as m:
+        m.post(
+            _APPS_URL,
+            [
+                {"status_code": 429, "headers": {"Retry-After": "3"}},
+                {"json": {"id": APP_ID}, "status_code": 201},
+            ],
+        )
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            result = create_win32_app(TOKEN, {"displayName": "Test App"})
+
+    assert result == APP_ID
+    assert sleep_mock.call_args.args[0] == 3.0
+
+
+def test_graph_request_deadline_stops_retries() -> None:
+    """Tests that an exhausted deadline surfaces the failure unslept."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, status_code=429, headers={"Retry-After": "60"})
+        with patch("napt.upload.graph.time.sleep") as sleep_mock:
+            with pytest.raises(NetworkError):
+                _graph_request(
+                    "GET",
+                    _APP_URL,
+                    "deadline test",
+                    headers=_auth_headers(TOKEN),
+                    deadline=time.monotonic() + 1.0,
+                )
 
     assert len(m.request_history) == 1
     sleep_mock.assert_not_called()


### PR DESCRIPTION
## Description
Microsoft Graph calls now retry transient failures: HTTP 429/503/509 honoring `Retry-After`, transient server errors (500/502/504) and connection drops with bounded exponential backoff (5 attempts, 2s initial, doubling). Resource-creating POSTs retry only unambiguous throttling responses (429/503/509) and never connection failures, so a reply lost after a processed create can never duplicate an Intune app. Every request carries a fresh `client-request-id` GUID per Microsoft''s reliability guidance.

## Motivation
Graph was the only network layer in NAPT without retries — downloads and Azure Blob PUTs already had them — and Intune''s Graph endpoints are aggressively throttled (429 with `Retry-After`, per app per tenant). A momentary throttle or 5xx failed a publish or marked an app''s promotion as failed, making the per-app failure-isolation path the common case instead of the rare one. Retry behavior was checked against Microsoft''s Graph error reference and best-practices docs: 509 is documented retryable (now covered), 409 is retryable only for directory-write concurrency violations NAPT can never hit (deliberately not retried), and 503 retries occur on a fresh connection as recommended.

## Changes
- New `_graph_request` helper wraps all 13 Graph call sites: retries with exponential backoff, honors numeric `Retry-After` (capped at 300s), sends `client-request-id`, and preserves the existing AuthError/ConfigError/NetworkError mapping with full response detail on the final attempt
- `idempotent=False` for the three creating POSTs restricts retries to shed-before-processing responses; a surfaced ambiguous failure converges on re-run via the existing stamp adoption (which deletes-and-recreates uncommitted orphans)
- `_poll` passes its 120s deadline into requests, so retry waits are charged against the poll budget — a wait that would blow it surfaces the failure instead of stretching the poll indefinitely
- Transport retry warnings (Graph and the existing blob PUT) log under the `HTTP` prefix, matching `download.py`''s convention; a prefix-naming rule is now documented in the project guide
- 404 tolerance for `delete_mobile_app` moved into the helper (`ok_statuses`)
- All remaining single-shot HTTP calls (PSADT and IntuneWinAppUtil GitHub lookups and downloads, web_scrape page fetches, api_github and api_json discovery requests) now go through the installer download layer's retrying session — same transient statuses, Retry-After respected, GET/HEAD only

## Testing
How was this tested?
- [x] Unit tests added/updated
    - Retry-After honoring, 500/509 backoff-and-succeed, attempt exhaustion, 400 fail-fast, connection-error retry, create fail-fast on connection error and 502, create 429 retry, client-request-id presence, deadline exhaustion, delete 404 tolerance — 725 passing
- [ ] Integration tests added/updated
- [x] Manual testing performed
    - pyright and ruff clean; two napt-reviewer passes (second verified all first-round findings resolved; verdict ship)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors

