### PR TITLE
chore: Prepare release 0.9.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,9 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Plan actions now carry reviewer context: the app's display name,
         and for ring advancement, when the release entered the ring it is
         leaving and that ring's bake threshold
-    - Migration: none needed for state — plans are transient. Update
-        promotion workflows to watch `state/plans/**` instead of
-        `state/plan.json` (see the reference workflows in Common Tasks)
+    - The reference workflows in Common Tasks watch `state/plans/**`
 - **BREAKING: Plan files read at a glance** - Every planned action now
     opens with a plain-English `summary` sentence and names the Intune
     `entry` it touches (`install` or `update`) and the version it
@@ -35,28 +33,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         release one ring forward (`from_ring: null` marks a first
         rollout) and `assign` points new installs at it — replacing
         `enter_ring`, `advance_ring`, and `assign_install`
-    - The displaced version is deliberately called `displaces`, not
-        "replaces" or "supersedes": the displaced release loses the
-        assignment but stays in Intune for rollback per
-        `deployment.retain_versions`, and NAPT does not use Intune's
-        Win32 supersedence feature
+    - `displaces` means the older release loses the assignment but stays
+        in Intune for rollback per `deployment.retain_versions` — NAPT
+        never uses Intune's Win32 supersedence feature
     - `napt promote plan` and `apply` print the same summary sentences,
         so console output and plan files never disagree
-- **BREAKING: Deployment state files read at a glance** - The same
-    treatment as plan files, applied to the publish PR's review surface
+- **BREAKING: Deployment state files read at a glance** -
+    `state/deployment/<app-id>.json` now reads top-to-bottom as the
+    publish PR's review record
     - `deployed` is renamed `published`: publishing uploads a release to
         Intune without assigning it, and `napt promote` deploys it
-        through the rings afterwards — `pending` to `published` is the
-        publish verb's lifecycle
+        through the rings afterwards
     - Each file names its app once at the top: `app_id` (stamped from
         the filename; a copied or renamed state file is now rejected)
         and the recipe's display `name`, refreshed on every save
     - Keys follow reading order — lifecycle order at the top level,
         `version` first and hashes last inside blocks — instead of
         alphabetical
-    - Migration: add `"published"` (renamed from `"deployed"`) to
-        existing state files, or let the next writeback rewrite them;
-        the schema version is unchanged
 - **Reviewer-friendly GitOps PRs** - The reference workflows in Common
     Tasks now generate the review surface instead of one-line PRs
     - Publish PRs are titled `Publish <Name> <version>` with a fact
@@ -69,9 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         final ring is targeted
     - Titles and bodies regenerate on every refresh, so a superseding
         release never leaves a stale decision under review
-    - The promotion PR branch is now `napt/promote-plan` (matching
-        `napt promote plan`); delete a lingering `napt/promotion-plan`
-        branch when updating existing workflows
+    - The promotion PR branch is now `napt/promote-plan`, matching the
+        `napt promote plan` command
 - **Graph API calls retry transient failures** - Throttling (HTTP
     429/503/509, honoring Retry-After) and transient server or
     connection errors now retry with bounded exponential backoff across

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-20
+
 ### Changed
 
 - **BREAKING: Per-app promotion plans** - `napt promote plan` now writes
@@ -492,6 +494,7 @@ Initial internal release.
 
 
 [Unreleased]: https://github.com/RogerCibrian/notapkgtool/compare/0.7.0...HEAD
+[0.9.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/RogerCibrian/notapkgtool/compare/0.5.1...0.6.0

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -44,7 +44,7 @@ For full CLI documentation:
 For more details, see the individual module docstrings.
 """
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -72,8 +72,8 @@ __all__ = [
 # Deterministic ordering of action types within one app's actions.
 _ACTION_ORDER = {"assign": 0, "promote": 1}
 
-# Schema version written to every plan file. Bump only with a migration
-# story: promote apply rejects plans stamped with a different version.
+# Schema version written to every plan file. Promote apply rejects
+# plans stamped with a different version.
 PLAN_SCHEMA_VERSION = 1
 
 

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -78,8 +78,8 @@ from typing import Any
 
 from napt.exceptions import StateError
 
-# Schema version written to every deployment state file. Bump only with
-# a migration story: loaders reject files stamped with a different version.
+# Schema version written to every deployment state file. Loaders reject
+# files stamped with a different version.
 DEPLOYMENT_STATE_SCHEMA_VERSION = 1
 
 # Reading order for serialization: identity, then the release lifecycle.
@@ -196,9 +196,7 @@ def load_deployment_state(state_path: Path) -> dict[str, Any]:
         raise StateError(
             f"Unsupported deployment state schema version {found!r} in "
             f"{state_path} (this NAPT release supports version "
-            f"{DEPLOYMENT_STATE_SCHEMA_VERSION}). Files from earlier "
-            f'pre-releases need "schemaVersion": '
-            f"{DEPLOYMENT_STATE_SCHEMA_VERSION} added."
+            f"{DEPLOYMENT_STATE_SCHEMA_VERSION})."
         )
 
     declared = state.get("app_id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napt"
-version = "0.8.0"
+version = "0.9.0"
 description = "Automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description
Release PR for NAPT 0.9.0. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[0.9.0] - 2026-07-20`, and adds a fresh empty `[Unreleased]` section.

## Motivation
Cuts the 0.9.0 release: the readable-GitOps arc (per-app promotion plans, self-describing plan and state files, reviewer-friendly PR generation) plus Graph API retry hardening, all live-validated end to end in the GitOps test bed.

## Changes
- Bump `pyproject.toml` version to 0.9.0
- Bump `napt/__init__.py` `__version__` to 0.9.0
- Promote `[Unreleased]` to `[0.9.0] - 2026-07-20` in `docs/changelog.md`, covering:
    - BREAKING: per-app promotion plans (`state/plans/<app-id>.json`) with per-app failure isolation
    - BREAKING: self-describing plan files (`summary`, `entry`, `displaces`, reading-order keys, `promote`/`assign` vocabulary)
    - BREAKING: self-describing deployment state files (`deployed` renamed `published`, top-level `app_id`/`name`, reading-order keys)
    - Reviewer-friendly reference workflows (generated publish PR titles/fact sheets, promotion PR risk line + summaries + drift + `promotes-to-production` label, `napt/promote-plan` branch)
    - Graph API transient-failure retries (throttling-aware, create-safe, `client-request-id`), shared retrying session for all remaining HTTP
- Add comparison link `[0.9.0]: ...compare/0.8.0...0.9.0`

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (full `pytest tests/`: 745 passed)
- [x] Manual testing performed (n/a - release prep only, no code changes)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated (changelog promoted)
- [x] Tests pass
- [x] No linting errors