### PR TITLE
feat: Make promotion plans self-describing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Migration: none needed for state — plans are transient. Update
         promotion workflows to watch `state/plans/**` instead of
         `state/plan.json` (see the reference workflows in Common Tasks)
+- **BREAKING: Plan files read at a glance** - Every planned action now
+    opens with a plain-English `summary` sentence and names the Intune
+    `entry` it touches (`install` or `update`) and the version it
+    `replaces`; the app's id and display name appear once at the top of
+    the file, and keys follow reading order instead of alphabetical
+    - The action vocabulary now matches the feature: `promote` moves a
+        release one ring forward (`from_ring: null` marks a first
+        rollout) and `assign` points new installs at it — replacing
+        `enter_ring`, `advance_ring`, and `assign_install`
+    - `napt promote plan` and `apply` print the same summary sentences,
+        so console output and plan files never disagree
 - **Graph API calls retry transient failures** - Throttling (HTTP
     429/503/509, honoring Retry-After) and transient server or
     connection errors now retry with bounded exponential backoff across

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -700,13 +700,16 @@ release has proven itself.
    napt promote plan
    ```
 
-   A newly uploaded release enters the first ring; a release that has held
-   its ring for `promote_after_days` advances to the next.
+   A newly uploaded release starts its rollout in the first ring; a
+   release that has held its ring for `promote_after_days` is promoted to
+   the next.
    Eligible actions are written per app to `state/plans/<app-id>.json`;
    review the files, or commit them and gate the apply on a pull request.
-   Each action names the app, the release, the groups it will assign,
-   and — for advancement — when the release entered its current ring and
-   that ring's bake threshold, so the files read as the review record.
+   Every action opens with a plain-English summary sentence and carries
+   the details behind it — the release, the groups it will assign, the
+   version it replaces, and for a promotion out of a held ring, when the
+   release entered it and the ring's bake threshold — so the files read
+   as the review record.
 
 3. **Apply** — execute the plan against Intune:
 
@@ -836,8 +839,8 @@ Adapt names, schedules, and branch rules to your org.
   and uploads it, with the hash gate guaranteeing the approved binary is
   exactly what ships.
 - **Promotion PRs** (one, batched): `napt promote plan` writes one
-  `state/plans/<id>.json` file per app with releases eligible to enter
-  or advance rings; CI commits them to a branch and opens a PR. Merging
+  `state/plans/<id>.json` file per app with that app's eligible
+  promotions; CI commits them to a branch and opens a PR. Merging
   approves the promotions — a workflow runs `napt promote apply`, which
   executes each app's plan as an allowlist, independently.
   To hold one app's promotions, delete its plan file in the PR; the

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -703,6 +703,8 @@ release has proven itself.
    A newly uploaded release starts its rollout in the first ring; a
    release that has held its ring for `promote_after_days` is promoted to
    the next.
+   The same plan also points new installs (the install entry) at the new
+   release, so net-new devices get it as soon as the first ring does.
    Eligible actions are written per app to `state/plans/<app-id>.json`;
    review the files, or commit them and gate the apply on a pull request.
    Every action opens with a plain-English summary sentence and carries

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -1074,6 +1074,10 @@ org-wide choice is `groups: ["All Users"]` for Company Portal
 self-service.
 The assignment is planned by `napt promote plan` and executed once per
 release by `napt promote apply`.
+The cutover happens with the release's first promotion: the same plan
+that starts a release's rollout in the first ring also points new
+installs at it, so net-new devices receive the release before it has
+baked through the rings.
 
 ### retain_versions
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,6 +30,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 | Pre/Post Install/Uninstall Script Support | 💡 Idea | User-Facing | Low | Medium |
 | Enhanced CLI Help Menu | 💡 Idea | User-Facing | Low | Medium |
 | Intune App Categorization & Scope Tags | 💡 Idea | User-Facing | Medium | Medium |
+| Configurable Install-Entry Cutover Ring | 💡 Idea | User-Facing | Medium | Medium |
 | PowerShell Validation | 💡 Idea | Code Quality | High | High |
 | Recipe Linting & Best Practices | 💡 Idea | Code Quality | High | Medium |
 | Unrecognized Config Field Warnings | ✅ Completed | Code Quality | Low | Medium |
@@ -43,8 +44,8 @@ This roadmap is a living document showing potential future directions for NAPT. 
 **Summary:**
 
 - ✅ **Completed**: 4
-- 💡 **Ideas**: 13
-- **Total**: 17 features
+- 💡 **Ideas**: 14
+- **Total**: 18 features
 
 ---
 
@@ -154,6 +155,42 @@ information, examples, and better organization.
 - Tips for troubleshooting (--verbose, --debug flags)
 
 **Related**: CLI help currently minimal, relies on online documentation
+
+#### Configurable Install-Entry Cutover Ring
+
+**Status**: 💡 Idea
+**Complexity**: Medium (1-3 days)
+**Value**: Medium
+
+**Description**: Today the same promotion plan that starts a release's
+rollout in the first ring also points new installs at it (the `assign`
+action), so net-new devices receive the release before it has baked.
+Add an optional `deployment.install` setting (e.g.
+`after_ring: <ring-name>`) so the install assignment follows the release
+only once it has entered that ring.
+Default stays immediate cutover.
+
+**Benefits**:
+
+- Net-new devices keep receiving the proven release while the new one
+  bakes through early rings
+- A release held or rolled back before the cutover ring never reaches
+  new installs at all
+- Org-policy knob in `defaults/org.yaml`, per-recipe overridable like
+  the rest of `deployment`
+
+**Dependencies**:
+
+- Planner must gate the `assign` action on ring state instead of
+  planning it on publish
+- New recipe field: run `/add-recipe-field` for validation and
+  recipe-reference updates
+
+**Related**: Deferring the cutover opens a small churn window: a new
+device in a ring group that already carries the new release installs
+the old one and updates right away.
+Bounded by the bake time of rings before the cutover point, so small
+with a pilot-sized first ring.
 
 ### Code Quality & Validation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,7 +167,8 @@ rollout in the first ring also points new installs at it (the `assign`
 action), so net-new devices receive the release before it has baked.
 Add an optional `deployment.install` setting (e.g.
 `after_ring: <ring-name>`) so the install assignment follows the release
-only once it has entered that ring.
+only once it has entered that ring — the planner gates the `assign`
+action on ring state instead of planning it on publish.
 Default stays immediate cutover.
 
 **Benefits**:
@@ -181,8 +182,6 @@ Default stays immediate cutover.
 
 **Dependencies**:
 
-- Planner must gate the `assign` action on ring state instead of
-  planning it on publish
 - New recipe field: run `/add-recipe-field` for validation and
   recipe-reference updates
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -443,17 +443,18 @@ napt package recipes/Google/chrome.yaml --version 130.0.6723.116
 ### napt promote
 
 Plans and applies ring-based promotion of published apps. `promote plan`
-computes which releases enter or advance deployment rings (per
-`deployment.rings`) and writes one plan file per app with work
+computes which releases are ready to promote through deployment rings
+(per `deployment.rings`) and writes one plan file per app with work
 (`state/plans/<app-id>.json`); an app's stale plan file is removed when
 nothing is eligible for it. Read-only unless `--reconcile` is passed.
 Besides the fields apply acts on, each action carries reviewer context:
-the app's display name and — for ring advancement — when the release
-entered the ring it is leaving and that ring's bake threshold.
+a plain-English summary sentence, the Intune entry it touches, the
+version it replaces, and — for a promotion out of a held ring — when
+the release entered that ring and its bake threshold.
 
 `promote apply` executes the plans against Intune: assigns install
-entries, enters and advances rings, unassigns displaced releases, and
-retires them per `deployment.retain_versions`. It consumes every plan
+entries, promotes releases through rings, unassigns displaced releases,
+and retires them per `deployment.retain_versions`. It consumes every plan
 file in `state/plans/` when any exist (removing each after its app
 applies fully) and plans fresh otherwise. Each app's plan is an
 independent unit — one app's failure keeps its plan file for retry and
@@ -690,6 +691,37 @@ Later pipeline stages consume it.
 `napt promote plan` evaluates ring eligibility as a pure function of
 deployment state, configuration, and the clock, and writes the result as
 one file per app: `state/plans/<app-id>.json`.
+A plan file names its app once at the top and lists actions of two
+types, one per Intune entry: `promote` moves a release one ring forward
+(`from_ring: null` marks a first rollout into the first ring), and
+`assign` points new installs at the release.
+Every action opens with a plain-English `summary` and carries the
+details behind it — the entry touched, the version it replaces, bake
+timestamps — so the file diff reads on its own in review:
+
+```json
+{
+  "schemaVersion": 1,
+  "app_id": "napt-chrome",
+  "name": "Google Chrome",
+  "actions": [
+    {
+      "summary": "Promote 140.0.7339.128 from pilot to production, replacing 139.0.7258.155; it has held pilot since 2026-07-14 (threshold: 2 days).",
+      "type": "promote",
+      "entry": "update",
+      "version": "140.0.7339.128",
+      "replaces": "139.0.7258.155",
+      "from_ring": "pilot",
+      "from_ring_entered_at": "2026-07-14T07:12:03+00:00",
+      "promote_after_days": 2,
+      "ring": "production",
+      "groups": ["Production Devices"],
+      "sha256": "6ff02fd8a4..."
+    }
+  ]
+}
+```
+
 An app's plan file exists exactly when that app has eligible actions: a
 plan run that finds nothing for an app removes its stale plan file.
 Each file's git status is therefore the per-app CI signal that a

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -650,27 +650,16 @@ def cmd_upload(args: argparse.Namespace) -> int:
 def _describe_action(action: dict[str, Any]) -> str:
     """Formats one planned promotion action as a summary line.
 
+    Reuses the action's ``summary`` — the same sentence written to the
+    plan file — so console output and plan files never disagree.
+
     Args:
         action: A planned action dict from plan_promotions.
 
     Returns:
         A one-line ASCII description for console output.
     """
-    groups = ", ".join(action["groups"])
-    if action["type"] == "assign_install":
-        return (
-            f"{action['app_id']}: assign install entry "
-            f"({action['intent']}) -> {groups}"
-        )
-    if action["type"] == "enter_ring":
-        return (
-            f"{action['app_id']}: {action['version']} enters ring "
-            f"'{action['ring']}' -> {groups}"
-        )
-    return (
-        f"{action['app_id']}: {action['version']} advances "
-        f"'{action['from_ring']}' -> '{action['ring']}' -> {groups}"
-    )
+    return f"{action['app_id']}: {action['summary']}"
 
 
 def cmd_promote_plan(args: argparse.Namespace) -> int:
@@ -830,8 +819,8 @@ def cmd_promote_apply(args: argparse.Namespace) -> int:
     """Handler for 'napt promote apply' command.
 
     Executes promotion plans against Intune: assigns install entries,
-    enters and advances releases through rings, displaces superseded
-    releases, and retires them per the retention policy. Consumes each
+    promotes releases through rings, displaces the older releases they
+    replace, and retires them per the retention policy. Consumes each
     per-app plan file after its app applies fully; otherwise plans
     fresh and applies immediately. One app's failure keeps its plan
     file for retry and never blocks the others, and stale or
@@ -1462,8 +1451,9 @@ def main() -> None:
         "plan",
         help="Compute eligible promotions and write per-app plan files",
         description=(
-            "Compute which releases enter or advance deployment rings, and "
-            "write one state/plans/<app>.json file per app with work. "
+            "Compute which releases are ready to promote through deployment "
+            "rings, and write one state/plans/<app>.json file per app with "
+            "work. "
             "Never modifies Intune. Read-only for deployment state too, "
             "except that --reconcile writes it when recovering a lost "
             "publication writeback. With --check-drift or --reconcile, "
@@ -1525,9 +1515,10 @@ def main() -> None:
         "apply",
         help="Execute promotion plans against Intune",
         description=(
-            "Execute promotion actions: assign install entries, enter and "
-            "advance rings, displace superseded releases, and retire them "
-            "per deployment.retain_versions. Consumes each per-app plan "
+            "Execute promotion actions: assign install entries, promote "
+            "releases through rings, displace the older releases they "
+            "replace, and retire them per deployment.retain_versions. "
+            "Consumes each per-app plan "
             "file in state/plans/ when any exist; otherwise plans fresh "
             "and applies immediately. One app's failure keeps its plan "
             "file and never blocks the others, and stale or "

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -15,8 +15,8 @@
 """Promotion apply for NAPT deployment rings.
 
 Executes promotion plans against Intune: assigns install entries,
-enters and advances releases through rings, displaces superseded
-releases, and retires them per the retention policy.
+promotes releases through rings, displaces the older releases they
+replace, and retires them per the retention policy.
 
 Plans are applied per app: each ``state/plans/<app_id>.json`` file is
 an independent unit of work, preflighted, executed, and consumed on
@@ -88,6 +88,11 @@ _RING_INTENT = "required"
 def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
     """Loads planned actions from a per-app plan file.
 
+    The file records its app id and display name once at the top level;
+    both are re-injected into every returned action, so in-memory
+    actions look the same whether they came from a plan file or a fresh
+    plan.
+
     Args:
         plan_path: Path to the plan file.
 
@@ -96,14 +101,15 @@ def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
 
     Raises:
         StateError: If the plan file contains invalid JSON, lacks an
-            actions list, its schemaVersion is missing or unsupported,
-            or its actions do not all belong to the single app the file
-            declares.
+            actions list or app id, its schemaVersion is missing or
+            unsupported, or an action references a different app than
+            the one the file declares.
 
     """
     try:
         data = json.loads(plan_path.read_text(encoding="utf-8"))
         actions = data["actions"]
+        declared = data["app_id"]
     except (json.JSONDecodeError, KeyError, TypeError) as err:
         raise StateError(
             f"Corrupted plan file: {plan_path}. "
@@ -120,17 +126,26 @@ def load_plan_file(plan_path: Path) -> list[dict[str, Any]]:
 
     # A plan file is one app's unit of work: apply's failure isolation
     # and consume-after-success semantics attribute the whole file to a
-    # single app, so a file mixing apps cannot be applied faithfully.
-    action_app_ids = {action.get("app_id") for action in actions}
-    declared = data.get("app_id")
-    expected = {declared} if declared is not None else action_app_ids
-    if len(action_app_ids) > 1 or action_app_ids - expected:
+    # single app, so a file whose actions reference another app (a hand
+    # edit) cannot be applied faithfully.
+    foreign = {
+        action.get("app_id")
+        for action in actions
+        if action.get("app_id") not in (None, declared)
+    }
+    if foreign:
         raise StateError(
             f"Plan file {plan_path} mixes actions for more than one app "
             f"(declared app_id {declared!r}, actions reference "
-            f"{sorted(str(a) for a in action_app_ids)}). Plan files are "
+            f"{sorted(str(a) for a in foreign)}). Plan files are "
             "per-app. Re-run 'napt promote plan' to regenerate them."
         )
+
+    name = data.get("name")
+    for action in actions:
+        action["app_id"] = declared
+        if name is not None:
+            action.setdefault("name", name)
     return actions
 
 
@@ -350,7 +365,7 @@ def _action_skip_reason(run: _ApplyRun, action: dict[str, Any]) -> str | None:
     if deployed.get("sha256") != sha256:
         return "stale action - the deployed release has changed"
 
-    if action["type"] == "assign_install":
+    if action["type"] == "assign":
         previous = state.get("install_assigned") or {}
         if previous.get("sha256") == sha256:
             return "already applied"
@@ -369,8 +384,8 @@ def _action_skip_reason(run: _ApplyRun, action: dict[str, Any]) -> str | None:
     return None
 
 
-def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> None:
-    """Applies an enter_ring or advance_ring action.
+def _apply_promote(run: _ApplyRun, action: dict[str, Any]) -> None:
+    """Applies a promote action, assigning the update entry to its target ring.
 
     Assumes the action was cleared by
     [_action_skip_reason][napt.promote.applier._action_skip_reason];
@@ -426,8 +441,8 @@ def _apply_ring_action(run: _ApplyRun, action: dict[str, Any]) -> None:
     run.applied.append(action)
 
 
-def _apply_install_action(run: _ApplyRun, action: dict[str, Any]) -> None:
-    """Applies an assign_install action.
+def _apply_assign(run: _ApplyRun, action: dict[str, Any]) -> None:
+    """Applies an assign action, pointing the install entry at the release.
 
     Assumes the action was cleared by
     [_action_skip_reason][napt.promote.applier._action_skip_reason];
@@ -602,10 +617,10 @@ def apply_plan(
                 if reason is not None:
                     run.skip(action, reason)
                     continue
-                if action["type"] == "assign_install":
-                    _apply_install_action(run, action)
+                if action["type"] == "assign":
+                    _apply_assign(run, action)
                 else:
-                    _apply_ring_action(run, action)
+                    _apply_promote(run, action)
         except (ConfigError, NetworkError, StateError) as err:
             logger.warning(
                 "PROMOTE",

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -20,14 +20,21 @@ file. Re-running plan against unchanged inputs produces byte-identical
 output, so committed plan files diff cleanly and CI can use the plan
 file's change status to decide whether to open a review.
 
-Three action types are planned per app:
+Two action types are planned per app, one per Intune entry:
 
-- ``assign_install``: The install entry has never been assigned; assign
-    it to the configured ``deployment.install`` groups.
-- ``enter_ring``: The deployed release holds no ring; assign the Update
-    entry to the first ring's groups.
-- ``advance_ring``: The deployed release has held its furthest ring for
-    at least that ring's ``promote_after_days``; assign the next ring.
+- ``assign``: Point new installs at the deployed release — assign its
+    install entry to the configured ``deployment.install`` groups,
+    displacing the previous release's install assignment.
+- ``promote``: Move the deployed release one ring forward — assign its
+    update entry to the target ring's groups. ``from_ring: null`` marks
+    a first rollout (the release enters the first ring); otherwise the
+    release has held ``from_ring`` for at least that ring's
+    ``promote_after_days``.
+
+Every action carries a plain-English ``summary`` sentence plus the
+reviewer context behind it — the entry it touches, the version it
+replaces, and bake timestamps — so a committed plan file reads on its
+own in review.
 
 A ring without ``promote_after_days`` never advances automatically —
 releases hold it until the configuration changes (the natural terminal
@@ -63,7 +70,7 @@ __all__ = [
 ]
 
 # Deterministic ordering of action types within one app's actions.
-_ACTION_ORDER = {"assign_install": 0, "enter_ring": 1, "advance_ring": 2}
+_ACTION_ORDER = {"assign": 0, "promote": 1}
 
 # Schema version written to every plan file. Bump only with a migration
 # story: promote apply rejects plans stamped with a different version.
@@ -123,6 +130,19 @@ def _parse_entered_at(value: str, context: str) -> datetime:
     return parsed
 
 
+def _replacing(replaces: str | None) -> str:
+    """Returns the summary clause naming the replaced version, if any.
+
+    Args:
+        replaces: Version the action replaces, or None.
+
+    Returns:
+        ``", replacing <version>"``, or an empty string.
+
+    """
+    return f", replacing {replaces}" if replaces else ""
+
+
 def _plan_app_actions(
     config: dict[str, Any],
     state: dict[str, Any],
@@ -131,9 +151,10 @@ def _plan_app_actions(
     """Computes promotion actions for one app.
 
     Besides the fields apply keys on (app id, sha256, ring), every
-    action carries informational fields for reviewers: the recipe's
-    display ``name``, and — for ``advance_ring`` — when the release
-    entered the ring it is leaving and that ring's bake threshold. Only
+    action carries reviewer context: a plain-English ``summary``
+    sentence, the Intune ``entry`` it touches, the version it
+    ``replaces``, and — for a promotion out of a held ring — when the
+    release entered that ring and the ring's bake threshold. Only
     values stable across runs are included (never clock-derived ones),
     preserving byte-identical plans for unchanged inputs.
 
@@ -170,15 +191,25 @@ def _plan_app_actions(
         and install_cfg["groups"]
         and install_assigned.get("sha256") != sha256
     ):
+        groups = list(install_cfg["groups"])
+        intent: str = install_cfg["intent"]
+        replaces = install_assigned.get("version")
         actions.append(
             {
-                "type": "assign_install",
                 "app_id": app_id,
                 "name": name,
+                "summary": (
+                    f"Point new installs at {version}: assign the install "
+                    f"entry to {', '.join(groups)} ({intent})"
+                    f"{_replacing(replaces)}."
+                ),
+                "type": "assign",
+                "entry": "install",
                 "version": version,
+                "replaces": replaces,
+                "intent": intent,
+                "groups": groups,
                 "sha256": sha256,
-                "intent": install_cfg["intent"],
-                "groups": list(install_cfg["groups"]),
             }
         )
 
@@ -197,15 +228,28 @@ def _plan_app_actions(
 
     if not held_indexes:
         first = rings_cfg[0]
+        ring_name: str = first["name"]
+        groups = list(first["groups"])
+        replaces = rings_state.get(ring_name, {}).get("version")
         actions.append(
             {
-                "type": "enter_ring",
                 "app_id": app_id,
                 "name": name,
+                "summary": (
+                    f"Start rolling out {version}: assign the update entry "
+                    f"to the {ring_name} ring ({', '.join(groups)})"
+                    f"{_replacing(replaces)}."
+                ),
+                "type": "promote",
+                "entry": "update",
                 "version": version,
+                "replaces": replaces,
+                "from_ring": None,
+                "from_ring_entered_at": None,
+                "promote_after_days": None,
+                "ring": ring_name,
+                "groups": groups,
                 "sha256": sha256,
-                "ring": first["name"],
-                "groups": list(first["groups"]),
             }
         )
         return actions
@@ -227,18 +271,30 @@ def _plan_app_actions(
         return actions  # Still baking.
 
     next_ring = rings_cfg[furthest + 1]
+    next_ring_name: str = next_ring["name"]
+    groups = list(next_ring["groups"])
+    replaces = rings_state.get(next_ring_name, {}).get("version")
+    day_word = "day" if days == 1 else "days"
     actions.append(
         {
-            "type": "advance_ring",
             "app_id": app_id,
             "name": name,
+            "summary": (
+                f"Promote {version} from {held_ring_name} to "
+                f"{next_ring_name}{_replacing(replaces)}; it has held "
+                f"{held_ring_name} since {entered_at.date().isoformat()} "
+                f"(threshold: {days} {day_word})."
+            ),
+            "type": "promote",
+            "entry": "update",
             "version": version,
-            "sha256": sha256,
+            "replaces": replaces,
             "from_ring": held_ring_name,
             "from_ring_entered_at": rings_state[held_ring_name]["entered_at"],
             "promote_after_days": days,
-            "ring": next_ring["name"],
-            "groups": list(next_ring["groups"]),
+            "ring": next_ring_name,
+            "groups": groups,
+            "sha256": sha256,
         }
     )
     return actions
@@ -382,8 +438,13 @@ def write_plan_files(
     review is needed. Only apps covered by this run (``app_ids``) are
     written or cleaned up — plan files for apps outside the run are left
     untouched, so planning a single recipe never clobbers the rest of
-    the fleet's plans. Output is deterministic (sorted keys, fixed
-    indentation, no clock-derived values).
+    the fleet's plans.
+
+    The app's id and display name are written once at the file's top
+    level rather than repeated per action; promote apply re-injects them
+    when it loads the file. Output is deterministic — a fixed key order
+    (reading order, ``summary`` first, not alphabetical), fixed
+    indentation, no clock-derived values.
 
     Args:
         actions: Planned actions from plan_promotions.
@@ -413,11 +474,18 @@ def write_plan_files(
                 {
                     "schemaVersion": PLAN_SCHEMA_VERSION,
                     "app_id": app_id,
-                    "actions": app_actions,
+                    "name": app_actions[0]["name"],
+                    "actions": [
+                        {
+                            key: value
+                            for key, value in action.items()
+                            if key not in ("app_id", "name")
+                        }
+                        for action in app_actions
+                    ],
                 },
                 f,
                 indent=2,
-                sort_keys=True,
             )
             f.write("\n")  # Trailing newline for git
         written.append(plan_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -736,12 +736,22 @@ class TestCmdPromotePlan:
         """Tests that planned actions print a summary and report the plan file."""
         actions = [
             {
-                "type": "enter_ring",
                 "app_id": "test-app",
+                "name": "App test-app",
+                "summary": (
+                    "Start rolling out 1.0.0: assign the update entry to "
+                    "the pilot ring (sg-pilot)."
+                ),
+                "type": "promote",
+                "entry": "update",
                 "version": "1.0.0",
-                "sha256": "a" * 64,
+                "replaces": None,
+                "from_ring": None,
+                "from_ring_entered_at": None,
+                "promote_after_days": None,
                 "ring": "pilot",
                 "groups": ["sg-pilot"],
+                "sha256": "a" * 64,
             }
         ]
         with (
@@ -759,7 +769,7 @@ class TestCmdPromotePlan:
             )
         assert code == 0
         out = capsys.readouterr().out
-        assert "enters ring 'pilot'" in out
+        assert "test-app: Start rolling out 1.0.0" in out
         assert "Plan written" in out
         assert write_mock.call_args.args[0] == actions
 
@@ -879,23 +889,31 @@ class TestCmdPromoteApply:
         summary = {
             "applied": [
                 {
-                    "type": "enter_ring",
                     "app_id": "test-app",
+                    "summary": (
+                        "Start rolling out 1.0.0: assign the update entry "
+                        "to the pilot ring (sg-pilot)."
+                    ),
+                    "type": "promote",
                     "version": "1.0.0",
-                    "sha256": "a" * 64,
                     "ring": "pilot",
                     "groups": ["sg-pilot"],
+                    "sha256": "a" * 64,
                 }
             ],
             "skipped": [
                 {
                     "action": {
-                        "type": "assign_install",
                         "app_id": "other-app",
+                        "summary": (
+                            "Point new installs at 1.0.0: assign the "
+                            "install entry to All Users (available)."
+                        ),
+                        "type": "assign",
                         "version": "1.0.0",
-                        "sha256": "b" * 64,
                         "intent": "available",
                         "groups": ["All Users"],
+                        "sha256": "b" * 64,
                     },
                     "reason": "already applied",
                 }
@@ -1102,12 +1120,16 @@ class TestReconcileOutput:
         without writing a plan file."""
         actions = [
             {
-                "type": "enter_ring",
                 "app_id": "test-app",
+                "summary": (
+                    "Start rolling out 1.0.0: assign the update entry to "
+                    "the pilot ring (ghost-group)."
+                ),
+                "type": "promote",
                 "version": "1.0.0",
-                "sha256": "a" * 64,
                 "ring": "pilot",
                 "groups": ["ghost-group"],
+                "sha256": "a" * 64,
             }
         ]
         with (
@@ -1164,12 +1186,16 @@ class TestReconcileOutput:
         groups were not validated."""
         actions = [
             {
-                "type": "enter_ring",
                 "app_id": "test-app",
+                "summary": (
+                    "Start rolling out 1.0.0: assign the update entry to "
+                    "the pilot ring (sg-pilot)."
+                ),
+                "type": "promote",
                 "version": "1.0.0",
-                "sha256": "a" * 64,
                 "ring": "pilot",
                 "groups": ["sg-pilot"],
+                "sha256": "a" * 64,
             }
         ]
         with (

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -125,8 +125,8 @@ class TestPlanPromotions:
 
         assert actions == []
 
-    def test_deployed_release_enters_first_ring(self, tmp_path):
-        """Tests that a deployed release holding no ring enters ring 0."""
+    def test_deployed_release_starts_rollout_in_first_ring(self, tmp_path):
+        """Tests that a deployed release holding no ring starts at ring 0."""
         recipe = _write_recipe(tmp_path, rings=_RINGS)
         state_dir = _write_state(tmp_path, deployed=_deployed())
 
@@ -134,13 +134,22 @@ class TestPlanPromotions:
 
         assert actions == [
             {
-                "type": "enter_ring",
                 "app_id": "test-app",
                 "name": "App test-app",
+                "summary": (
+                    "Start rolling out 1.0.0: assign the update entry to "
+                    "the pilot ring (sg-pilot)."
+                ),
+                "type": "promote",
+                "entry": "update",
                 "version": "1.0.0",
-                "sha256": "a" * 64,
+                "replaces": None,
+                "from_ring": None,
+                "from_ring_entered_at": None,
+                "promote_after_days": None,
                 "ring": "pilot",
                 "groups": ["sg-pilot"],
+                "sha256": "a" * 64,
             }
         ]
 
@@ -153,13 +162,19 @@ class TestPlanPromotions:
 
         assert actions == [
             {
-                "type": "assign_install",
                 "app_id": "test-app",
                 "name": "App test-app",
+                "summary": (
+                    "Point new installs at 1.0.0: assign the install entry "
+                    "to All Users (available)."
+                ),
+                "type": "assign",
+                "entry": "install",
                 "version": "1.0.0",
-                "sha256": "a" * 64,
+                "replaces": None,
                 "intent": "available",
                 "groups": ["All Users"],
+                "sha256": "a" * 64,
             }
         ]
 
@@ -188,8 +203,10 @@ class TestPlanPromotions:
 
         actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
 
-        assert [a["type"] for a in actions] == ["assign_install"]
+        assert [a["type"] for a in actions] == ["assign"]
         assert actions[0]["sha256"] == "b" * 64
+        assert actions[0]["replaces"] == "prev"
+        assert ", replacing prev." in actions[0]["summary"]
 
     def test_baking_release_does_not_advance(self, tmp_path):
         """Tests that a release still baking holds its ring."""
@@ -210,8 +227,8 @@ class TestPlanPromotions:
 
         assert actions == []
 
-    def test_baked_release_advances_to_next_ring(self, tmp_path):
-        """Tests that an eligible release advances with the next ring's groups."""
+    def test_baked_release_promotes_to_next_ring(self, tmp_path):
+        """Tests that an eligible release promotes with the next ring's groups."""
         recipe = _write_recipe(tmp_path, rings=_RINGS)
         state_dir = _write_state(
             tmp_path,
@@ -229,16 +246,22 @@ class TestPlanPromotions:
 
         assert actions == [
             {
-                "type": "advance_ring",
                 "app_id": "test-app",
                 "name": "App test-app",
+                "summary": (
+                    "Promote 1.0.0 from pilot to broad; it has held pilot "
+                    "since 2026-07-06 (threshold: 2 days)."
+                ),
+                "type": "promote",
+                "entry": "update",
                 "version": "1.0.0",
-                "sha256": "a" * 64,
+                "replaces": None,
                 "from_ring": "pilot",
                 "from_ring_entered_at": "2026-07-06T12:00:00+00:00",
                 "promote_after_days": 2,
                 "ring": "broad",
                 "groups": ["sg-broad"],
+                "sha256": "a" * 64,
             }
         ]
 
@@ -302,7 +325,8 @@ class TestPlanPromotions:
         actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
 
         assert len(actions) == 1
-        assert actions[0]["type"] == "enter_ring"
+        assert actions[0]["type"] == "promote"
+        assert actions[0]["from_ring"] is None
         assert actions[0]["ring"] == "pilot"
         assert actions[0]["version"] == "2.0.0"
 
@@ -313,7 +337,7 @@ class TestPlanPromotions:
 
         actions = plan_promotions(recipe, state_dir=state_dir, now=NOW)
 
-        assert [a["type"] for a in actions] == ["assign_install"]
+        assert [a["type"] for a in actions] == ["assign"]
 
     def test_actions_sorted_by_app_id(self, tmp_path):
         """Tests that actions across apps are deterministically ordered."""
@@ -366,7 +390,7 @@ class TestPlanPromotions:
         actions = plan_promotions(recipe, state_dir=None, now=NOW)
 
         assert len(actions) == 1
-        assert actions[0]["type"] == "enter_ring"
+        assert actions[0]["type"] == "promote"
 
 
 class TestResolveStateDir:
@@ -390,13 +414,22 @@ class TestResolveStateDir:
 
 def _action(app_id: str = "a") -> dict[str, Any]:
     return {
-        "type": "enter_ring",
         "app_id": app_id,
         "name": f"App {app_id}",
+        "summary": (
+            "Start rolling out 1.0: assign the update entry to the "
+            "pilot ring (g)."
+        ),
+        "type": "promote",
+        "entry": "update",
         "version": "1.0",
-        "sha256": "x",
+        "replaces": None,
+        "from_ring": None,
+        "from_ring_entered_at": None,
+        "promote_after_days": None,
         "ring": "pilot",
         "groups": ["g"],
+        "sha256": "x",
     }
 
 
@@ -418,10 +451,38 @@ class TestWritePlanFiles:
 
         assert plan_path_for(state_dir, "a").read_bytes() == first
         assert json.loads(first.decode("utf-8")) == {
-            "actions": actions,
-            "app_id": "a",
             "schemaVersion": 1,
+            "app_id": "a",
+            "name": "App a",
+            "actions": [
+                {
+                    key: value
+                    for key, value in _action().items()
+                    if key not in ("app_id", "name")
+                }
+            ],
         }
+
+    def test_plan_file_keys_in_reading_order(self, tmp_path):
+        """Tests that plan files keep reading order, summary first."""
+        state_dir = tmp_path / "state"
+        write_plan_files([_action()], state_dir, ["a"])
+
+        text = plan_path_for(state_dir, "a").read_text(encoding="utf-8")
+
+        top_level = ['"schemaVersion"', '"app_id"', '"name"', '"actions"']
+        action_keys = [
+            '"summary"',
+            '"type"',
+            '"entry"',
+            '"version"',
+            '"replaces"',
+            '"ring"',
+            '"groups"',
+            '"sha256"',
+        ]
+        positions = [text.index(key) for key in top_level + action_keys]
+        assert positions == sorted(positions)
 
     def test_splits_actions_per_app(self, tmp_path):
         """Tests that each app's actions land in that app's plan file."""
@@ -438,7 +499,9 @@ class TestWritePlanFiles:
         plan_b = json.loads(written[1].read_text(encoding="utf-8"))
         assert len(plan_a["actions"]) == 2
         assert len(plan_b["actions"]) == 1
-        assert all(a["app_id"] == "a" for a in plan_a["actions"])
+        assert plan_a["app_id"] == "a"
+        assert plan_a["name"] == "App a"
+        assert all("app_id" not in a for a in plan_a["actions"])
 
     def test_no_actions_removes_stale_plan(self, tmp_path):
         """Tests that an app with no work has its stale plan file removed."""

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -226,20 +226,29 @@ def _write_plan(tmp_path: Path, actions: list[dict[str, Any]]) -> Path:
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     plan_path.write_text(
         json.dumps(
-            {"schemaVersion": 1, "app_id": app_id, "actions": actions},
+            {
+                "schemaVersion": 1,
+                "app_id": app_id,
+                "name": f"App {app_id}",
+                "actions": [
+                    {
+                        key: value
+                        for key, value in action.items()
+                        if key not in ("app_id", "name")
+                    }
+                    for action in actions
+                ],
+            },
             indent=2,
-            sort_keys=True,
         ),
         encoding="utf-8",
     )
     return plan_path
 
 
-def _enter_ring_action(
-    sha256: str = "b" * 64, version: str = "2.0.0"
-) -> dict[str, Any]:
+def _promote_action(sha256: str = "b" * 64, version: str = "2.0.0") -> dict[str, Any]:
     return {
-        "type": "enter_ring",
+        "type": "promote",
         "app_id": "test-app",
         "version": version,
         "sha256": sha256,
@@ -248,14 +257,14 @@ def _enter_ring_action(
     }
 
 
-class TestApplyRingActions:
-    """Tests for enter_ring and advance_ring execution."""
+class TestApplyPromoteActions:
+    """Tests for promote execution."""
 
-    def test_enter_ring_assigns_and_records(self, tmp_path):
-        """Tests that entering a ring assigns groups and writes state."""
+    def test_promote_assigns_and_records(self, tmp_path):
+        """Tests that promoting into a ring assigns groups and writes state."""
         _write_recipe(tmp_path, rings=_RINGS)
         state_path = _write_state(tmp_path, deployed=_deployed())
-        plan_path = _write_plan(tmp_path, [_enter_ring_action()])
+        plan_path = _write_plan(tmp_path, [_promote_action()])
 
         summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
 
@@ -288,7 +297,7 @@ class TestApplyRingActions:
         """Tests that admin-made assignments survive the assign call."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed())
-        _write_plan(tmp_path, [_enter_ring_action()])
+        _write_plan(tmp_path, [_promote_action()])
         admin_assignment = {
             "id": "existing-1",
             "intent": "available",
@@ -323,7 +332,7 @@ class TestApplyRingActions:
                 }
             },
         )
-        _write_plan(tmp_path, [_enter_ring_action()])
+        _write_plan(tmp_path, [_promote_action()])
         old_assignment = {
             "id": "x",
             "intent": "required",
@@ -364,7 +373,7 @@ class TestApplyRingActions:
             },
             retained=[{"version": "0.9.0", "sha256": "9" * 64}],
         )
-        _write_plan(tmp_path, [_enter_ring_action()])
+        _write_plan(tmp_path, [_promote_action()])
         tenant = _tenant() + [
             _stamped("test-app", "install", "9" * 64, "install-ancient"),
             _stamped("test-app", "update", "9" * 64, "update-ancient"),
@@ -380,7 +389,7 @@ class TestApplyRingActions:
         """Tests that an action for a superseded release is skipped."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed(version="3.0.0", sha256="c" * 64))
-        _write_plan(tmp_path, [_enter_ring_action()])  # plans v2, deployed v3
+        _write_plan(tmp_path, [_promote_action()])  # plans v2, deployed v3
 
         summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
 
@@ -403,7 +412,7 @@ class TestApplyRingActions:
                 }
             },
         )
-        _write_plan(tmp_path, [_enter_ring_action()])
+        _write_plan(tmp_path, [_promote_action()])
 
         summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
 
@@ -415,7 +424,7 @@ class TestApplyRingActions:
         """Tests that a release without a stamped update entry is skipped."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed())
-        _write_plan(tmp_path, [_enter_ring_action()])
+        _write_plan(tmp_path, [_promote_action()])
 
         summary, mocks = _run_apply(tmp_path, existing_apps=[])
 
@@ -427,7 +436,7 @@ class TestApplyRingActions:
         """Tests that a Graph failure fails the app and keeps its plan file."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed())
-        plan_path = _write_plan(tmp_path, [_enter_ring_action()])
+        plan_path = _write_plan(tmp_path, [_promote_action()])
 
         summary, _ = _run_apply(
             tmp_path,
@@ -440,12 +449,12 @@ class TestApplyRingActions:
         assert "Graph down" in summary["failed"][0]["error"]
 
 
-class TestApplyInstallActions:
-    """Tests for assign_install execution."""
+class TestApplyAssignActions:
+    """Tests for assign execution."""
 
-    def _install_action(self, sha256: str = "b" * 64) -> dict[str, Any]:
+    def _assign_action(self, sha256: str = "b" * 64) -> dict[str, Any]:
         return {
-            "type": "assign_install",
+            "type": "assign",
             "app_id": "test-app",
             "version": "2.0.0",
             "sha256": sha256,
@@ -457,7 +466,7 @@ class TestApplyInstallActions:
         """Tests that the install entry is assigned and recorded by sha."""
         _write_recipe(tmp_path, install_groups=["All Users"])
         state_path = _write_state(tmp_path, deployed=_deployed())
-        _write_plan(tmp_path, [self._install_action()])
+        _write_plan(tmp_path, [self._assign_action()])
 
         summary, mocks = _run_apply(tmp_path, existing_apps=_tenant())
 
@@ -483,7 +492,7 @@ class TestApplyInstallActions:
         """Tests that the previous release's install entry loses the groups."""
         _write_recipe(tmp_path, install_groups=["All Users"])
         _write_state(tmp_path, deployed=_deployed(), install_assigned="a" * 64)
-        _write_plan(tmp_path, [self._install_action()])
+        _write_plan(tmp_path, [self._assign_action()])
         old_assignment = {
             "id": "x",
             "intent": "available",
@@ -555,7 +564,7 @@ class TestApplyOrchestration:
         summary, _ = _run_apply(tmp_path, existing_apps=_tenant())
 
         assert [f["kind"] for f in summary["recovered"]] == ["recovered"]
-        assert [a["type"] for a in summary["applied"]] == ["enter_ring"]
+        assert [a["type"] for a in summary["applied"]] == ["promote"]
         state = load_deployment_state(state_path)
         assert state["pending"] is None
         assert state["deployed"]["intune_app_id"] == "install-new"
@@ -570,9 +579,9 @@ class TestApplyOrchestration:
         plan_path = _write_plan(
             tmp_path,
             [
-                _enter_ring_action(),  # resolvable: Pilot Devices
+                _promote_action(),  # resolvable: Pilot Devices
                 {
-                    "type": "advance_ring",
+                    "type": "promote",
                     "app_id": "test-app",
                     "version": "2.0.0",
                     "sha256": "b" * 64,
@@ -614,11 +623,11 @@ class TestApplyOrchestration:
         _write_plan(
             tmp_path,
             [
-                _enter_ring_action(),  # live: Pilot Devices
+                _promote_action(),  # live: Pilot Devices
                 # Stale: sha no longer deployed; its group was deleted
                 # after the action originally applied.
                 {
-                    "type": "enter_ring",
+                    "type": "promote",
                     "app_id": "test-app",
                     "version": "1.0.0",
                     "sha256": "a" * 64,
@@ -641,7 +650,7 @@ class TestApplyOrchestration:
             resolve_side_effect=_resolve,
         )
 
-        assert [a["type"] for a in summary["applied"]] == ["enter_ring"]
+        assert [a["type"] for a in summary["applied"]] == ["promote"]
         assert [s["reason"] for s in summary["skipped"]] == [
             "stale action - the deployed release has changed"
         ]
@@ -654,10 +663,10 @@ class TestApplyOrchestration:
         _write_recipe(tmp_path, app_id="app-good", rings=_RINGS)
         _write_state(tmp_path, app_id="app-bad", deployed=_deployed())
         good_state = _write_state(tmp_path, app_id="app-good", deployed=_deployed())
-        bad_action = _enter_ring_action()
+        bad_action = _promote_action()
         bad_action["app_id"] = "app-bad"
         bad_action["groups"] = ["missing-group"]
-        good_action = _enter_ring_action()
+        good_action = _promote_action()
         good_action["app_id"] = "app-good"
         bad_plan = _write_plan(tmp_path, [bad_action])
         good_plan = _write_plan(tmp_path, [good_action])
@@ -692,9 +701,9 @@ class TestApplyOrchestration:
         _write_recipe(tmp_path, app_id="app-good", rings=_RINGS)
         _write_state(tmp_path, app_id="app-bad", deployed=_deployed())
         _write_state(tmp_path, app_id="app-good", deployed=_deployed())
-        bad_action = _enter_ring_action()
+        bad_action = _promote_action()
         bad_action["app_id"] = "app-bad"
-        good_action = _enter_ring_action()
+        good_action = _promote_action()
         good_action["app_id"] = "app-good"
         bad_plan = _write_plan(tmp_path, [bad_action])
         good_plan = _write_plan(tmp_path, [good_action])
@@ -722,7 +731,7 @@ class TestApplyOrchestration:
         """Tests that a plan action without a matching recipe is skipped."""
         _write_recipe(tmp_path, rings=_RINGS)
         _write_state(tmp_path, deployed=_deployed())
-        action = _enter_ring_action()
+        action = _promote_action()
         action["app_id"] = "ghost-app"
         _write_plan(tmp_path, [action])
 
@@ -746,21 +755,32 @@ class TestLoadPlanFile:
     def test_missing_actions_key_raises(self, tmp_path):
         """Tests that a plan without an actions list raises StateError."""
         plan_path = tmp_path / "plan.json"
-        plan_path.write_text('{"other": []}', encoding="utf-8")
+        plan_path.write_text('{"app_id": "test-app"}', encoding="utf-8")
 
         with pytest.raises(StateError, match="Corrupted plan file"):
             load_plan_file(plan_path)
 
-    def test_mixed_app_plan_raises(self, tmp_path):
-        """Tests that a plan file mixing apps is rejected."""
+    def test_missing_app_id_raises(self, tmp_path):
+        """Tests that a plan without a declared app id raises StateError."""
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(
+            '{"schemaVersion": 1, "actions": []}', encoding="utf-8"
+        )
+
+        with pytest.raises(StateError, match="Corrupted plan file"):
+            load_plan_file(plan_path)
+
+    def test_foreign_action_app_id_raises(self, tmp_path):
+        """Tests that an action referencing another app is rejected."""
         plan_path = tmp_path / "plan.json"
         plan_path.write_text(
             json.dumps(
                 {
                     "schemaVersion": 1,
+                    "app_id": "test-app",
                     "actions": [
-                        _enter_ring_action(),
-                        {**_enter_ring_action(), "app_id": "other-app"},
+                        _promote_action(),
+                        {**_promote_action(), "app_id": "other-app"},
                     ],
                 }
             ),
@@ -770,27 +790,38 @@ class TestLoadPlanFile:
         with pytest.raises(StateError, match="per-app"):
             load_plan_file(plan_path)
 
-    def test_declared_app_id_mismatch_raises(self, tmp_path):
-        """Tests that actions disagreeing with the declared app are rejected."""
+    def test_injects_file_level_app_id_and_name(self, tmp_path):
+        """Tests that the file's app id and name are injected into actions."""
         plan_path = tmp_path / "plan.json"
+        action = {
+            key: value
+            for key, value in _promote_action().items()
+            if key != "app_id"
+        }
         plan_path.write_text(
             json.dumps(
                 {
                     "schemaVersion": 1,
-                    "app_id": "other-app",
-                    "actions": [_enter_ring_action()],
+                    "app_id": "test-app",
+                    "name": "App test-app",
+                    "actions": [action],
                 }
             ),
             encoding="utf-8",
         )
 
-        with pytest.raises(StateError, match="per-app"):
-            load_plan_file(plan_path)
+        actions = load_plan_file(plan_path)
+
+        assert actions[0]["app_id"] == "test-app"
+        assert actions[0]["name"] == "App test-app"
 
     def test_unsupported_plan_schema_version_raises(self, tmp_path):
-        """Tests that a future plan schema version is rejected."""
+        """Tests that an unsupported plan schema version is rejected."""
         plan_path = tmp_path / "plan.json"
-        plan_path.write_text('{"schemaVersion": 99, "actions": []}', encoding="utf-8")
+        plan_path.write_text(
+            '{"schemaVersion": 99, "app_id": "test-app", "actions": []}',
+            encoding="utf-8",
+        )
 
         with pytest.raises(StateError, match="schema version 99"):
             load_plan_file(plan_path)

--- a/tests/test_promote_preflight.py
+++ b/tests/test_promote_preflight.py
@@ -22,7 +22,7 @@ def _resolve_or_raise(token, group, cache=None):
 
 def _actions(*group_lists: list[str]) -> list[dict]:
     return [
-        {"type": "enter_ring", "app_id": f"app-{i}", "groups": groups}
+        {"type": "promote", "app_id": f"app-{i}", "groups": groups}
         for i, groups in enumerate(group_lists)
     ]
 


### PR DESCRIPTION
## Description
Redesigns promotion plan files so they read at a glance in review. Every action now opens with a plain-English `summary` sentence and carries the reviewer context behind it; the action vocabulary is unified and renamed to match the feature; and file key order follows reading order instead of alphabetical.

## Motivation
A plan file like `{"actions": [{"app_id": ..., "groups": [...], "sha256": "000...", "type": "enter_ring"}]}` was technically complete but told a reviewer nothing at a glance: alphabetical key order buried the action type under a 64-char hash, `enter_ring` was ring-mechanics jargon, and nothing distinguished a first rollout from an update displacing an older version. Since the plan-file diff is exactly what a promotion PR reviewer stares at, the file itself should read as the review record.

## Changes
- **BREAKING: Action vocabulary unified to two types, one per Intune entry** — `promote` moves a release one ring forward (`from_ring: null` marks a first rollout) and `assign` points new installs at it, replacing `enter_ring`, `advance_ring`, and `assign_install`. Both ring actions performed the same Graph operation and could never co-occur, so one verb describes them honestly; `assign` is the term Intune admins already use.
- **BREAKING: Plan files are self-describing** — each action carries `summary` (deterministic plain-English sentence), `entry` (`install`/`update`), and `replaces` (the version the action displaces, or null). The field is deliberately named `replaces`, not `supersedes`, to avoid implying Intune Win32 supersedence (which NAPT does not use).
- `app_id` and `name` are written once at the file top level; `load_plan_file` re-injects them, so in-memory actions are unchanged.
- Serialization drops `sort_keys` for a fixed reading-order key layout (`summary` first, `sha256` last) — still byte-deterministic.
- Internal code matches the file vocabulary: applier handlers renamed (`_apply_promote` / `_apply_assign`), docstrings, help text, and log-visible wording updated.
- `napt promote plan` / `apply` console output prints each action's own `summary`, so console and plan files can never disagree.
- Docs: user-guide gains an annotated plan-file example; common-tasks and changelog updated.

## Testing
- [x] Unit tests added/updated (727 passing: new coverage for `summary`/`entry`/`replaces` fields, reading-order serialization, top-level identity hoisting and re-injection, foreign-action rejection)
- [ ] Integration tests added/updated (not applicable — no network-facing behavior changed)
- [x] Manual testing performed (napt-reviewer pass; live validation follows in napt-gitops-test once merged)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors