### PR TITLE
feat: Replace device code auth with napt auth login

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -282,7 +282,7 @@ Examples:
 **Prefixes:** The prefix names the pipeline stage the message belongs to
 (`DISCOVERY`, `BUILD`, `PACKAGE`, `UPLOAD`, `PROMOTE`, `INIT`). Shared
 infrastructure modules log under their domain instead — `HTTP` for
-transport (requests, retries), `FILE`, `CACHE`, `CONFIG`, `STATE`,
+transport (requests, retries), `AUTH`, `FILE`, `CACHE`, `CONFIG`, `STATE`,
 `DETECTION` — so the same module reads consistently regardless of which
 stage called it. Don't invent a new prefix when a message fits an
 existing one.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`napt auth login` / `status` / `logout`** - Sign in to Microsoft Graph
+    once and let every later command authenticate silently
+    - `login` opens the Windows/macOS account picker (Web Account Manager /
+        Company Portal) when available, otherwise the browser; `--no-broker`
+        forces the browser
+    - The client and tenant IDs given to the first `login` are remembered;
+        `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` still override them
+    - `status` shows which credential NAPT would use, the account, tenant,
+        expiry, and Graph permissions it carries, and exits 1 naming any
+        required permission that is missing
+    - Tokens are cached in the OS credential store (DPAPI, Keychain,
+        libsecret), never in plain files
+- **OIDC federation for CI/CD** - `AZURE_FEDERATED_TOKEN_FILE` (as set by
+    GitHub Actions `azure/login`) is now honored, so pipelines can run
+    without a client secret; documented as the recommended CI/CD setup
+
+### Changed
+
+- **BREAKING: Device code flow removed** - Interactive sign-in is now
+    `napt auth login` (authorization code + PKCE, or the OS broker). Device
+    code is the flow most often abused to bypass MFA and is increasingly
+    blocked by Microsoft-managed Conditional Access policies
+    - App registrations need the `http://localhost` and
+        `ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>` redirect URIs
+        under **Mobile and desktop applications**; "Allow public client
+        flows" is no longer required
+    - `napt upload` and `napt promote` never open a browser; without a
+        credential they fail with `Not authenticated. Run 'napt auth login'`
+- **BREAKING: Managed identity removed** - `ManagedIdentityCredential` is
+    no longer tried; use a service principal or OIDC federation
+- Removed the unused `--tenant-id` option from `napt upload`
+
 ## [0.9.0] - 2026-07-20
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         Company Portal) when available, otherwise the browser; `--no-broker`
         forces the browser
     - The client and tenant IDs given to the first `login` are remembered;
-        `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` still override them
+        `AZURE_*` environment variables are for CI/CD credentials only and
+        no longer configure interactive sign-in
     - `status` shows which credential NAPT would use, the account, tenant,
         expiry, and Graph permissions it carries, and exits 1 naming any
         required permission that is missing

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,8 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     blocked by Microsoft-managed Conditional Access policies
     - App registrations need the `http://localhost` and
         `ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>` redirect URIs
-        under **Mobile and desktop applications**; set "Allow public client
-        flows" to No
+        under **Mobile and desktop applications**
+    - "Allow public client flows" is no longer needed; registrations set
+        to **Yes** for earlier NAPT versions can go back to the default
+        **No**, which blocks device code against the app
     - `napt upload` and `napt promote` never open a browser; without a
         credential they fail with `Not authenticated. Run 'napt auth login'`
 - **BREAKING: Managed identity removed** - `ManagedIdentityCredential` is

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`napt auth login` / `status` / `logout`** - Sign in to Microsoft Graph
     once and let every later command authenticate silently
-    - `login` opens the Windows/macOS account picker (Web Account Manager /
-        Company Portal) when available, otherwise the browser; `--no-broker`
-        forces the browser
+    - `login` opens the Windows account picker (Web Account Manager) when
+        available, otherwise the browser; `--no-broker` forces the browser
     - The client and tenant IDs given to the first `login` are remembered;
         `AZURE_*` environment variables are for CI/CD credentials only and
         no longer configure interactive sign-in
@@ -37,8 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     blocked by Microsoft-managed Conditional Access policies
     - App registrations need the `http://localhost` and
         `ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>` redirect URIs
-        under **Mobile and desktop applications**; "Allow public client
-        flows" is no longer required
+        under **Mobile and desktop applications**; set "Allow public client
+        flows" to No
     - `napt upload` and `napt promote` never open a browser; without a
         credential they fail with `Not authenticated. Run 'napt auth login'`
 - **BREAKING: Managed identity removed** - `ManagedIdentityCredential` is

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `status` shows which credential NAPT would use, the account, tenant,
         expiry, and Graph permissions it carries, and exits 1 naming any
         required permission that is missing
+    - Multiple tenants are remembered; `login --tenant-id <id>` switches
+        between signed-in tenants without a prompt, and `logout --all`
+        clears them all
     - Tokens are cached in the OS credential store (DPAPI, Keychain,
         libsecret), never in plain files
 - **OIDC federation for CI/CD** - `AZURE_FEDERATED_TOKEN_FILE` (as set by

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -498,11 +498,10 @@ admin consent, and add the `http://localhost` and
 Sign in once with the IDs from the app registration:
 
 ```bash
-napt auth login --client-id "<Application (client) ID>" --tenant-id "<Directory (tenant) ID>"
+napt auth login --tenant-id "<Directory (tenant) ID>" --client-id "<Application (client) ID>"
 ```
 
-On Windows and macOS the OS account picker opens; elsewhere your browser
-does.
+On Windows the OS account picker opens; elsewhere your browser does.
 The IDs are remembered, so later sessions are just `napt auth login`, and
 `napt upload` / `napt promote` run silently until the session expires.
 `napt auth status` shows the account, tenant, and permissions in use;

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -485,41 +485,38 @@ Upload a packaged app to Microsoft Intune. Requires `napt package` to have run f
 
 ### App Registration Setup (one time per organization)
 
-1. Go to [entra.microsoft.com](https://entra.microsoft.com) →
-   **App registrations** → **New registration**
-2. Name it (e.g. "NAPT"), leave redirect URI blank, click **Register**
-3. Note the **Application (client) ID** and **Directory (tenant) ID**
-4. Go to **API permissions** → **Add a permission** →
-   **Microsoft Graph** → **Application permissions**
-5. Search for and add `DeviceManagementApps.ReadWrite.All`
-6. Repeat for **Delegated permissions** → add `DeviceManagementApps.ReadWrite.All`
-7. Click **Grant admin consent**
-8. Go to **Authentication** → **Advanced settings** →
-   set **Allow public client flows** to **Yes** → click **Save**
-   (required for device code flow)
+Follow [App Registration Setup](user-guide.md#app-registration-setup) in the
+user guide.
+In short: register an app, add `DeviceManagementApps.ReadWrite.All` and
+`Group.Read.All` as both application and delegated Graph permissions, grant
+admin consent, and add the `http://localhost` and
+`ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>` redirect URIs under
+**Mobile and desktop applications**.
 
 ### Developer Setup (one time)
 
-Set two environment variables using the IDs from app registration setup:
+Sign in once with the IDs from the app registration:
 
 ```bash
-export AZURE_CLIENT_ID="<Application (client) ID>"
-export AZURE_TENANT_ID="<Directory (tenant) ID>"
+napt auth login --client-id "<Application (client) ID>" --tenant-id "<Directory (tenant) ID>"
 ```
 
-On first run, NAPT prompts for authentication in the browser:
-
-```console
-To sign in, use a web browser to open the page https://microsoft.com/devicelogin
-and enter the code ABCD1234 to authenticate.
-```
-
-After consenting once, subsequent runs authenticate silently.
+On Windows and macOS the OS account picker opens; elsewhere your browser
+does.
+The IDs are remembered, so later sessions are just `napt auth login`, and
+`napt upload` / `napt promote` run silently until the session expires.
+`napt auth status` shows the account, tenant, and permissions in use;
+`napt auth logout` clears the session.
 
 ### CI/CD Setup (one time)
 
-Create a client secret: **Certificates & secrets** → **New client secret**.
-Add all three as pipeline secrets:
+Prefer OIDC federation when your platform supports it (GitHub Actions does):
+add a federated credential to the app registration and let `azure/login`
+mint the token — no secret to store or rotate.
+See [CI/CD setup — OIDC federation](user-guide.md#app-registration-setup).
+
+Otherwise create a client secret (**Certificates & secrets** → **New client
+secret**) and add all three as pipeline secrets:
 
 ```bash
 AZURE_CLIENT_ID="<Application (client) ID>"
@@ -579,10 +576,27 @@ napt upload recipes/Google/chrome.yaml
 
 ### CI/CD Setup
 
-Set these environment variables in your CI/CD pipeline:
+With OIDC federation (recommended):
 
 ```yaml
 # GitHub Actions example
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: azure/login@v2
+    with:
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      allow-no-subscriptions: true
+  - name: Upload to Intune
+    run: napt upload recipes/Google/chrome.yaml
+```
+
+With a client secret:
+
+```yaml
 - name: Upload to Intune
   env:
     AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -591,8 +605,8 @@ Set these environment variables in your CI/CD pipeline:
   run: napt upload recipes/Google/chrome.yaml
 ```
 
-The app registration must have the `DeviceManagementApps.ReadWrite.All`
-Microsoft Graph API permission.
+The app registration must have the `DeviceManagementApps.ReadWrite.All` and
+`Group.Read.All` Microsoft Graph application permissions.
 
 ### Override Publisher and Description
 
@@ -867,8 +881,10 @@ Two consequences to set up once:
   token with bypass rights.
 - `[skip ci]` keeps the writeback from re-triggering workflows.
 
-**Secrets.** `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and
-`AZURE_TENANT_ID` for the app registration
+**Secrets.** `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` for the app
+registration, plus either a federated credential (OIDC, recommended — swap
+the `env:` block in the examples below for an `azure/login` step) or
+`AZURE_CLIENT_SECRET`
 (see [App Registration Setup](user-guide.md#app-registration-setup)).
 
 **Recommended org.yaml hardening:**

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,7 +247,7 @@ Graph API. Run `napt package` before uploading.
    so what was recorded at discovery is byte-for-byte what ships.
    When no pending release is recorded, the upload proceeds with a warning,
    or fails when `deployment.require_pending` is enabled
-2. **Authenticate** - Tries three credential methods in order (see [Authentication](#authentication) below)
+2. **Authenticate** - Uses the CI/CD environment credential or the session from `napt auth login` (see [Authentication](#authentication) below)
 3. **Parse Package Metadata** - Reads encryption metadata from `Detection.xml` inside the `.intunewin` ZIP
 4–6. **Create, Upload, Commit (install entry)** - Creates the Win32 app record
    using the base app name and detection script only, uploads the encrypted
@@ -287,56 +287,119 @@ corresponding entry is not created
 
 #### Authentication
 
-`napt upload` requires a NAPT app registration in Microsoft Entra ID.
-See [App Registration Setup](#app-registration-setup) below.
-The authentication method is selected automatically based on environment
-variables:
+`napt upload`, `napt promote apply`, and `napt promote plan --reconcile`/`--check-drift`
+all need a Microsoft Graph token.
+NAPT resolves it the same way every time — `napt auth status` shows which
+source it picked:
 
 | Method | When it's used |
 |--------|---------------|
-| `EnvironmentCredential` | `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID` are set — service principal, recommended for CI/CD |
-| `ManagedIdentityCredential` | Running on an Azure VM, Container Instance, or pipeline agent with managed identity assigned — no env vars needed |
-| `DeviceCodeCredential` | `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` are set (no secret), interactive terminal — prompts with a URL and code to authenticate in any browser |
+| Service principal (`EnvironmentCredential`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` (or `AZURE_CLIENT_CERTIFICATE_PATH`) are set — CI/CD |
+| Workload identity federation (`WorkloadIdentityCredential`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE` are set — CI/CD with OIDC, e.g. GitHub Actions `azure/login`. Recommended over a client secret whenever your CI platform supports it |
+| Interactive session (`napt auth login`) | Nothing above is set and you have signed in on this machine — developers |
+
+NAPT never opens a browser on its own.
+If no credential is available, commands fail with
+`Not authenticated. Run 'napt auth login'`.
+This mirrors `az`/`gh`: sign in explicitly once, then everything else is
+silent.
+
+Device code flow is not supported.
+It is the flow most often abused to bypass MFA, and Microsoft-managed
+Conditional Access policies increasingly block it tenant-wide.
 
 #### App Registration Setup
 
-Create the app registration once per organization:
+Create the app registration once per organization.
+Two ways to do it:
+
+**Manual (Entra portal):**
 
 1. Go to [entra.microsoft.com](https://entra.microsoft.com) →
    **App registrations** → **New registration**
 2. Name it (e.g. "NAPT"), leave redirect URI blank, click **Register**
 3. Note the **Application (client) ID** and **Directory (tenant) ID**
 4. Go to **API permissions** → **Add a permission** →
-   **Microsoft Graph** → **Application permissions**
-5. Search for and add `DeviceManagementApps.ReadWrite.All`
-6. Also add `Group.Read.All` (application permission) — used to resolve
-   Entra ID group names in `deployment:` configuration to object IDs
-7. Also add the **Delegated** versions of both permissions
-   (for interactive device code auth)
-8. Click **Grant admin consent**
-9. Go to **Authentication** → **Advanced settings** →
-   set **Allow public client flows** to **Yes** → click **Save**
-   (required for device code flow)
+   **Microsoft Graph** → **Application permissions** → add
+   `DeviceManagementApps.ReadWrite.All` and `Group.Read.All`
+   (used by CI/CD; `Group.Read.All` resolves Entra ID group names in
+   `deployment:` configuration to object IDs)
+5. Repeat for **Delegated permissions** → add the same two
+   (used by interactive sign-in)
+6. Click **Grant admin consent**
+7. Go to **Authentication** → **Add a platform** →
+   **Mobile and desktop applications** and add these redirect URIs:
+    - `http://localhost` (browser sign-in)
+    - `ms-appx-web://Microsoft.AAD.BrokerPlugin/<Application (client) ID>`
+      (Windows broker sign-in)
+8. Leave **Allow public client flows** at **No** — NAPT does not use device
+   code flow
+
+**Automatic (`napt auth setup`):** planned for a later release — it will
+create the registration above through Graph, which needs an account holding
+the Application Administrator (or Global Administrator) role.
+Until then, use the manual steps.
 
 **Developer setup:**
 
-Set two environment variables — no client secret needed:
+Sign in once; the client and tenant IDs are remembered for later logins:
 
 ```bash
-export AZURE_CLIENT_ID="<Application (client) ID>"
-export AZURE_TENANT_ID="<Directory (tenant) ID>"
+napt auth login --client-id "<Application (client) ID>" --tenant-id "<Directory (tenant) ID>"
 ```
 
-On first run, NAPT prompts with a device code:
+On Windows and macOS this opens the OS account picker (Web Account
+Manager / Company Portal), signing you in with your work account and
+honoring device-based Conditional Access.
+Elsewhere — or with `--no-broker` — it opens your browser.
+Tokens are cached in the OS credential store (DPAPI, Keychain, or
+libsecret) and refreshed silently until the session expires or is revoked.
+`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` environment variables override the
+remembered IDs.
+
+Check what you are holding at any time:
 
 ```console
-To sign in, use a web browser to open the page https://microsoft.com/devicelogin
-and enter the code ABCD1234 to authenticate.
+$ napt auth status
+Method:      interactive (broker)
+Account:     admin@contoso.com
+Tenant:      00000000-0000-0000-0000-000000000000
+Client ID:   11111111-1111-1111-1111-111111111111
+Expires:     2026-08-16T19:04:11+00:00
+Permissions: DeviceManagementApps.ReadWrite.All, Group.Read.All
 ```
 
-After consenting once, subsequent runs authenticate silently.
+`napt auth status` exits 1 when no credential is available or a required
+permission is missing, and names the missing permission.
+`napt auth logout` removes the cached session.
 
-**CI/CD setup:**
+**CI/CD setup — OIDC federation (recommended):**
+
+No secret to store or rotate.
+In the app registration, go to **Certificates & secrets** →
+**Federated credentials** → **Add credential** → **GitHub Actions deploying
+Azure resources**, and enter your organization, repository, and the entity
+(branch, environment, or tag) the workflow runs as.
+Then let `azure/login` mint the federated token before NAPT runs:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: azure/login@v2
+    with:
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      allow-no-subscriptions: true
+  - run: napt upload recipes/Google/chrome.yaml
+```
+
+`azure/login` exports `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and
+`AZURE_FEDERATED_TOKEN_FILE`; NAPT picks them up automatically.
+
+**CI/CD setup — client secret:**
 
 Create a client secret under **Certificates & secrets** → **New client secret**.
 Set all three environment variables as pipeline secrets:
@@ -347,10 +410,8 @@ AZURE_CLIENT_SECRET="<client secret value>"
 AZURE_TENANT_ID="<Directory (tenant) ID>"
 ```
 
-**Azure managed identity:**
-
-No environment variables needed. Assign the managed identity the
-`DeviceManagementApps.ReadWrite.All` application permission in Entra ID.
+A certificate works the same way with `AZURE_CLIENT_CERTIFICATE_PATH`
+instead of `AZURE_CLIENT_SECRET`.
 
 ### Directory Structure
 
@@ -525,10 +586,22 @@ napt status [OPTIONS]
 ### napt upload
 
 Uploads the `.intunewin` package to Microsoft Intune via the Graph API.
-Authentication is automatic — no configuration required.
+Uses the CI/CD environment credential when set, otherwise the session from
+`napt auth login`.
 
 ```bash
 napt upload recipes/Google/chrome.yaml [OPTIONS]
+```
+
+### napt auth
+
+Manages the credential NAPT uses for Intune.
+See [Authentication](#authentication).
+
+```bash
+napt auth login [--client-id ID] [--tenant-id ID] [--no-broker]
+napt auth status
+napt auth logout
 ```
 
 ### Output Modes

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -354,8 +354,10 @@ honoring device-based Conditional Access.
 Elsewhere — or with `--no-broker` — it opens your browser.
 Tokens are cached in the OS credential store (DPAPI, Keychain, or
 libsecret) and refreshed silently until the session expires or is revoked.
-`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` environment variables override the
-remembered IDs.
+The `AZURE_*` environment variables play no part in interactive sign-in;
+they are how CI/CD supplies a credential (below), and when they are set
+they take precedence over your session — the same rule `gh` (`GH_TOKEN`)
+and `aws` (`AWS_ACCESS_KEY_ID`) follow.
 
 Check what you are holding at any time:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -369,8 +369,17 @@ Tenant:      00000000-0000-0000-0000-000000000000
 Client ID:   11111111-1111-1111-1111-111111111111
 Expires:     2026-08-16T19:04:11+00:00
 Permissions: DeviceManagementApps.ReadWrite.All, Group.Read.All
+
+Known tenants:
+  * contoso.com (Contoso)  admin@contoso.com  00000000-0000-0000-0000-000000000000  client 11111111-1111-1111-1111-111111111111
+  (* = active; switch with 'napt auth login --tenant-id <id>')
 ```
 
+The tenant's default domain and display name are looked up once at login
+through the delegated `User.Read` permission, which new app registrations
+carry by default.
+Without it the tenant is listed as `(name unknown)` — sign-in itself is
+unaffected.
 `napt auth status` exits 1 when no credential is available or a required
 permission is missing, and names the missing permission.
 `napt auth logout` signs out of the active tenant (`--all` for every tenant);

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -332,11 +332,6 @@ Two ways to do it:
     - `http://localhost` (browser sign-in)
     - `ms-appx-web://Microsoft.AAD.BrokerPlugin/<Application (client) ID>`
       (Windows broker sign-in)
-8. Under **Advanced settings**, set **Allow public client flows** to **No**
-   and save.
-   NAPT does not use device code flow, and leaving it enabled lets device
-   code be used against this app registration.
-   Registrations created for earlier NAPT versions have it set to **Yes**.
 
 **Automatic (`napt auth setup`):** planned for a later release — it will
 create the registration above through Graph, which needs an account holding

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -332,8 +332,11 @@ Two ways to do it:
     - `http://localhost` (browser sign-in)
     - `ms-appx-web://Microsoft.AAD.BrokerPlugin/<Application (client) ID>`
       (Windows broker sign-in)
-8. Leave **Allow public client flows** at **No** — NAPT does not use device
-   code flow
+8. Under **Advanced settings**, set **Allow public client flows** to **No**
+   and save.
+   NAPT does not use device code flow, and leaving it enabled lets device
+   code be used against this app registration.
+   Registrations created for earlier NAPT versions have it set to **Yes**.
 
 **Automatic (`napt auth setup`):** planned for a later release — it will
 create the registration above through Graph, which needs an account holding
@@ -345,13 +348,15 @@ Until then, use the manual steps.
 Sign in once; the client and tenant IDs are remembered for later logins:
 
 ```bash
-napt auth login --client-id "<Application (client) ID>" --tenant-id "<Directory (tenant) ID>"
+napt auth login --tenant-id "<Directory (tenant) ID>" --client-id "<Application (client) ID>"
 ```
 
-On Windows and macOS this opens the OS account picker (Web Account
-Manager / Company Portal), signing you in with your work account and
-honoring device-based Conditional Access.
+On Windows this opens the OS account picker (Web Account Manager),
+signing you in with your work account, honoring device-based Conditional
+Access, and keeping the refresh token device-bound.
 Elsewhere — or with `--no-broker` — it opens your browser.
+The broker needs an interactive Windows session: from a scheduled task,
+service, `runas`, or SSH session, use a service principal or OIDC instead.
 Tokens are cached in the OS credential store (DPAPI, Keychain, or
 libsecret) and refreshed silently until the session expires or is revoked.
 The `AZURE_*` environment variables play no part in interactive sign-in;
@@ -385,7 +390,7 @@ Switch with just the tenant ID — no prompt as long as that tenant's session
 is still valid:
 
 ```bash
-napt auth login --client-id "<prod client ID>" --tenant-id "<prod tenant ID>"   # first time
+napt auth login --tenant-id "<prod tenant ID>" --client-id "<prod client ID>"   # first time
 napt auth login --tenant-id "<dev tenant ID>"                                    # switch back, silent
 ```
 
@@ -615,7 +620,7 @@ Manages the credential NAPT uses for Intune.
 See [Authentication](#authentication).
 
 ```bash
-napt auth login [--client-id ID] [--tenant-id ID] [--no-broker]
+napt auth login [--tenant-id ID] [--client-id ID] [--no-broker]
 napt auth status
 napt auth logout
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -373,7 +373,21 @@ Permissions: DeviceManagementApps.ReadWrite.All, Group.Read.All
 
 `napt auth status` exits 1 when no credential is available or a required
 permission is missing, and names the missing permission.
-`napt auth logout` removes the cached session.
+`napt auth logout` signs out of the active tenant (`--all` for every tenant);
+the IDs stay remembered.
+
+**Multiple tenants:**
+
+Sign in to each tenant once with its own client ID.
+NAPT remembers every tenant you have signed in to and which one is active;
+`napt auth status` lists them.
+Switch with just the tenant ID — no prompt as long as that tenant's session
+is still valid:
+
+```bash
+napt auth login --client-id "<prod client ID>" --tenant-id "<prod tenant ID>"   # first time
+napt auth login --tenant-id "<dev tenant ID>"                                    # switch back, silent
+```
 
 **CI/CD setup — OIDC federation (recommended):**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -354,6 +354,9 @@ The broker needs an interactive Windows session: from a scheduled task,
 service, `runas`, or SSH session, use a service principal or OIDC instead.
 Tokens are cached in the OS credential store (DPAPI, Keychain, or
 libsecret) and refreshed silently until the session expires or is revoked.
+The remembered tenants and the cache live under `%LOCALAPPDATA%\napt`
+(Windows), `~/Library/Application Support/napt` (macOS), or
+`~/.config/napt` (Linux); set `NAPT_USER_DIR` to relocate them.
 The `AZURE_*` environment variables play no part in interactive sign-in;
 they are how CI/CD supplies a credential (below), and when they are set
 they take precedence over your session — the same rule `gh` (`GH_TOKEN`)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -371,8 +371,15 @@ Expires:     2026-08-16T19:04:11+00:00
 Permissions: DeviceManagementApps.ReadWrite.All, Group.Read.All
 
 Known tenants:
-  * contoso.com (Contoso)  admin@contoso.com  00000000-0000-0000-0000-000000000000  client 11111111-1111-1111-1111-111111111111
-  (* = active; switch with 'napt auth login --tenant-id <id>')
+  * Contoso (contoso.com)
+      Account:   admin@contoso.com
+      Tenant ID: 00000000-0000-0000-0000-000000000000
+      Client ID: 11111111-1111-1111-1111-111111111111
+    Contoso Dev (contosodev.onmicrosoft.com)
+      Account:   (signed out)
+      Tenant ID: 22222222-2222-2222-2222-222222222222
+      Client ID: 33333333-3333-3333-3333-333333333333
+  (* = active; switch with 'napt auth login --tenant-id <id or domain>')
 ```
 
 The tenant's default domain and display name are looked up once at login
@@ -390,12 +397,12 @@ the IDs stay remembered.
 Sign in to each tenant once with its own client ID.
 NAPT remembers every tenant you have signed in to and which one is active;
 `napt auth status` lists them.
-Switch with just the tenant ID — no prompt as long as that tenant's session
-is still valid:
+Switch with just the tenant ID — or its default domain, once known — with
+no prompt as long as that tenant's session is still valid:
 
 ```bash
 napt auth login --tenant-id "<prod tenant ID>" --client-id "<prod client ID>"   # first time
-napt auth login --tenant-id "<dev tenant ID>"                                    # switch back, silent
+napt auth login --tenant-id contosodev.onmicrosoft.com                           # switch back, silent
 ```
 
 **CI/CD setup — OIDC federation (recommended):**

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1588,7 +1588,7 @@ def main() -> None:
         description=(
             "Manage the credential NAPT uses for Intune.\n\n"
             "Examples:\n"
-            "  napt auth login --client-id <id> --tenant-id <id>\n"
+            "  napt auth login --tenant-id <id> --client-id <id>\n"
             "  napt auth login\n"
             "  napt auth status\n"
             "  napt auth logout\n\n"
@@ -1607,7 +1607,7 @@ def main() -> None:
         help="Sign in interactively (browser or OS broker)",
         description=(
             "Sign in interactively and cache the session so later commands\n"
-            "authenticate silently. Uses the Windows/macOS broker when\n"
+            "authenticate silently. Uses the Windows broker (WAM) when\n"
             "available, otherwise the system browser.\n\n"
             "The tenant, client ID, and account are remembered after the first\n"
             "login. Pass --tenant-id to switch between signed-in tenants (no\n"
@@ -1616,14 +1616,17 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser_auth_login.add_argument(
-        "--client-id",
-        default=None,
-        help="Application (client) ID of the NAPT app registration",
-    )
-    parser_auth_login.add_argument(
         "--tenant-id",
         default=None,
         help="Directory (tenant) ID (defaults to the active tenant)",
+    )
+    parser_auth_login.add_argument(
+        "--client-id",
+        default=None,
+        help=(
+            "Application (client) ID of the NAPT app registration "
+            "(needed the first time you sign in to a tenant)"
+        ),
     )
     parser_auth_login.add_argument(
         "--no-broker",

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -117,6 +117,7 @@ from napt.upload.auth import (
     AuthStatus,
     get_access_token,
     get_status as auth_status,
+    load_auth_store,
     login as auth_login,
     logout as auth_logout,
 )
@@ -997,6 +998,23 @@ def _print_auth_status(status: AuthStatus) -> None:
         )
 
 
+def _print_known_tenants() -> None:
+    """Lists tenants remembered by 'napt auth login', marking the active one."""
+    try:
+        store = load_auth_store()
+    except ConfigError:
+        return
+    if not store.tenants:
+        return
+    print()
+    print("Known tenants:")
+    for tenant_id, cfg in store.tenants.items():
+        marker = "*" if tenant_id == store.active else " "
+        who = cfg.username or "(signed out)"
+        print(f"  {marker} {tenant_id}  {who}  client {cfg.client_id}")
+    print("  (* = active; switch with 'napt auth login --tenant-id <id>')")
+
+
 def cmd_auth_login(args: argparse.Namespace) -> int:
     """Handler for 'napt auth login' command.
 
@@ -1038,11 +1056,12 @@ def cmd_auth_login(args: argparse.Namespace) -> int:
 def cmd_auth_logout(args: argparse.Namespace) -> int:
     """Handler for 'napt auth logout' command.
 
-    Removes the cached interactive session. The saved client and tenant IDs
-    are kept for the next login.
+    Removes the active tenant's cached session, or every tenant's with
+    --all. Client and tenant IDs are kept for the next login.
 
     Args:
-        args: Parsed command-line arguments containing debug flags.
+        args: Parsed command-line arguments containing the --all flag and
+            debug flags.
 
     Returns:
         Exit code (0 for success, 1 for failure).
@@ -1052,7 +1071,7 @@ def cmd_auth_logout(args: argparse.Namespace) -> int:
     set_global_logger(logger)
 
     try:
-        removed = auth_logout()
+        removed = auth_logout(all_tenants=args.all)
     except (AuthError, ConfigError) as err:
         print(f"Authentication error: {err}")
         if args.verbose or args.debug:
@@ -1062,7 +1081,10 @@ def cmd_auth_logout(args: argparse.Namespace) -> int:
         return 1
 
     if removed:
-        print("[OK] Signed out. Run 'napt auth login' to sign in again.")
+        print(
+            f"[OK] Signed out of {len(removed)} tenant(s): {', '.join(removed)}. "
+            "Run 'napt auth login' to sign in again."
+        )
     else:
         print("No interactive session to sign out of.")
     return 0
@@ -1101,9 +1123,12 @@ def cmd_auth_status(args: argparse.Namespace) -> int:
         print("  CI/CD:        set AZURE_CLIENT_ID, AZURE_TENANT_ID and either")
         print("                AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH,")
         print("                or use OIDC federation")
+        _print_known_tenants()
         return 1
 
     _print_auth_status(status)
+    if status.method.startswith("interactive"):
+        _print_known_tenants()
     return 0 if not status.missing else 1
 
 
@@ -1584,7 +1609,9 @@ def main() -> None:
             "Sign in interactively and cache the session so later commands\n"
             "authenticate silently. Uses the Windows/macOS broker when\n"
             "available, otherwise the system browser.\n\n"
-            "The client and tenant IDs are remembered after the first login."
+            "The tenant, client ID, and account are remembered after the first\n"
+            "login. Pass --tenant-id to switch between signed-in tenants (no\n"
+            "prompt when that tenant's session is still valid)."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1596,7 +1623,7 @@ def main() -> None:
     parser_auth_login.add_argument(
         "--tenant-id",
         default=None,
-        help="Directory (tenant) ID",
+        help="Directory (tenant) ID (defaults to the active tenant)",
     )
     parser_auth_login.add_argument(
         "--no-broker",
@@ -1620,7 +1647,15 @@ def main() -> None:
     parser_auth_logout = auth_sub.add_parser(
         "logout",
         help="Remove the cached interactive session",
-        description="Sign out of the cached interactive session.",
+        description=(
+            "Sign out of the active tenant's cached session (or every "
+            "tenant's with --all)."
+        ),
+    )
+    parser_auth_logout.add_argument(
+        "--all",
+        action="store_true",
+        help="Sign out of every remembered tenant",
     )
     parser_auth_logout.add_argument(
         "-v",

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1008,10 +1008,22 @@ def _print_known_tenants() -> None:
         return
     print()
     print("Known tenants:")
-    for tenant_id, cfg in store.tenants.items():
-        marker = "*" if tenant_id == store.active else " "
-        who = cfg.username or "(signed out)"
-        print(f"  {marker} {tenant_id}  {who}  client {cfg.client_id}")
+    rows = [
+        (
+            "*" if tenant_id == store.active else " ",
+            cfg.label or "(name unknown)",
+            cfg.username or "(signed out)",
+            tenant_id,
+            cfg.client_id,
+        )
+        for tenant_id, cfg in store.tenants.items()
+    ]
+    widths = [max(len(row[col]) for row in rows) for col in range(1, 4)]
+    for marker, label, who, tenant_id, client_id in rows:
+        print(
+            f"  {marker} {label.ljust(widths[0])}  {who.ljust(widths[1])}  "
+            f"{tenant_id.ljust(widths[2])}  client {client_id}"
+        )
     print("  (* = active; switch with 'napt auth login --tenant-id <id>')")
 
 

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1008,23 +1008,13 @@ def _print_known_tenants() -> None:
         return
     print()
     print("Known tenants:")
-    rows = [
-        (
-            "*" if tenant_id == store.active else " ",
-            cfg.label or "(name unknown)",
-            cfg.username or "(signed out)",
-            tenant_id,
-            cfg.client_id,
-        )
-        for tenant_id, cfg in store.tenants.items()
-    ]
-    widths = [max(len(row[col]) for row in rows) for col in range(1, 4)]
-    for marker, label, who, tenant_id, client_id in rows:
-        print(
-            f"  {marker} {label.ljust(widths[0])}  {who.ljust(widths[1])}  "
-            f"{tenant_id.ljust(widths[2])}  client {client_id}"
-        )
-    print("  (* = active; switch with 'napt auth login --tenant-id <id>')")
+    for tenant_id, cfg in store.tenants.items():
+        marker = "*" if tenant_id == store.active else " "
+        print(f"  {marker} {cfg.label or '(name unknown)'}")
+        print(f"      Account:   {cfg.username or '(signed out)'}")
+        print(f"      Tenant ID: {tenant_id}")
+        print(f"      Client ID: {cfg.client_id}")
+    print("  (* = active; switch with 'napt auth login --tenant-id <id or domain>')")
 
 
 def cmd_auth_login(args: argparse.Namespace) -> int:
@@ -1630,7 +1620,10 @@ def main() -> None:
     parser_auth_login.add_argument(
         "--tenant-id",
         default=None,
-        help="Directory (tenant) ID (defaults to the active tenant)",
+        help=(
+            "Directory (tenant) ID, or the default domain of a tenant you have "
+            "signed in to before (defaults to the active tenant)"
+        ),
     )
     parser_auth_login.add_argument(
         "--client-id",

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -25,6 +25,7 @@ Commands:
     build: Build PSADT package from recipe
     package: Create .intunewin package for Intune (recipe-based)
     upload: Upload .intunewin package to Microsoft Intune
+    auth: Sign in to Microsoft Graph and inspect credentials
     promote: Plan and apply deployment ring promotion
     status: Show deployment state across all apps
 
@@ -112,7 +113,13 @@ from napt.promote import (
 )
 from napt.state import summarize_deployment_states
 from napt.upload import upload_package
-from napt.upload.auth import get_access_token
+from napt.upload.auth import (
+    AuthStatus,
+    get_access_token,
+    get_status as auth_status,
+    login as auth_login,
+    logout as auth_logout,
+)
 from napt.upload.graph import list_mobile_apps
 from napt.validation import validate_recipe
 
@@ -563,9 +570,8 @@ def cmd_upload(args: argparse.Namespace) -> int:
 
     Uploads the .intunewin package for a recipe to Microsoft Intune via the
     Graph API. Infers the package path from the recipe's app ID. Authentication
-    is automatic: tries EnvironmentCredential (AZURE_CLIENT_ID +
-    AZURE_CLIENT_SECRET + AZURE_TENANT_ID), ManagedIdentityCredential, and
-    DeviceCodeCredential (browser login) in that order.
+    uses service principal / OIDC environment variables when set, otherwise
+    the session saved by 'napt auth login'.
 
     Args:
         args: Parsed command-line arguments containing recipe path and
@@ -578,9 +584,8 @@ def cmd_upload(args: argparse.Namespace) -> int:
         Run 'napt package' before this command to create the .intunewin file.
         Re-running an upload adopts existing NAPT-stamped apps instead of
         creating duplicates; --force re-sends metadata and content to them.
-        Developers: set AZURE_CLIENT_ID and AZURE_TENANT_ID, then complete
-        the device code flow when prompted.
-        Set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID for CI/CD.
+        Developers: run 'napt auth login' once. CI/CD: set AZURE_CLIENT_ID,
+        AZURE_TENANT_ID and AZURE_CLIENT_SECRET, or use OIDC federation.
 
     """
     # Configure global logger
@@ -971,6 +976,135 @@ def cmd_status(args: argparse.Namespace) -> int:
         print("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(line)))
 
     return 0
+
+
+def _print_auth_status(status: AuthStatus) -> None:
+    """Prints one credential's status block for 'napt auth status'/'login'."""
+    print(f"Method:      {status.method}")
+    print(f"Account:     {status.account or '(unknown)'}")
+    print(f"Tenant:      {status.tenant_id or '(unknown)'}")
+    print(f"Client ID:   {status.client_id or '(unknown)'}")
+    if status.expires_at is not None:
+        print(f"Expires:     {status.expires_at.isoformat(timespec='seconds')}")
+    print(f"Permissions: {', '.join(status.permissions) or '(none)'}")
+    if status.missing:
+        print()
+        print(f"[WARNING] Missing required permissions: {', '.join(status.missing)}")
+        print(
+            "          Add them to the app registration (application permissions "
+            "for CI/CD,\n          delegated for interactive use) and grant admin "
+            "consent."
+        )
+
+
+def cmd_auth_login(args: argparse.Namespace) -> int:
+    """Handler for 'napt auth login' command.
+
+    Signs in interactively through the OS broker or the browser and caches
+    the session so later commands authenticate silently.
+
+    Args:
+        args: Parsed command-line arguments containing optional client and
+            tenant IDs and the --no-broker flag.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    try:
+        status = auth_login(
+            client_id=args.client_id,
+            tenant_id=args.tenant_id,
+            use_broker=not args.no_broker,
+        )
+    except (AuthError, ConfigError) as err:
+        print(f"Authentication error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    print()
+    print(f"[OK] Signed in as {status.account or '(unknown account)'}")
+    print()
+    _print_auth_status(status)
+    return 0
+
+
+def cmd_auth_logout(args: argparse.Namespace) -> int:
+    """Handler for 'napt auth logout' command.
+
+    Removes the cached interactive session. The saved client and tenant IDs
+    are kept for the next login.
+
+    Args:
+        args: Parsed command-line arguments containing debug flags.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    try:
+        removed = auth_logout()
+    except (AuthError, ConfigError) as err:
+        print(f"Authentication error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    if removed:
+        print("[OK] Signed out. Run 'napt auth login' to sign in again.")
+    else:
+        print("No interactive session to sign out of.")
+    return 0
+
+
+def cmd_auth_status(args: argparse.Namespace) -> int:
+    """Handler for 'napt auth status' command.
+
+    Shows which credential NAPT would use right now -- the same resolution
+    'napt upload' performs -- and flags missing Graph permissions.
+
+    Args:
+        args: Parsed command-line arguments containing debug flags.
+
+    Returns:
+        Exit code (0 when a credential is available, 1 otherwise).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    try:
+        status = auth_status()
+    except (AuthError, ConfigError) as err:
+        print(f"Authentication error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    if status is None:
+        print("Not authenticated.")
+        print()
+        print("  Interactive:  run 'napt auth login'")
+        print("  CI/CD:        set AZURE_CLIENT_ID, AZURE_TENANT_ID and either")
+        print("                AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH,")
+        print("                or use OIDC federation")
+        return 1
+
+    _print_auth_status(status)
+    return 0 if not status.missing else 1
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -1384,13 +1518,12 @@ def main() -> None:
         description=(
             "Upload the most recent .intunewin package for a recipe to "
             "Microsoft Intune via the Graph API.\n\n"
-            "Authentication is automatic — tried in this order:\n"
-            "  1. AZURE_CLIENT_ID + AZURE_CLIENT_SECRET + AZURE_TENANT_ID env vars\n"
-            "  2. Managed identity (Azure VMs, GitHub Actions OIDC)\n"
-            "  3. Device code flow (browser login — set AZURE_CLIENT_ID + AZURE_TENANT_ID)\n\n"
+            "Authentication:\n"
+            "  CI/CD:       AZURE_CLIENT_ID + AZURE_TENANT_ID + AZURE_CLIENT_SECRET,\n"
+            "               or OIDC federation (azure/login)\n"
+            "  Interactive: run 'napt auth login' once\n\n"
             "Examples:\n"
             "  napt upload recipes/Google/chrome.yaml\n"
-            "  napt upload recipes/Google/chrome.yaml --tenant-id <id>\n"
             "  napt upload recipes/Google/chrome.yaml --verbose\n\n"
             "See docs for auth setup and full configuration guide."
         ),
@@ -1399,11 +1532,6 @@ def main() -> None:
     parser_upload.add_argument(
         "recipe",
         help="Path to the recipe YAML file",
-    )
-    parser_upload.add_argument(
-        "--tenant-id",
-        default=None,
-        help="Azure AD tenant ID (overrides defaults/org.yaml)",
     )
     parser_upload.add_argument(
         "--force",
@@ -1427,6 +1555,112 @@ def main() -> None:
         help="Show detailed debugging output (implies --verbose)",
     )
     parser_upload.set_defaults(func=cmd_upload)
+
+    # 'auth' command with subcommands
+    parser_auth = subparsers.add_parser(
+        "auth",
+        help="Sign in to Microsoft Graph and inspect credentials",
+        description=(
+            "Manage the credential NAPT uses for Intune.\n\n"
+            "Examples:\n"
+            "  napt auth login --client-id <id> --tenant-id <id>\n"
+            "  napt auth login\n"
+            "  napt auth status\n"
+            "  napt auth logout\n\n"
+            "See docs for app registration setup."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    auth_sub = parser_auth.add_subparsers(
+        dest="subcommand",
+        help="Auth subcommands",
+        required=True,
+    )
+
+    parser_auth_login = auth_sub.add_parser(
+        "login",
+        help="Sign in interactively (browser or OS broker)",
+        description=(
+            "Sign in interactively and cache the session so later commands\n"
+            "authenticate silently. Uses the Windows/macOS broker when\n"
+            "available, otherwise the system browser.\n\n"
+            "The client and tenant IDs are remembered after the first login;\n"
+            "AZURE_CLIENT_ID / AZURE_TENANT_ID environment variables override them."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser_auth_login.add_argument(
+        "--client-id",
+        default=None,
+        help="Application (client) ID of the NAPT app registration",
+    )
+    parser_auth_login.add_argument(
+        "--tenant-id",
+        default=None,
+        help="Directory (tenant) ID",
+    )
+    parser_auth_login.add_argument(
+        "--no-broker",
+        action="store_true",
+        help="Use the browser even when the OS broker is available",
+    )
+    parser_auth_login.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_auth_login.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_auth_login.set_defaults(func=cmd_auth_login)
+
+    parser_auth_logout = auth_sub.add_parser(
+        "logout",
+        help="Remove the cached interactive session",
+        description="Sign out of the cached interactive session.",
+    )
+    parser_auth_logout.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_auth_logout.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_auth_logout.set_defaults(func=cmd_auth_logout)
+
+    parser_auth_status = auth_sub.add_parser(
+        "status",
+        help="Show which credential NAPT would use and its permissions",
+        description=(
+            "Show the credential NAPT would use right now (the same resolution\n"
+            "'napt upload' performs), the account and tenant it belongs to, and\n"
+            "the Graph permissions it carries. Exits 1 when no credential is\n"
+            "available or a required permission is missing."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser_auth_status.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_auth_status.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_auth_status.set_defaults(func=cmd_auth_status)
 
     # 'promote' command with subcommands
     parser_promote = subparsers.add_parser(

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1584,8 +1584,7 @@ def main() -> None:
             "Sign in interactively and cache the session so later commands\n"
             "authenticate silently. Uses the Windows/macOS broker when\n"
             "available, otherwise the system browser.\n\n"
-            "The client and tenant IDs are remembered after the first login;\n"
-            "AZURE_CLIENT_ID / AZURE_TENANT_ID environment variables override them."
+            "The client and tenant IDs are remembered after the first login."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/napt/config/defaults.py
+++ b/napt/config/defaults.py
@@ -28,9 +28,9 @@ This design ensures that NAPT works out of the box without requiring any
 configuration files, while still allowing full customization when needed.
 
 Note:
-    Authentication for 'napt upload' requires no config file. Developers set
-    AZURE_CLIENT_ID and AZURE_TENANT_ID and complete the device code flow;
-    CI/CD pipelines set all three env vars including AZURE_CLIENT_SECRET.
+    Authentication for 'napt upload' requires no config file. Developers run
+    'napt auth login' once; CI/CD pipelines set AZURE_CLIENT_ID,
+    AZURE_TENANT_ID and AZURE_CLIENT_SECRET, or use OIDC federation.
 """
 
 from __future__ import annotations

--- a/napt/exceptions.py
+++ b/napt/exceptions.py
@@ -189,11 +189,11 @@ class AuthError(NAPTError):
 
     This exception is raised when there are problems with:
 
-    - azure-identity credential chain exhausted (all credential types
-        unavailable or failed)
+    - No credential available (no service principal / OIDC environment and
+        no session from 'napt auth login')
     - Graph API 401 Unauthorized or 403 Forbidden responses
-    - Device code flow timeout or user cancellation
-    - Invalid or missing credentials for the DeviceCodeCredential fallback
+    - Interactive sign-in failure, timeout, or cancellation
+    - A cached sign-in session that can no longer be refreshed
 
     Example:
         Catching auth errors:

--- a/napt/upload/__init__.py
+++ b/napt/upload/__init__.py
@@ -17,16 +17,15 @@
 This module provides the complete upload pipeline for deploying Win32 LOB apps
 to Microsoft Intune via the Graph API.
 
-Authentication is automatic — no configuration file required:
+Authentication needs no configuration file:
 
-- Developers: set AZURE_CLIENT_ID and AZURE_TENANT_ID, then complete the device code flow in a browser (DeviceCodeCredential)
-- CI/CD: set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID (EnvironmentCredential)
-- Azure-hosted runners: assign a managed identity to the resource (ManagedIdentityCredential)
+- Developers: run `napt auth login` once (browser or OS broker); later commands use the cached session silently
+- CI/CD: set AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET (EnvironmentCredential), or use OIDC federation (WorkloadIdentityCredential)
 
 Modules:
     manager - Upload orchestration (load config, auth, upload flow).
     graph - Graph API and Azure Blob Storage HTTP calls.
-    auth - Azure credential chain via azure-identity.
+    auth - Credential resolution (azure-identity chain, MSAL interactive session).
     intunewin - .intunewin ZIP parser (reads Detection.xml encryption metadata).
 
 Example:

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -28,11 +28,13 @@ Non-interactive (CI/CD):
         CI platform supports it: no secret to store or rotate.
 
 Interactive (a person at a terminal):
-    3. A session established earlier with `napt auth login`. Tokens are
-        cached by MSAL in an OS-encrypted store (DPAPI on Windows, Keychain on
-        macOS, libsecret on Linux) and refreshed silently; the browser or
-        Windows/macOS broker is only opened by `napt auth login` itself,
-        never by `napt upload`.
+    3. The active tenant's session established earlier with
+        `napt auth login`. Tokens are cached by MSAL in an OS-encrypted store
+        (DPAPI on Windows, Keychain on macOS, libsecret on Linux) and
+        refreshed silently; the browser or Windows/macOS broker is only
+        opened by `napt auth login` itself, never by `napt upload`. Several
+        tenants can be signed in at once; `napt auth login --tenant-id`
+        switches the active one.
 
 `napt auth login` uses the authorization code flow with PKCE against a
 loopback redirect, or -- on Windows and macOS when the MSAL broker runtime is
@@ -82,12 +84,14 @@ from napt.exceptions import AuthError, ConfigError
 __all__ = [
     "AuthConfig",
     "AuthStatus",
+    "AuthStore",
     "GRAPH_SCOPES",
     "REQUIRED_PERMISSIONS",
     "get_access_token",
     "get_credential",
     "get_status",
     "load_auth_config",
+    "load_auth_store",
     "login",
     "logout",
     "resolve_auth_config",
@@ -149,15 +153,34 @@ _HINT_LOGIN_FAILED = (
 
 @dataclass(frozen=True)
 class AuthConfig:
-    """App registration used for interactive sign-in.
+    """One tenant's interactive sign-in settings.
 
     Attributes:
-        client_id: Application (client) ID of the NAPT app registration.
+        client_id: Application (client) ID of the NAPT app registration in
+            this tenant.
         tenant_id: Directory (tenant) ID the sign-in is scoped to.
+        username: Account that signed in last (UPN), or ``None`` before the
+            first login. Selects the right cached account when several
+            tenants are signed in.
     """
 
     client_id: str
     tenant_id: str
+    username: str | None = None
+
+
+@dataclass
+class AuthStore:
+    """Everything `napt auth login` remembers, keyed by tenant.
+
+    Attributes:
+        active: Tenant ID that commands use, or ``None`` before the first
+            login.
+        tenants: Known tenants by tenant ID.
+    """
+
+    active: str | None = None
+    tenants: dict[str, AuthConfig] = field(default_factory=dict)
 
 
 @dataclass
@@ -224,68 +247,96 @@ def _token_cache_path() -> Path:
     return _user_data_dir() / _TOKEN_CACHE_FILENAME
 
 
-def load_auth_config() -> AuthConfig | None:
-    """Reads the app registration saved by a previous `napt auth login`.
+def load_auth_store() -> AuthStore:
+    """Reads what previous `napt auth login` runs remembered.
 
     Returns:
-        The saved config, or ``None`` when no login has been run yet.
+        The saved store, empty when no login has been run yet.
 
     Raises:
         ConfigError: If the file exists but is unreadable or malformed.
     """
     path = _auth_config_path()
     if not path.exists():
-        return None
+        return AuthStore()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        return AuthConfig(client_id=data["client_id"], tenant_id=data["tenant_id"])
-    except (OSError, ValueError, KeyError, TypeError) as err:
+        tenants = {
+            tenant_id: AuthConfig(
+                client_id=entry["client_id"],
+                tenant_id=tenant_id,
+                username=entry.get("username"),
+            )
+            for tenant_id, entry in data.get("tenants", {}).items()
+        }
+        return AuthStore(active=data.get("active"), tenants=tenants)
+    except (OSError, ValueError, KeyError, TypeError, AttributeError) as err:
         raise ConfigError(
             f"Cannot read saved auth config {path}: {err}. "
             "Delete the file and run 'napt auth login' again."
         ) from err
 
 
-def _save_auth_config(config: AuthConfig) -> Path:
+def _save_auth_store(store: AuthStore) -> Path:
     path = _auth_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(
-            {"client_id": config.client_id, "tenant_id": config.tenant_id},
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    payload = {
+        "active": store.active,
+        "tenants": {
+            tenant_id: {"client_id": cfg.client_id, "username": cfg.username}
+            for tenant_id, cfg in store.tenants.items()
+        },
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
+
+
+def load_auth_config() -> AuthConfig | None:
+    """Returns the active tenant's sign-in settings, or ``None``.
+
+    Raises:
+        ConfigError: If the saved auth config is malformed.
+    """
+    store = load_auth_store()
+    if store.active is None:
+        return None
+    return store.tenants.get(store.active)
 
 
 def resolve_auth_config(
     client_id: str | None = None, tenant_id: str | None = None
 ) -> AuthConfig | None:
-    """Determines the app registration to use for interactive sign-in.
+    """Determines the tenant and app registration for interactive sign-in.
 
-    Per field, an explicit argument wins over the config saved by the last
-    `napt auth login`. ``AZURE_*`` environment variables are deliberately not
-    consulted: they describe a non-interactive credential, not which app a
-    person signs in to.
+    The tenant is ``tenant_id`` or the active one from the last login. The
+    client ID is ``client_id`` or the one remembered for that tenant. The
+    remembered username carries over only when the client ID is unchanged,
+    since a different app registration means a different cached session.
+    ``AZURE_*`` environment variables are deliberately not consulted: they
+    describe a non-interactive credential, not which app a person signs in
+    to.
 
     Args:
         client_id: Explicit client ID (from ``--client-id``).
         tenant_id: Explicit tenant ID (from ``--tenant-id``).
 
     Returns:
-        The resolved config, or ``None`` if either field is still unknown.
+        The resolved config, or ``None`` if the tenant or client ID is still
+        unknown.
 
     Raises:
         ConfigError: If a saved config file exists but is malformed.
     """
-    saved = load_auth_config()
-    resolved_client = client_id or (saved.client_id if saved else None)
-    resolved_tenant = tenant_id or (saved.tenant_id if saved else None)
-    if resolved_client and resolved_tenant:
-        return AuthConfig(client_id=resolved_client, tenant_id=resolved_tenant)
-    return None
+    store = load_auth_store()
+    tenant = tenant_id or store.active
+    if not tenant:
+        return None
+    known = store.tenants.get(tenant)
+    client = client_id or (known.client_id if known else None)
+    if not client:
+        return None
+    username = known.username if known and known.client_id == client else None
+    return AuthConfig(client_id=client, tenant_id=tenant, username=username)
 
 
 # ---------------------------------------------------------------------------
@@ -423,14 +474,17 @@ def _msal_error(result: dict[str, Any]) -> str:
 
 
 def _acquire_silent(config: AuthConfig, *, use_broker: bool) -> str | None:
-    """Returns a cached/refreshed token for the saved session, or ``None``.
+    """Returns a cached/refreshed token for the tenant's session, or ``None``.
 
-    ``None`` means no account is cached. An account whose session can no
-    longer be refreshed raises AuthError instead, since that needs a new
-    login rather than a different credential.
+    ``None`` means no session for this tenant is cached (no login yet, or a
+    different app registration than the one signed in with). A session that
+    can no longer be refreshed raises AuthError instead, since that needs a
+    new login rather than a different credential.
     """
+    if config.username is None:
+        return None
     app = _build_public_client(config, use_broker=use_broker)
-    accounts = app.get_accounts()
+    accounts = app.get_accounts(username=config.username)
     if not accounts:
         return None
     result = app.acquire_token_silent_with_error(GRAPH_SCOPES, account=accounts[0])
@@ -441,11 +495,23 @@ def _acquire_silent(config: AuthConfig, *, use_broker: bool) -> str | None:
 
 
 def _interactive_config() -> AuthConfig | None:
-    """The interactive app registration, or ``None`` when unconfigured."""
+    """The active tenant's sign-in settings, or ``None`` when unconfigured."""
     try:
         return resolve_auth_config()
     except ConfigError:
         return None
+
+
+def _interactive_method(broker: bool) -> str:
+    return "interactive (broker)" if broker else "interactive (browser)"
+
+
+def _remember(config: AuthConfig) -> Path:
+    """Records ``config`` as the active tenant and returns the file path."""
+    store = load_auth_store()
+    store.tenants[config.tenant_id] = config
+    store.active = config.tenant_id
+    return _save_auth_store(store)
 
 
 def login(
@@ -454,22 +520,24 @@ def login(
     tenant_id: str | None = None,
     use_broker: bool = True,
 ) -> AuthStatus:
-    """Signs a user in interactively and persists the session.
+    """Signs in to a tenant and makes it the active one.
 
-    Opens the platform broker (Windows/macOS, when the MSAL broker runtime is
-    installed and ``use_broker`` is true) or the system browser, then stores
-    the resulting account in NAPT's encrypted token cache so later commands
-    authenticate silently. Also saves the client/tenant IDs so future logins
-    don't need them repeated.
+    If the tenant already has a usable cached session, it is reused silently
+    -- so ``napt auth login --tenant-id <id>`` switches between signed-in
+    tenants without a prompt. Otherwise the platform broker (Windows/macOS,
+    when the MSAL broker runtime is installed and ``use_broker`` is true) or
+    the system browser opens, and the resulting account is stored in NAPT's
+    encrypted token cache. The tenant, client ID, and signed-in username are
+    remembered so later logins need no arguments.
 
     Args:
-        client_id: App registration client ID; overrides the saved config.
-        tenant_id: Tenant ID; overrides the saved config.
+        client_id: App registration client ID; overrides the one remembered
+            for the tenant.
+        tenant_id: Tenant ID; defaults to the active tenant.
         use_broker: Prefer the OS broker over a browser when available.
 
     Returns:
-        Status of the newly acquired token, including any missing
-        permissions.
+        Status of the token now in use, including any missing permissions.
 
     Raises:
         AuthError: If no app registration is configured or the sign-in fails.
@@ -484,6 +552,21 @@ def login(
         raise AuthError(_HINT_NO_CLIENT_CONFIG)
 
     broker = use_broker and _broker_available()
+
+    try:
+        cached = _acquire_silent(config, use_broker=broker)
+    except AuthError as err:
+        logger.verbose("AUTH", f"Cached session unusable, signing in again: {err}")
+        cached = None
+    if cached is not None:
+        _remember(config)
+        logger.info(
+            "AUTH",
+            f"Reusing signed-in session for {config.username} "
+            f"in tenant {config.tenant_id}",
+        )
+        return _status_from_token(cached, _interactive_method(broker))
+
     app = _build_public_client(config, use_broker=broker)
     logger.verbose(
         "AUTH",
@@ -513,39 +596,67 @@ def login(
     if "access_token" not in result:
         raise AuthError(f"{_HINT_LOGIN_FAILED}Details: {_msal_error(result)}")
 
-    saved_to = _save_auth_config(config)
-    logger.verbose("AUTH", f"Saved app registration to {saved_to}")
-
-    method = "interactive (broker)" if broker else "interactive (browser)"
-    status = _status_from_token(result["access_token"], method)
+    status = _status_from_token(result["access_token"], _interactive_method(broker))
+    claims = result.get("id_token_claims")
+    username = (
+        claims.get("preferred_username") if isinstance(claims, dict) else None
+    ) or status.account
     if not status.account:
-        claims = result.get("id_token_claims")
-        if isinstance(claims, dict):
-            status.account = claims.get("preferred_username")
+        status.account = username
+
+    saved_to = _remember(
+        AuthConfig(
+            client_id=config.client_id,
+            tenant_id=config.tenant_id,
+            username=username,
+        )
+    )
+    logger.verbose("AUTH", f"Saved sign-in settings to {saved_to}")
     return status
 
 
-def logout() -> bool:
-    """Removes the cached interactive session.
+def logout(*, all_tenants: bool = False) -> list[str]:
+    """Removes cached interactive sessions.
 
-    Signs every cached account out of NAPT's token cache (and the OS broker,
-    when it was used). The saved client/tenant IDs are kept so the next
+    Signs the active tenant's account out of NAPT's token cache (and the OS
+    broker, when it was used). With ``all_tenants``, every remembered tenant
+    is signed out. Client and tenant IDs are kept so the next
     `napt auth login` needs no arguments.
 
+    Args:
+        all_tenants: Sign out of every remembered tenant, not just the
+            active one.
+
     Returns:
-        True if a session was removed, False if none was cached.
+        Tenant IDs that had a session removed (empty if none was cached).
 
     Raises:
         ConfigError: If the saved auth config is malformed.
     """
-    config = resolve_auth_config()
-    if config is None or not _token_cache_path().exists():
-        return False
-    app = _build_public_client(config, use_broker=_broker_available())
-    accounts = app.get_accounts()
-    for account in accounts:
-        app.remove_account(account)
-    return bool(accounts)
+    store = load_auth_store()
+    if all_tenants:
+        targets = list(store.tenants.values())
+    else:
+        active = store.tenants.get(store.active or "")
+        targets = [active] if active else []
+
+    signed_out: list[str] = []
+    broker = _broker_available()
+    for config in targets:
+        if config.username is None:
+            continue
+        app = _build_public_client(config, use_broker=broker)
+        accounts = app.get_accounts(username=config.username)
+        for account in accounts:
+            app.remove_account(account)
+        store.tenants[config.tenant_id] = AuthConfig(
+            client_id=config.client_id, tenant_id=config.tenant_id
+        )
+        if accounts:
+            signed_out.append(config.tenant_id)
+    if targets:
+        _save_auth_store(store)
+    return signed_out
 
 
 def get_status() -> AuthStatus | None:
@@ -576,9 +687,7 @@ def get_status() -> AuthStatus | None:
     token = _acquire_silent(config, use_broker=broker)
     if token is None:
         return None
-    return _status_from_token(
-        token, "interactive (broker)" if broker else "interactive (browser)"
-    )
+    return _status_from_token(token, _interactive_method(broker))
 
 
 def get_access_token() -> str:

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -190,10 +190,10 @@ class AuthConfig:
 
     @property
     def label(self) -> str | None:
-        """Human-readable tenant label: ``"contoso.com (Contoso)"``, or ``None``."""
+        """Human-readable tenant label: ``"Contoso (contoso.com)"``, or ``None``."""
         if self.domain and self.display_name:
-            return f"{self.domain} ({self.display_name})"
-        return self.domain or self.display_name
+            return f"{self.display_name} ({self.domain})"
+        return self.display_name or self.domain
 
 
 @dataclass
@@ -342,16 +342,19 @@ def resolve_auth_config(
 ) -> AuthConfig | None:
     """Determines the tenant and app registration for interactive sign-in.
 
-    The tenant is ``tenant_id`` or the active one from the last login. The
-    client ID is ``client_id`` or the one remembered for that tenant. The
-    remembered username carries over only when the client ID is unchanged,
-    since a different app registration means a different cached session.
+    The tenant is ``tenant_id`` or the active one from the last login;
+    ``tenant_id`` may also be the default domain of a remembered tenant
+    (``contoso.com``), which is mapped back to its ID. The client ID is
+    ``client_id`` or the one remembered for that tenant. The remembered
+    username carries over only when the client ID is unchanged, since a
+    different app registration means a different cached session.
     ``AZURE_*`` environment variables are deliberately not consulted: they
     describe a non-interactive credential, not which app a person signs in
     to.
 
     Args:
-        tenant_id: Explicit tenant ID (from ``--tenant-id``).
+        tenant_id: Explicit tenant ID or remembered domain (from
+            ``--tenant-id``).
         client_id: Explicit client ID (from ``--client-id``).
 
     Returns:
@@ -365,6 +368,11 @@ def resolve_auth_config(
     tenant = tenant_id or store.active
     if not tenant:
         return None
+    if tenant not in store.tenants:
+        by_domain = {
+            cfg.domain.lower(): tid for tid, cfg in store.tenants.items() if cfg.domain
+        }
+        tenant = by_domain.get(tenant.lower(), tenant)
     known = store.tenants.get(tenant)
     client = client_id or (known.client_id if known else None)
     if not client:
@@ -401,9 +409,11 @@ def _decode_claims(token: str) -> dict[str, Any]:
 
 def _status_from_token(token: str, method: str) -> AuthStatus:
     claims = _decode_claims(token)
-    scopes = str(claims.get("scp", "")).split()
-    roles = list(claims.get("roles") or [])
-    permissions = sorted(set(scopes) | set(roles))
+    # OIDC scopes MSAL requests on every sign-in; not Graph permissions.
+    oidc = {"openid", "profile", "email", "offline_access"}
+    scopes = set(str(claims.get("scp", "")).split()) - oidc
+    roles = set(claims.get("roles") or [])
+    permissions = sorted(scopes | roles)
     account = (
         claims.get("preferred_username")
         or claims.get("upn")

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -126,9 +126,8 @@ _HINT_SESSION_EXPIRED = (
 
 _HINT_NO_CLIENT_CONFIG = (
     "No app registration configured for interactive sign-in.\n\n"
-    "Run 'napt auth login --client-id <id> --tenant-id <id>' once; the IDs are\n"
-    "remembered for later logins. AZURE_CLIENT_ID and AZURE_TENANT_ID\n"
-    "environment variables take precedence when set.\n"
+    "Run: napt auth login --client-id <id> --tenant-id <id>\n"
+    "(The IDs are remembered for later logins.)\n"
 )
 
 _HINT_LOGIN_FAILED = (
@@ -266,9 +265,10 @@ def resolve_auth_config(
 ) -> AuthConfig | None:
     """Determines the app registration to use for interactive sign-in.
 
-    Precedence per field: explicit argument, then ``AZURE_CLIENT_ID`` /
-    ``AZURE_TENANT_ID`` environment variable, then the config saved by the
-    last `napt auth login`.
+    Per field, an explicit argument wins over the config saved by the last
+    `napt auth login`. ``AZURE_*`` environment variables are deliberately not
+    consulted: they describe a non-interactive credential, not which app a
+    person signs in to.
 
     Args:
         client_id: Explicit client ID (from ``--client-id``).
@@ -281,16 +281,8 @@ def resolve_auth_config(
         ConfigError: If a saved config file exists but is malformed.
     """
     saved = load_auth_config()
-    resolved_client = (
-        client_id
-        or os.environ.get("AZURE_CLIENT_ID")
-        or (saved.client_id if saved else None)
-    )
-    resolved_tenant = (
-        tenant_id
-        or os.environ.get("AZURE_TENANT_ID")
-        or (saved.tenant_id if saved else None)
-    )
+    resolved_client = client_id or (saved.client_id if saved else None)
+    resolved_tenant = tenant_id or (saved.tenant_id if saved else None)
     if resolved_client and resolved_tenant:
         return AuthConfig(client_id=resolved_client, tenant_id=resolved_tenant)
     return None
@@ -471,10 +463,8 @@ def login(
     don't need them repeated.
 
     Args:
-        client_id: App registration client ID; overrides ``AZURE_CLIENT_ID``
-            and the saved config.
-        tenant_id: Tenant ID; overrides ``AZURE_TENANT_ID`` and the saved
-            config.
+        client_id: App registration client ID; overrides the saved config.
+        tenant_id: Tenant ID; overrides the saved config.
         use_broker: Prefer the OS broker over a browser when available.
 
     Returns:

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -733,6 +733,7 @@ def logout(*, all_tenants: bool = False) -> list[str]:
         Tenant IDs that had a session removed (empty if none was cached).
 
     Raises:
+        AuthError: If the OS-encrypted token cache cannot be opened.
         ConfigError: If the saved auth config is malformed.
     """
     store = load_auth_store()

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -12,28 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Azure credential acquisition for NAPT Intune upload.
+"""Microsoft Graph authentication for NAPT.
+
+Every command that talks to Intune (`napt upload`, `napt promote apply`,
+`napt promote plan --reconcile/--check-drift`) calls
+[get_access_token][napt.upload.auth.get_access_token] once. The token comes
+from the first source that works:
+
+Non-interactive (CI/CD):
+    1. EnvironmentCredential -- service principal via AZURE_CLIENT_ID,
+        AZURE_TENANT_ID and either AZURE_CLIENT_SECRET or
+        AZURE_CLIENT_CERTIFICATE_PATH.
+    2. WorkloadIdentityCredential -- federated (OIDC) identity, e.g. GitHub
+        Actions with `azure/login`. Recommended over client secrets when the
+        CI platform supports it: no secret to store or rotate.
+
+Interactive (a person at a terminal):
+    3. A session established earlier with `napt auth login`. Tokens are
+        cached by MSAL in an OS-encrypted store (DPAPI on Windows, Keychain on
+        macOS, libsecret on Linux) and refreshed silently; the browser or
+        Windows/macOS broker is only opened by `napt auth login` itself,
+        never by `napt upload`.
+
+`napt auth login` uses the authorization code flow with PKCE against a
+loopback redirect, or -- on Windows and macOS when the MSAL broker runtime is
+installed -- the platform broker (Web Account Manager / Company Portal),
+which gives single sign-on with the signed-in OS account and honors
+device-based Conditional Access.
 
 Requires a NAPT app registration in Microsoft Entra ID with the
-`DeviceManagementApps.ReadWrite.All` Microsoft Graph API permission.
-See the authentication documentation for setup instructions.
-
-Authentication is selected automatically based on environment variables:
-
-Authentication order:
-    1. EnvironmentCredential -- service principal via environment variables.
-        Set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
-        Recommended for CI/CD pipelines (GitHub Actions, Azure DevOps, etc.).
-    2. ManagedIdentityCredential -- Azure managed identity. Works automatically
-        on Azure VMs, Azure Container Instances, and Azure-hosted pipeline
-        agents with a managed identity assigned. No credentials to manage.
-    3. DeviceCodeCredential -- interactive device code flow (TTY only).
-        Requires AZURE_CLIENT_ID and AZURE_TENANT_ID to be set (no secret
-        needed). Prints a URL and code; the user completes authentication in
-        any browser. Skipped in CI/CD and when output is redirected.
-
-If all available methods fail, an AuthError is raised with guidance on which
-environment variables to set.
+`DeviceManagementApps.ReadWrite.All` and `Group.Read.All` Microsoft Graph
+permissions (application permissions for CI/CD, delegated for interactive
+use). See the authentication documentation for setup instructions.
 
 Example:
     Acquiring a token for Graph API:
@@ -48,97 +58,553 @@ Example:
 
 from __future__ import annotations
 
+import base64
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+import json
+import logging
 import os
+from pathlib import Path
 import sys
+from typing import Any
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import (
     ChainedTokenCredential,
-    DeviceCodeCredential,
     EnvironmentCredential,
-    ManagedIdentityCredential,
+    WorkloadIdentityCredential,
 )
+import msal
+import msal_extensions
 
-from napt.exceptions import AuthError
+from napt.exceptions import AuthError, ConfigError
 
-__all__ = ["get_access_token", "get_credential", "GRAPH_SCOPES"]
+__all__ = [
+    "AuthConfig",
+    "AuthStatus",
+    "GRAPH_SCOPES",
+    "REQUIRED_PERMISSIONS",
+    "get_access_token",
+    "get_credential",
+    "get_status",
+    "load_auth_config",
+    "login",
+    "logout",
+    "resolve_auth_config",
+]
 
 GRAPH_SCOPES = ["https://graph.microsoft.com/.default"]
 
-_DEVICE_CODE_SCOPES = ["https://graph.microsoft.com/DeviceManagementApps.ReadWrite.All"]
+# azure-identity logs a WARNING every time the non-interactive chain comes up
+# empty, which is the normal path for a signed-in developer. NAPT reports the
+# outcome itself, so keep the library quiet below ERROR.
+logging.getLogger("azure.identity").setLevel(logging.ERROR)
 
-_AUTH_FAILURE_HINT_NONINTERACTIVE = (
-    "Authentication failed. Tried: EnvironmentCredential, "
-    "ManagedIdentityCredential.\n\n"
-    "To fix this, use one of the following:\n"
-    "  CI/CD:      set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID\n"
-    "  Azure VMs:  assign a managed identity to the resource\n"
+# Graph permissions NAPT needs, whether granted as application permissions
+# (service principal, workload identity) or delegated permissions (interactive).
+REQUIRED_PERMISSIONS = ("DeviceManagementApps.ReadWrite.All", "Group.Read.All")
+
+_AUTHORITY_BASE = "https://login.microsoftonline.com"
+_AUTH_CONFIG_FILENAME = "auth.json"
+_TOKEN_CACHE_FILENAME = "token_cache.bin"
+
+# Seconds `napt auth login` waits for the browser round-trip before giving up.
+_LOGIN_TIMEOUT = 300
+
+_HINT_NOT_LOGGED_IN = (
+    "Not authenticated.\n\n"
+    "  Interactive:  run 'napt auth login'\n"
+    "  CI/CD:        set AZURE_CLIENT_ID, AZURE_TENANT_ID and either\n"
+    "                AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH,\n"
+    "                or use OIDC federation (WorkloadIdentityCredential)\n"
 )
 
-_AUTH_FAILURE_HINT_INTERACTIVE_NO_CLIENT = (
-    "Authentication failed. No app registration configured for interactive "
-    "auth.\n\n"
-    "Set AZURE_CLIENT_ID and AZURE_TENANT_ID to enable device code "
-    "authentication,\n"
-    "or set all three (including AZURE_CLIENT_SECRET) for service principal "
-    "auth.\n\n"
-    "See the authentication documentation for app registration setup "
-    "instructions.\n"
+_HINT_SESSION_EXPIRED = (
+    "Your sign-in session has expired or was revoked. "
+    "Run 'napt auth login' to sign in again.\n"
 )
 
-_AUTH_FAILURE_HINT_DEVICE_CODE = (
-    "Authentication failed during device code flow.\n\n"
+_HINT_NO_CLIENT_CONFIG = (
+    "No app registration configured for interactive sign-in.\n\n"
+    "Run 'napt auth login --client-id <id> --tenant-id <id>' once; the IDs are\n"
+    "remembered for later logins. AZURE_CLIENT_ID and AZURE_TENANT_ID\n"
+    "environment variables take precedence when set.\n"
+)
+
+_HINT_LOGIN_FAILED = (
+    "Interactive sign-in failed.\n\n"
     "Common causes:\n"
-    "  - Public client flows not enabled: in the Azure portal, go to\n"
-    "    App registrations -> your app -> Authentication -> Advanced settings\n"
-    "    and set 'Allow public client flows' to Yes.\n"
-    "  - Wrong AZURE_CLIENT_ID or AZURE_TENANT_ID: verify the values.\n"
-    "  - Device code prompt not completed: re-run and finish in the browser.\n\n"
-    "Alternatively, set AZURE_CLIENT_SECRET to use service principal auth.\n"
+    "  - Missing redirect URI: the app registration needs a 'Mobile and\n"
+    "    desktop applications' platform with redirect URI http://localhost\n"
+    "    (and ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id> for the\n"
+    "    Windows broker).\n"
+    "  - Delegated permissions not consented: add the delegated\n"
+    "    DeviceManagementApps.ReadWrite.All and Group.Read.All permissions\n"
+    "    and grant admin consent.\n"
+    "  - Wrong client ID or tenant ID: check 'napt auth status'.\n"
+    "  - Browser showed 'localhost refused to connect': the sign-in took\n"
+    "    longer than the listener waited, or a proxy is not bypassing\n"
+    "    localhost. Retry, or retry with --no-broker / without a proxy.\n"
 )
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    """App registration used for interactive sign-in.
+
+    Attributes:
+        client_id: Application (client) ID of the NAPT app registration.
+        tenant_id: Directory (tenant) ID the sign-in is scoped to.
+    """
+
+    client_id: str
+    tenant_id: str
+
+
+@dataclass
+class AuthStatus:
+    """What `napt auth status` reports about the current credential.
+
+    Attributes:
+        method: Human-readable credential source, e.g. ``"service principal"``
+            or ``"interactive (broker)"``.
+        account: Signed-in user (UPN) for delegated tokens, or the client ID
+            for application tokens. ``None`` when the token could not be
+            decoded.
+        tenant_id: Tenant the token was issued for, when decodable.
+        client_id: App registration the token was issued to, when decodable.
+        expires_at: Access token expiry, when decodable.
+        permissions: Graph permissions carried by the token -- delegated
+            scopes (``scp``) or application roles (``roles``).
+        missing: Required Graph permissions (``REQUIRED_PERMISSIONS``) absent
+            from ``permissions``.
+    """
+
+    method: str
+    account: str | None = None
+    tenant_id: str | None = None
+    client_id: str | None = None
+    expires_at: datetime | None = None
+    permissions: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Config and cache locations
+# ---------------------------------------------------------------------------
+
+
+def _user_data_dir() -> Path:
+    """Returns NAPT's per-user data directory.
+
+    Windows: ``%LOCALAPPDATA%/napt``. macOS: ``~/Library/Application
+    Support/napt``. Elsewhere: ``$XDG_CONFIG_HOME/napt`` or ``~/.config/napt``.
+    ``NAPT_USER_DIR`` overrides all of these.
+    """
+    override = os.environ.get("NAPT_USER_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / "napt"
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "napt"
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        if xdg:
+            return Path(xdg) / "napt"
+    return Path.home() / ".config" / "napt"
+
+
+def _auth_config_path() -> Path:
+    return _user_data_dir() / _AUTH_CONFIG_FILENAME
+
+
+def _token_cache_path() -> Path:
+    return _user_data_dir() / _TOKEN_CACHE_FILENAME
+
+
+def load_auth_config() -> AuthConfig | None:
+    """Reads the app registration saved by a previous `napt auth login`.
+
+    Returns:
+        The saved config, or ``None`` when no login has been run yet.
+
+    Raises:
+        ConfigError: If the file exists but is unreadable or malformed.
+    """
+    path = _auth_config_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return AuthConfig(client_id=data["client_id"], tenant_id=data["tenant_id"])
+    except (OSError, ValueError, KeyError, TypeError) as err:
+        raise ConfigError(
+            f"Cannot read saved auth config {path}: {err}. "
+            "Delete the file and run 'napt auth login' again."
+        ) from err
+
+
+def _save_auth_config(config: AuthConfig) -> Path:
+    path = _auth_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"client_id": config.client_id, "tenant_id": config.tenant_id},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def resolve_auth_config(
+    client_id: str | None = None, tenant_id: str | None = None
+) -> AuthConfig | None:
+    """Determines the app registration to use for interactive sign-in.
+
+    Precedence per field: explicit argument, then ``AZURE_CLIENT_ID`` /
+    ``AZURE_TENANT_ID`` environment variable, then the config saved by the
+    last `napt auth login`.
+
+    Args:
+        client_id: Explicit client ID (from ``--client-id``).
+        tenant_id: Explicit tenant ID (from ``--tenant-id``).
+
+    Returns:
+        The resolved config, or ``None`` if either field is still unknown.
+
+    Raises:
+        ConfigError: If a saved config file exists but is malformed.
+    """
+    saved = load_auth_config()
+    resolved_client = (
+        client_id
+        or os.environ.get("AZURE_CLIENT_ID")
+        or (saved.client_id if saved else None)
+    )
+    resolved_tenant = (
+        tenant_id
+        or os.environ.get("AZURE_TENANT_ID")
+        or (saved.tenant_id if saved else None)
+    )
+    if resolved_client and resolved_tenant:
+        return AuthConfig(client_id=resolved_client, tenant_id=resolved_tenant)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Token inspection
+# ---------------------------------------------------------------------------
+
+
+def _decode_claims(token: str) -> dict[str, Any]:
+    """Extracts the payload claims of a JWT without validating it.
+
+    Diagnostic only -- NAPT never trusts these values for authorization, and
+    Graph access tokens are not guaranteed to stay decodable. Returns an
+    empty dict when the token is not a readable JWT.
+    """
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload))
+    except (IndexError, ValueError, UnicodeDecodeError):
+        return {}
+
+
+def _status_from_token(token: str, method: str) -> AuthStatus:
+    claims = _decode_claims(token)
+    scopes = str(claims.get("scp", "")).split()
+    roles = list(claims.get("roles") or [])
+    permissions = sorted(set(scopes) | set(roles))
+    account = (
+        claims.get("preferred_username")
+        or claims.get("upn")
+        or claims.get("unique_name")
+        or claims.get("appid")
+        or claims.get("azp")
+    )
+    exp = claims.get("exp")
+    return AuthStatus(
+        method=method,
+        account=account,
+        tenant_id=claims.get("tid"),
+        client_id=claims.get("appid") or claims.get("azp"),
+        expires_at=(
+            datetime.fromtimestamp(exp, tz=UTC)
+            if isinstance(exp, (int, float))
+            else None
+        ),
+        permissions=permissions,
+        missing=[p for p in REQUIRED_PERMISSIONS if p not in permissions],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive chain (azure-identity)
+# ---------------------------------------------------------------------------
 
 
 def get_credential() -> ChainedTokenCredential:
-    """Build the Phase 1 credential chain for non-interactive authentication.
+    """Builds the non-interactive credential chain.
 
-    Returns a credential that tries service principal auth (via environment
-    variables) first, then managed identity for Azure-hosted workloads.
-    Both use the `.default` scope, suitable for application permissions.
-
-    For interactive device code auth, use `get_access_token()` directly,
-    which handles Phase 2 automatically when Phase 1 fails.
+    Service principal (environment variables), then workload identity
+    federation (only when its ``AZURE_FEDERATED_TOKEN_FILE`` etc. variables
+    are present). Both use the `.default` scope, suitable for application
+    permissions.
 
     Returns:
         A ChainedTokenCredential for non-interactive authentication.
-
     """
-    return ChainedTokenCredential(
-        EnvironmentCredential(),
-        ManagedIdentityCredential(),
+    credentials: list[Any] = [EnvironmentCredential()]
+    if all(
+        os.environ.get(var)
+        for var in (
+            "AZURE_TENANT_ID",
+            "AZURE_CLIENT_ID",
+            "AZURE_FEDERATED_TOKEN_FILE",
+        )
+    ):
+        credentials.append(WorkloadIdentityCredential())
+    return ChainedTokenCredential(*credentials)
+
+
+def _describe_noninteractive_method() -> str:
+    if os.environ.get("AZURE_CLIENT_SECRET") or os.environ.get(
+        "AZURE_CLIENT_CERTIFICATE_PATH"
+    ):
+        return "service principal"
+    return "workload identity (OIDC)"
+
+
+# ---------------------------------------------------------------------------
+# Interactive session (MSAL)
+# ---------------------------------------------------------------------------
+
+
+def _broker_available() -> bool:
+    """Whether the MSAL broker runtime is importable on this platform."""
+    if sys.platform not in ("win32", "darwin"):
+        return False
+    try:
+        import pymsalruntime  # noqa: F401  # pyright: ignore[reportMissingImports]
+    except ImportError:
+        return False
+    return True
+
+
+def _build_token_cache() -> msal_extensions.PersistedTokenCache:
+    """Opens NAPT's OS-encrypted token cache, creating the directory if needed."""
+    path = _token_cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        persistence = msal_extensions.build_encrypted_persistence(str(path))
+    except Exception as err:  # msal_extensions raises platform-specific types
+        raise AuthError(
+            f"Cannot open an encrypted token cache at {path}: {err}\n"
+            "Interactive sign-in needs the OS credential store (DPAPI, "
+            "Keychain, or libsecret). Use a service principal instead."
+        ) from err
+    return msal_extensions.PersistedTokenCache(persistence)
+
+
+def _build_public_client(
+    config: AuthConfig, *, use_broker: bool
+) -> msal.PublicClientApplication:
+    return msal.PublicClientApplication(
+        config.client_id,
+        authority=f"{_AUTHORITY_BASE}/{config.tenant_id}",
+        token_cache=_build_token_cache(),
+        enable_broker_on_windows=use_broker,
+        enable_broker_on_mac=use_broker,
+    )
+
+
+def _msal_error(result: dict[str, Any]) -> str:
+    code = result.get("error", "unknown_error")
+    description = str(result.get("error_description", "")).splitlines()
+    return f"{code}: {description[0]}" if description else str(code)
+
+
+def _acquire_silent(config: AuthConfig, *, use_broker: bool) -> str | None:
+    """Returns a cached/refreshed token for the saved session, or ``None``.
+
+    ``None`` means no account is cached. An account whose session can no
+    longer be refreshed raises AuthError instead, since that needs a new
+    login rather than a different credential.
+    """
+    app = _build_public_client(config, use_broker=use_broker)
+    accounts = app.get_accounts()
+    if not accounts:
+        return None
+    result = app.acquire_token_silent_with_error(GRAPH_SCOPES, account=accounts[0])
+    if not result or "access_token" not in result:
+        detail = _msal_error(result) if result else "no token"
+        raise AuthError(f"{_HINT_SESSION_EXPIRED}Details: {detail}")
+    return result["access_token"]
+
+
+def _interactive_config() -> AuthConfig | None:
+    """The interactive app registration, or ``None`` when unconfigured."""
+    try:
+        return resolve_auth_config()
+    except ConfigError:
+        return None
+
+
+def login(
+    *,
+    client_id: str | None = None,
+    tenant_id: str | None = None,
+    use_broker: bool = True,
+) -> AuthStatus:
+    """Signs a user in interactively and persists the session.
+
+    Opens the platform broker (Windows/macOS, when the MSAL broker runtime is
+    installed and ``use_broker`` is true) or the system browser, then stores
+    the resulting account in NAPT's encrypted token cache so later commands
+    authenticate silently. Also saves the client/tenant IDs so future logins
+    don't need them repeated.
+
+    Args:
+        client_id: App registration client ID; overrides ``AZURE_CLIENT_ID``
+            and the saved config.
+        tenant_id: Tenant ID; overrides ``AZURE_TENANT_ID`` and the saved
+            config.
+        use_broker: Prefer the OS broker over a browser when available.
+
+    Returns:
+        Status of the newly acquired token, including any missing
+        permissions.
+
+    Raises:
+        AuthError: If no app registration is configured or the sign-in fails.
+        ConfigError: If the saved auth config is malformed.
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+
+    config = resolve_auth_config(client_id, tenant_id)
+    if config is None:
+        raise AuthError(_HINT_NO_CLIENT_CONFIG)
+
+    broker = use_broker and _broker_available()
+    app = _build_public_client(config, use_broker=broker)
+    logger.verbose(
+        "AUTH",
+        f"Signing in to tenant {config.tenant_id} as app {config.client_id} "
+        f"({'broker' if broker else 'browser'})",
+    )
+
+    def _announce(ui: str = "browser", **_: Any) -> None:
+        if ui == "broker":
+            print("A sign-in window will open. Choose your work account.")
+        else:
+            print("Opening your browser to sign in...")
+
+    try:
+        result = app.acquire_token_interactive(
+            GRAPH_SCOPES,
+            prompt="select_account",
+            timeout=_LOGIN_TIMEOUT,
+            parent_window_handle=(
+                msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE if broker else None
+            ),
+            on_before_launching_ui=_announce,
+        )
+    except Exception as err:  # MSAL surfaces transport/broker failures as raw errors
+        raise AuthError(f"{_HINT_LOGIN_FAILED}Details: {err}") from err
+
+    if "access_token" not in result:
+        raise AuthError(f"{_HINT_LOGIN_FAILED}Details: {_msal_error(result)}")
+
+    saved_to = _save_auth_config(config)
+    logger.verbose("AUTH", f"Saved app registration to {saved_to}")
+
+    method = "interactive (broker)" if broker else "interactive (browser)"
+    status = _status_from_token(result["access_token"], method)
+    if not status.account:
+        claims = result.get("id_token_claims")
+        if isinstance(claims, dict):
+            status.account = claims.get("preferred_username")
+    return status
+
+
+def logout() -> bool:
+    """Removes the cached interactive session.
+
+    Signs every cached account out of NAPT's token cache (and the OS broker,
+    when it was used). The saved client/tenant IDs are kept so the next
+    `napt auth login` needs no arguments.
+
+    Returns:
+        True if a session was removed, False if none was cached.
+
+    Raises:
+        ConfigError: If the saved auth config is malformed.
+    """
+    config = resolve_auth_config()
+    if config is None or not _token_cache_path().exists():
+        return False
+    app = _build_public_client(config, use_broker=_broker_available())
+    accounts = app.get_accounts()
+    for account in accounts:
+        app.remove_account(account)
+    return bool(accounts)
+
+
+def get_status() -> AuthStatus | None:
+    """Reports which credential NAPT would use right now, or ``None``.
+
+    Resolves a token exactly as [get_access_token][napt.upload.auth.get_access_token]
+    does -- so the answer reflects what `napt upload` will do -- and
+    decodes it for display.
+
+    Returns:
+        The current credential's status, or ``None`` when nothing is
+        configured or signed in.
+
+    Raises:
+        AuthError: If a credential is configured but fails (for example, a
+            saved session that can no longer be refreshed).
+    """
+    try:
+        token = get_credential().get_token(*GRAPH_SCOPES).token
+        return _status_from_token(token, _describe_noninteractive_method())
+    except ClientAuthenticationError:
+        pass
+
+    config = _interactive_config()
+    if config is None:
+        return None
+    broker = _broker_available()
+    token = _acquire_silent(config, use_broker=broker)
+    if token is None:
+        return None
+    return _status_from_token(
+        token, "interactive (broker)" if broker else "interactive (browser)"
     )
 
 
 def get_access_token() -> str:
-    """Acquire a Microsoft Graph API access token.
+    """Acquires a Microsoft Graph access token.
 
-    Tries credential methods in order until one succeeds:
-
-    Phase 1 (always tried):
-        EnvironmentCredential (service principal via AZURE_CLIENT_ID,
-        AZURE_CLIENT_SECRET, AZURE_TENANT_ID) then ManagedIdentityCredential.
-        Both use the `.default` scope (application permissions).
-
-    Phase 2 (only if Phase 1 fails and stdout is a TTY):
-        DeviceCodeCredential using AZURE_CLIENT_ID and AZURE_TENANT_ID.
-        Uses the explicit DeviceManagementApps.ReadWrite.All scope, which
-        triggers a consent prompt on first run.
+    Tries the non-interactive chain from
+    [get_credential][napt.upload.auth.get_credential] first, then the session
+    saved by `napt auth login`. Never opens a browser: an interactive user
+    who has not logged in is told to run `napt auth login`.
 
     Returns:
         Bearer token string for use in Authorization headers.
 
     Raises:
-        AuthError: If all credential types fail or are unavailable,
-            with guidance on which environment variables to set.
+        AuthError: If no credential is available or the saved session can no
+            longer be refreshed, with guidance on what to do.
 
     Example:
         Get a token and use it in a request:
@@ -150,30 +616,15 @@ def get_access_token() -> str:
             ```
 
     """
-    # Phase 1: service principal or managed identity
     try:
         return get_credential().get_token(*GRAPH_SCOPES).token
     except ClientAuthenticationError:
         pass
 
-    # Phase 2: interactive device code (TTY only)
-    if sys.stdout.isatty():
-        client_id = os.environ.get("AZURE_CLIENT_ID", "")
-        tenant_id = os.environ.get("AZURE_TENANT_ID", "")
-        if client_id and tenant_id:
-            try:
-                return (
-                    DeviceCodeCredential(
-                        client_id=client_id,
-                        tenant_id=tenant_id,
-                    )
-                    .get_token(*_DEVICE_CODE_SCOPES)
-                    .token
-                )
-            except ClientAuthenticationError as err:
-                raise AuthError(
-                    f"{_AUTH_FAILURE_HINT_DEVICE_CODE}Details: {err}"
-                ) from err
-        raise AuthError(_AUTH_FAILURE_HINT_INTERACTIVE_NO_CLIENT)
+    config = _interactive_config()
+    if config is not None:
+        token = _acquire_silent(config, use_broker=_broker_available())
+        if token is not None:
+            return token
 
-    raise AuthError(_AUTH_FAILURE_HINT_NONINTERACTIVE)
+    raise AuthError(_HINT_NOT_LOGGED_IN)

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -31,16 +31,18 @@ Interactive (a person at a terminal):
     3. The active tenant's session established earlier with
         `napt auth login`. Tokens are cached by MSAL in an OS-encrypted store
         (DPAPI on Windows, Keychain on macOS, libsecret on Linux) and
-        refreshed silently; the browser or Windows/macOS broker is only
+        refreshed silently; the browser or Windows broker is only
         opened by `napt auth login` itself, never by `napt upload`. Several
         tenants can be signed in at once; `napt auth login --tenant-id`
         switches the active one.
 
 `napt auth login` uses the authorization code flow with PKCE against a
-loopback redirect, or -- on Windows and macOS when the MSAL broker runtime is
-installed -- the platform broker (Web Account Manager / Company Portal),
-which gives single sign-on with the signed-in OS account and honors
-device-based Conditional Access.
+loopback redirect, or -- on Windows, when the MSAL broker runtime is
+installed -- the Web Account Manager (WAM) broker, which gives single
+sign-on with accounts known to Windows, honors device-based Conditional
+Access, and keeps refresh tokens device-bound. The broker needs an
+interactive Windows session; scheduled tasks, services, and SSH sessions
+should use a service principal or OIDC instead.
 
 Requires a NAPT app registration in Microsoft Entra ID with the
 `DeviceManagementApps.ReadWrite.All` and `Group.Read.All` Microsoft Graph
@@ -130,7 +132,7 @@ _HINT_SESSION_EXPIRED = (
 
 _HINT_NO_CLIENT_CONFIG = (
     "No app registration configured for interactive sign-in.\n\n"
-    "Run: napt auth login --client-id <id> --tenant-id <id>\n"
+    "Run: napt auth login --tenant-id <id> --client-id <id>\n"
     "(The IDs are remembered for later logins.)\n"
 )
 
@@ -148,6 +150,15 @@ _HINT_LOGIN_FAILED = (
     "  - Browser showed 'localhost refused to connect': the sign-in took\n"
     "    longer than the listener waited, or a proxy is not bypassing\n"
     "    localhost. Retry, or retry with --no-broker / without a proxy.\n"
+)
+
+_HINT_LOGIN_CANCELED = (
+    "Sign-in was canceled before it completed.\n\n"
+    "If the sign-in window showed an error such as AADSTS500113 or\n"
+    "AADSTS50011, the app registration is missing a redirect URI: add\n"
+    "http://localhost and ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>\n"
+    "under Authentication -> Mobile and desktop applications, then retry.\n"
+    "Otherwise just run 'napt auth login' again.\n"
 )
 
 
@@ -304,7 +315,7 @@ def load_auth_config() -> AuthConfig | None:
 
 
 def resolve_auth_config(
-    client_id: str | None = None, tenant_id: str | None = None
+    tenant_id: str | None = None, client_id: str | None = None
 ) -> AuthConfig | None:
     """Determines the tenant and app registration for interactive sign-in.
 
@@ -317,8 +328,8 @@ def resolve_auth_config(
     to.
 
     Args:
-        client_id: Explicit client ID (from ``--client-id``).
         tenant_id: Explicit tenant ID (from ``--tenant-id``).
+        client_id: Explicit client ID (from ``--client-id``).
 
     Returns:
         The resolved config, or ``None`` if the tenant or client ID is still
@@ -430,8 +441,8 @@ def _describe_noninteractive_method() -> str:
 
 
 def _broker_available() -> bool:
-    """Whether the MSAL broker runtime is importable on this platform."""
-    if sys.platform not in ("win32", "darwin"):
+    """Whether the Windows broker (WAM) runtime is importable."""
+    if sys.platform != "win32":
         return False
     try:
         import pymsalruntime  # noqa: F401  # pyright: ignore[reportMissingImports]
@@ -463,7 +474,6 @@ def _build_public_client(
         authority=f"{_AUTHORITY_BASE}/{config.tenant_id}",
         token_cache=_build_token_cache(),
         enable_broker_on_windows=use_broker,
-        enable_broker_on_mac=use_broker,
     )
 
 
@@ -516,24 +526,24 @@ def _remember(config: AuthConfig) -> Path:
 
 def login(
     *,
-    client_id: str | None = None,
     tenant_id: str | None = None,
+    client_id: str | None = None,
     use_broker: bool = True,
 ) -> AuthStatus:
     """Signs in to a tenant and makes it the active one.
 
     If the tenant already has a usable cached session, it is reused silently
     -- so ``napt auth login --tenant-id <id>`` switches between signed-in
-    tenants without a prompt. Otherwise the platform broker (Windows/macOS,
-    when the MSAL broker runtime is installed and ``use_broker`` is true) or
-    the system browser opens, and the resulting account is stored in NAPT's
+    tenants without a prompt. Otherwise the Windows broker (when the MSAL
+    broker runtime is installed and ``use_broker`` is true) or the system
+    browser opens, and the resulting account is stored in NAPT's
     encrypted token cache. The tenant, client ID, and signed-in username are
     remembered so later logins need no arguments.
 
     Args:
+        tenant_id: Tenant ID; defaults to the active tenant.
         client_id: App registration client ID; overrides the one remembered
             for the tenant.
-        tenant_id: Tenant ID; defaults to the active tenant.
         use_broker: Prefer the OS broker over a browser when available.
 
     Returns:
@@ -547,7 +557,7 @@ def login(
 
     logger = get_global_logger()
 
-    config = resolve_auth_config(client_id, tenant_id)
+    config = resolve_auth_config(tenant_id, client_id)
     if config is None:
         raise AuthError(_HINT_NO_CLIENT_CONFIG)
 
@@ -594,7 +604,14 @@ def login(
         raise AuthError(f"{_HINT_LOGIN_FAILED}Details: {err}") from err
 
     if "access_token" not in result:
-        raise AuthError(f"{_HINT_LOGIN_FAILED}Details: {_msal_error(result)}")
+        logger.debug("AUTH", f"MSAL interactive response: {result}")
+        detail = _msal_error(result)
+        if result.get("correlation_id"):
+            detail += f" (correlation_id {result['correlation_id']})"
+        # _broker_status is a pymsalruntime enum; compare by name.
+        canceled = str(result.get("_broker_status", "")).endswith("Status_UserCanceled")
+        hint = _HINT_LOGIN_CANCELED if canceled else _HINT_LOGIN_FAILED
+        raise AuthError(f"{hint}Details: {detail}")
 
     status = _status_from_token(result["access_token"], _interactive_method(broker))
     claims = result.get("id_token_claims")

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -80,6 +80,7 @@ from azure.identity import (
 )
 import msal
 import msal_extensions
+import requests
 
 from napt.exceptions import AuthError, ConfigError
 
@@ -111,6 +112,7 @@ logging.getLogger("azure.identity").setLevel(logging.ERROR)
 REQUIRED_PERMISSIONS = ("DeviceManagementApps.ReadWrite.All", "Group.Read.All")
 
 _AUTHORITY_BASE = "https://login.microsoftonline.com"
+_GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 _AUTH_CONFIG_FILENAME = "auth.json"
 _TOKEN_CACHE_FILENAME = "token_cache.bin"
 
@@ -173,11 +175,25 @@ class AuthConfig:
         username: Account that signed in last (UPN), or ``None`` before the
             first login. Selects the right cached account when several
             tenants are signed in.
+        domain: The tenant's default verified domain (e.g. ``contoso.com``),
+            looked up from Graph at login; ``None`` when the lookup was not
+            possible.
+        display_name: The tenant's organization display name, looked up
+            alongside ``domain``.
     """
 
     client_id: str
     tenant_id: str
     username: str | None = None
+    domain: str | None = None
+    display_name: str | None = None
+
+    @property
+    def label(self) -> str | None:
+        """Human-readable tenant label: ``"contoso.com (Contoso)"``, or ``None``."""
+        if self.domain and self.display_name:
+            return f"{self.domain} ({self.display_name})"
+        return self.domain or self.display_name
 
 
 @dataclass
@@ -277,6 +293,8 @@ def load_auth_store() -> AuthStore:
                 client_id=entry["client_id"],
                 tenant_id=tenant_id,
                 username=entry.get("username"),
+                domain=entry.get("domain"),
+                display_name=entry.get("display_name"),
             )
             for tenant_id, entry in data.get("tenants", {}).items()
         }
@@ -294,7 +312,12 @@ def _save_auth_store(store: AuthStore) -> Path:
     payload = {
         "active": store.active,
         "tenants": {
-            tenant_id: {"client_id": cfg.client_id, "username": cfg.username}
+            tenant_id: {
+                "client_id": cfg.client_id,
+                "username": cfg.username,
+                "domain": cfg.domain,
+                "display_name": cfg.display_name,
+            }
             for tenant_id, cfg in store.tenants.items()
         },
     }
@@ -347,7 +370,13 @@ def resolve_auth_config(
     if not client:
         return None
     username = known.username if known and known.client_id == client else None
-    return AuthConfig(client_id=client, tenant_id=tenant, username=username)
+    return AuthConfig(
+        client_id=client,
+        tenant_id=tenant,
+        username=username,
+        domain=known.domain if known else None,
+        display_name=known.display_name if known else None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -524,6 +553,53 @@ def _remember(config: AuthConfig) -> Path:
     return _save_auth_store(store)
 
 
+def _lookup_tenant(token: str) -> tuple[str | None, str | None]:
+    """Fetches the tenant's default domain and display name from Graph.
+
+    Best effort: needs the delegated ``User.Read`` permission (present on
+    new app registrations by default). Any failure yields ``(None, None)``
+    rather than blocking sign-in -- the label is a convenience for
+    `napt auth status`, never a source of truth.
+
+    Returns:
+        ``(domain, display_name)`` with either element ``None`` when unknown.
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    try:
+        response = requests.get(
+            f"{_GRAPH_BASE}/organization?$select=displayName,verifiedDomains",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=15,
+        )
+        response.raise_for_status()
+        orgs = response.json().get("value") or []
+    except (requests.RequestException, ValueError) as err:
+        logger.verbose("AUTH", f"Tenant name lookup skipped: {err}")
+        return None, None
+    if not orgs:
+        return None, None
+    org = orgs[0]
+    domains = org.get("verifiedDomains") or []
+    default = next((d.get("name") for d in domains if d.get("isDefault")), None)
+    return default, org.get("displayName") or None
+
+
+def _with_tenant_label(config: AuthConfig, token: str) -> AuthConfig:
+    """Fills in the tenant label from Graph when ``config`` lacks one."""
+    if config.domain or config.display_name:
+        return config
+    domain, display_name = _lookup_tenant(token)
+    return AuthConfig(
+        client_id=config.client_id,
+        tenant_id=config.tenant_id,
+        username=config.username,
+        domain=domain,
+        display_name=display_name,
+    )
+
+
 def login(
     *,
     tenant_id: str | None = None,
@@ -569,7 +645,7 @@ def login(
         logger.verbose("AUTH", f"Cached session unusable, signing in again: {err}")
         cached = None
     if cached is not None:
-        _remember(config)
+        _remember(_with_tenant_label(config, cached))
         logger.info(
             "AUTH",
             f"Reusing signed-in session for {config.username} "
@@ -621,13 +697,12 @@ def login(
     if not status.account:
         status.account = username
 
-    saved_to = _remember(
-        AuthConfig(
-            client_id=config.client_id,
-            tenant_id=config.tenant_id,
-            username=username,
-        )
+    signed_in = AuthConfig(
+        client_id=config.client_id,
+        tenant_id=config.tenant_id,
+        username=username,
     )
+    saved_to = _remember(_with_tenant_label(signed_in, result["access_token"]))
     logger.verbose("AUTH", f"Saved sign-in settings to {saved_to}")
     return status
 
@@ -667,7 +742,10 @@ def logout(*, all_tenants: bool = False) -> list[str]:
         for account in accounts:
             app.remove_account(account)
         store.tenants[config.tenant_id] = AuthConfig(
-            client_id=config.client_id, tenant_id=config.tenant_id
+            client_id=config.client_id,
+            tenant_id=config.tenant_id,
+            domain=config.domain,
+            display_name=config.display_name,
         )
         if accounts:
             signed_out.append(config.tenant_id)

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -679,11 +679,11 @@ def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
     The package directory is inferred as packages/{app.id}/{version}/.
     Run 'napt package' before calling this function.
 
-    Authentication is automatic — no configuration required:
+    Authentication needs no configuration file:
 
-    - Developers: set AZURE_CLIENT_ID and AZURE_TENANT_ID, complete device code flow
-    - CI/CD: set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID
-    - Azure-hosted runners: assign a managed identity to the resource
+    - Developers: run 'napt auth login' once
+    - CI/CD: set AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET, or use
+        OIDC federation
 
     Before any Graph call, the package's installer hash (from the build
     manifest) is verified against the pending release recorded in the app's

--- a/poetry.lock
+++ b/poetry.lock
@@ -1062,7 +1062,7 @@ description = "The MSALRuntime Python Interop Package"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "(platform_system == \"Windows\" or platform_system == \"Darwin\" or platform_system == \"Linux\") and (sys_platform == \"win32\" or sys_platform == \"darwin\")"
+markers = "(platform_system == \"Windows\" or platform_system == \"Darwin\" or platform_system == \"Linux\") and sys_platform == \"win32\""
 files = [
     {file = "pymsalruntime-0.20.6-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:c5b61c4117b8f0f3738527a631434f4a5f0aef0d1a4a362af1c2e90a153323f6"},
     {file = "pymsalruntime-0.20.6-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:0ed68ca808fb50f5d31c664955f0750675d55386a1adb20500587d30fb1c7cd5"},
@@ -1479,4 +1479,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "e0674b36ff842ff368199f7f626fb52319062e922f1244cb4e296809b3155d52"
+content-hash = "491da7ea777e08a50369b16f4c4bb4b3a5f39c81f893d4db704897f63b348719"

--- a/poetry.lock
+++ b/poetry.lock
@@ -869,10 +869,11 @@ files = [
 [package.dependencies]
 cryptography = ">=2.5,<51"
 PyJWT = {version = ">=1.0.0,<3", extras = ["crypto"]}
+pymsalruntime = {version = ">=0.20,<0.21", optional = true, markers = "python_version >= \"3.9\" and (platform_system == \"Windows\" or platform_system == \"Darwin\" or platform_system == \"Linux\") and extra == \"broker\""}
 requests = ">=2.0.0,<3"
 
 [package.extras]
-broker = ["pymsalruntime (>=0.20,<0.21) ; python_version >= \"3.9\" and platform_system == \"Darwin\"", "pymsalruntime (>=0.20,<0.21) ; python_version >= \"3.9\" and platform_system == \"Linux\"", "pymsalruntime (>=0.20,<0.21) ; python_version >= \"3.9\" and platform_system == \"Windows\""]
+broker = ["pymsalruntime (>=0.20,<0.21) ; python_version >= \"3.9\" and (platform_system == \"Windows\" or platform_system == \"Darwin\" or platform_system == \"Linux\")", "pymsalruntime (>=0.20,<0.21) ; python_version >= \"3.9\" and platform_system == \"Darwin\"", "pymsalruntime (>=0.20,<0.21) ; python_version >= \"3.9\" and platform_system == \"Linux\""]
 
 [[package]]
 name = "msal-extensions"
@@ -1053,6 +1054,51 @@ pyyaml = "*"
 
 [package.extras]
 extra = ["pygments (>=2.19.1)"]
+
+[[package]]
+name = "pymsalruntime"
+version = "0.20.6"
+description = "The MSALRuntime Python Interop Package"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "(platform_system == \"Windows\" or platform_system == \"Darwin\" or platform_system == \"Linux\") and (sys_platform == \"win32\" or sys_platform == \"darwin\")"
+files = [
+    {file = "pymsalruntime-0.20.6-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:c5b61c4117b8f0f3738527a631434f4a5f0aef0d1a4a362af1c2e90a153323f6"},
+    {file = "pymsalruntime-0.20.6-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:0ed68ca808fb50f5d31c664955f0750675d55386a1adb20500587d30fb1c7cd5"},
+    {file = "pymsalruntime-0.20.6-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:9b443733cdbb85965eb5681158e72b33ed07e96ef68f5d1ecde303af2c5a1c3a"},
+    {file = "pymsalruntime-0.20.6-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:a9763b5fccd532da1bf4bca351d127b560e6ede622c311857d4213e09c056e6d"},
+    {file = "pymsalruntime-0.20.6-cp310-cp310-win32.whl", hash = "sha256:9e58d9163fe04d7299a8e64b9490e0d750156cd2b9e297b45d167897f74c2260"},
+    {file = "pymsalruntime-0.20.6-cp310-cp310-win_amd64.whl", hash = "sha256:0c8b4f2e04f262e3703731337ab597f0642c0535231cb0384470b6f0218ae89f"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ac54865d761124b774ffac4c19dcbbd85f44b1fa30beebdb6b4d01bd9b7f4c49"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:583a6174f1bd4b625493ff262beef771d6aca1e95cd5e2515f76ef994fdf9985"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-manylinux_2_24_x86_64.whl", hash = "sha256:6aeb3f18a01cad487b08a91d2eddda37d8ba758e5d9b2d014180fad62e890a25"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:6544f1eb50b31c45cff3a85cc7c41085124ee3a94be5b0dfaebc5e769499aedc"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-win32.whl", hash = "sha256:0a8cf16bf7582bd5dfb99fa9602b9cfe5e3d3d614fb4f830813a461957d3b5d8"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-win_amd64.whl", hash = "sha256:354be5d1fae5e2432510190a9f85b2fa5c11ea589bbb2b7696c02967fb03b352"},
+    {file = "pymsalruntime-0.20.6-cp311-cp311-win_arm64.whl", hash = "sha256:e2b8161950529dc8b392dcbf8ffee2e9ac1c2c0f2d21c1c3732f7e3a17a1cf5b"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd3dfa0345ff8cd36e8c625e382911acc244c6011421cacd6915aff99c424969"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:8bf4cf41dac35607291b0e96094112afe037b1da87f3a8d297d440e7b504a925"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-manylinux_2_24_x86_64.whl", hash = "sha256:c73d067faffc36b415cc3fad717703621c038a8a80555d5047f98e74a517a10a"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:27092c9ff824cb1ab87bd246329a2923bd0309f8466ccd993aa61a3a0864ef34"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-win32.whl", hash = "sha256:8680badb652d00c894f478cd6df01c750fdaaaf3d21b35897e158ee05ccf3983"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-win_amd64.whl", hash = "sha256:6b07eba5a99b755939157d5cab536d20d29718f28c6adf1ecf3b8753232082c1"},
+    {file = "pymsalruntime-0.20.6-cp312-cp312-win_arm64.whl", hash = "sha256:90eca0ea2563354b9d34fd9fed71f344c18fb4cdb3c6c0dcaf055d9e424cb30a"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:07ea98667e9607084b5bec103558f296fe936966dc6fc7e9a76bad11df6b87bf"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:b1e46f3a34b9fdd1fb8239337b698f39f97a7e0025cd7e36f41c67aa8492e0ad"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-manylinux_2_24_x86_64.whl", hash = "sha256:933934e2af37e8473b3388be9fd84df3bcabf30daacb27a22618e8d1368c5c9b"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:6273f1051d967079ddd266cfee5e38d5d596cc0d92824c368cea1dbfd4f47326"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-win32.whl", hash = "sha256:979c0d76ba8f5162b0e2128deb304c39b1e392120537302c56fd87aa856dc0dd"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-win_amd64.whl", hash = "sha256:2b8c6cfbb097175b0d8a2630aa3d2a86d583a6bb075917a775af0a177580dd92"},
+    {file = "pymsalruntime-0.20.6-cp313-cp313-win_arm64.whl", hash = "sha256:8ca988f5308f4c17a6cf85d14550015a1e17dc4e898e22698d040d3af2bee693"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b135a282d3357edbf52b380c40f0cf9967946c0c7b009d65e78f7d5fee714541"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:696faefab49f8de8144f2946b6efc1b0190fd15fb341c5ee89b5d3b9595e5722"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-manylinux_2_24_x86_64.whl", hash = "sha256:4abf78ad63e8d4e302033eaed4349ff8f3d75157e92cf39f5173a042990b807d"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:e4f92fafb39654abd13d6f1ca9fd20f51c7c6af86cd402b9daf6c8ec2b94e8c0"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-win32.whl", hash = "sha256:306bc0c0d673216820d10d591fefb05835543ae3487562f8493f16615ff72618"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-win_amd64.whl", hash = "sha256:eee01ce18b3e8b0212415859b020d7aef9b53dcd16c226f2ad035147c3ff04ae"},
+    {file = "pymsalruntime-0.20.6-cp314-cp314-win_arm64.whl", hash = "sha256:7deb8783c7f033c9ffaa1965e2b2be10bc236615c878be473f78aa5fc5ad20ba"},
+]
 
 [[package]]
 name = "pyright"
@@ -1433,4 +1479,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "64a058a9ac8f0d410259ac292f23aacd09e7c8e2071656a5c0a01a5f4e4bca9b"
+content-hash = "e0674b36ff842ff368199f7f626fb52319062e922f1244cb4e296809b3155d52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,8 @@ dependencies = [
     "azure-identity>=1.25.3",
     "msal>=1.35.1",
     "msal-extensions>=1.2.0",
-    # OS broker (Windows WAM / macOS Company Portal) for `napt auth login`.
-    # The native runtime only ships wheels for these platforms.
-    "msal[broker]>=1.35.1; sys_platform == 'win32' or sys_platform == 'darwin'",
+    # Windows broker (Web Account Manager) for `napt auth login`.
+    "msal[broker]>=1.35.1; sys_platform == 'win32'",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dependencies = [
     "jsonpath-ng>=1.6.1",
     "beautifulsoup4>=4.14.0",
     "azure-identity>=1.25.3",
+    "msal>=1.35.1",
+    "msal-extensions>=1.2.0",
+    # OS broker (Windows WAM / macOS Company Portal) for `napt auth login`.
+    # The native runtime only ships wheels for these platforms.
+    "msal[broker]>=1.35.1; sys_platform == 'win32' or sys_platform == 'darwin'",
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -643,7 +643,9 @@ class TestCmdAuth:
             AuthStore(
                 active="tid-b",
                 tenants={
-                    "tid-a": AuthConfig("cid-a", "tid-a", "a@x"),
+                    "tid-a": AuthConfig(
+                        "cid-a", "tid-a", "a@x", domain="a.com", display_name="A"
+                    ),
                     "tid-b": AuthConfig("cid-b", "tid-b", "b@x"),
                 },
             )
@@ -657,8 +659,8 @@ class TestCmdAuth:
             assert cmd_auth_status(_args()) == 0
         out = capsys.readouterr().out
         assert "Known tenants:" in out
-        assert "* tid-b  b@x  client cid-b" in out
-        assert "  tid-a  a@x  client cid-a" in out
+        assert "    a.com (A)       a@x  tid-a  client cid-a" in out
+        assert "  * (name unknown)  b@x  tid-b  client cid-b" in out
 
     def test_status_not_authenticated_returns_one(self, capsys):
         """Tests that status exits 1 and points at login when unauthenticated."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,9 @@ import pytest
 
 from napt.cli import (
     _resolve_build_dir_from_recipe,
+    cmd_auth_login,
+    cmd_auth_logout,
+    cmd_auth_status,
     cmd_build,
     cmd_discover,
     cmd_init,
@@ -22,6 +25,7 @@ from napt.cli import (
     cmd_validate,
 )
 from napt.exceptions import AuthError, ConfigError, NetworkError, PackagingError
+from napt.upload.auth import AuthStatus
 
 
 def _args(**kwargs) -> argparse.Namespace:
@@ -556,6 +560,109 @@ class TestCmdUpload:
         recipe.touch()
         with patch("napt.cli.upload_package", side_effect=NetworkError("net")):
             assert cmd_upload(_args(recipe=str(recipe), force=False)) == 1
+
+
+# =============================================================================
+# cmd_auth_*
+# =============================================================================
+
+
+class TestCmdAuth:
+    """Tests for the 'napt auth' subcommand handlers."""
+
+    def test_login_prints_account_and_permissions(self, capsys):
+        """Tests that a successful login prints the signed-in status block."""
+        status = AuthStatus(
+            method="interactive (broker)",
+            account="admin@contoso.com",
+            tenant_id="tid",
+            client_id="cid",
+            permissions=["DeviceManagementApps.ReadWrite.All", "Group.Read.All"],
+        )
+        with patch("napt.cli.auth_login", return_value=status) as login:
+            code = cmd_auth_login(
+                _args(client_id="cid", tenant_id="tid", no_broker=True)
+            )
+        assert code == 0
+        assert login.call_args.kwargs["use_broker"] is False
+        out = capsys.readouterr().out
+        assert "[OK] Signed in as admin@contoso.com" in out
+        assert "interactive (broker)" in out
+        assert "[WARNING]" not in out
+
+    def test_login_warns_about_missing_permissions(self, capsys):
+        """Tests that a token lacking required permissions is flagged."""
+        status = AuthStatus(
+            method="interactive (browser)",
+            account="u@x",
+            permissions=["Group.Read.All"],
+            missing=["DeviceManagementApps.ReadWrite.All"],
+        )
+        with patch("napt.cli.auth_login", return_value=status):
+            code = cmd_auth_login(
+                _args(client_id=None, tenant_id=None, no_broker=False)
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Missing required permissions: DeviceManagementApps" in out
+
+    def test_login_auth_error_returns_one(self, capsys):
+        """Tests that AuthError from login is reported and returns 1."""
+        with patch("napt.cli.auth_login", side_effect=AuthError("no redirect uri")):
+            code = cmd_auth_login(
+                _args(client_id=None, tenant_id=None, no_broker=False)
+            )
+        assert code == 1
+        assert "Authentication error: no redirect uri" in capsys.readouterr().out
+
+    def test_logout_reports_removed_session(self, capsys):
+        """Tests that logout confirms when a session was removed."""
+        with patch("napt.cli.auth_logout", return_value=True):
+            assert cmd_auth_logout(_args()) == 0
+        assert "[OK] Signed out" in capsys.readouterr().out
+
+    def test_logout_reports_nothing_to_do(self, capsys):
+        """Tests that logout says so when no session was cached."""
+        with patch("napt.cli.auth_logout", return_value=False):
+            assert cmd_auth_logout(_args()) == 0
+        assert "No interactive session" in capsys.readouterr().out
+
+    def test_status_not_authenticated_returns_one(self, capsys):
+        """Tests that status exits 1 and points at login when unauthenticated."""
+        with patch("napt.cli.auth_status", return_value=None):
+            assert cmd_auth_status(_args()) == 1
+        out = capsys.readouterr().out
+        assert "Not authenticated" in out
+        assert "napt auth login" in out
+
+    def test_status_ok_returns_zero(self, capsys):
+        """Tests that a fully permissioned credential exits 0."""
+        status = AuthStatus(
+            method="service principal",
+            account="cid",
+            permissions=["DeviceManagementApps.ReadWrite.All", "Group.Read.All"],
+        )
+        with patch("napt.cli.auth_status", return_value=status):
+            assert cmd_auth_status(_args()) == 0
+        assert "service principal" in capsys.readouterr().out
+
+    def test_status_missing_permission_returns_one(self, capsys):
+        """Tests that a credential missing a required permission exits 1."""
+        status = AuthStatus(
+            method="service principal",
+            account="cid",
+            permissions=[],
+            missing=["DeviceManagementApps.ReadWrite.All", "Group.Read.All"],
+        )
+        with patch("napt.cli.auth_status", return_value=status):
+            assert cmd_auth_status(_args()) == 1
+        assert "[WARNING] Missing required permissions" in capsys.readouterr().out
+
+    def test_status_auth_error_returns_one(self, capsys):
+        """Tests that an expired session surfaces as an authentication error."""
+        with patch("napt.cli.auth_status", side_effect=AuthError("expired")):
+            assert cmd_auth_status(_args()) == 1
+        assert "Authentication error: expired" in capsys.readouterr().out
 
 
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -659,8 +659,16 @@ class TestCmdAuth:
             assert cmd_auth_status(_args()) == 0
         out = capsys.readouterr().out
         assert "Known tenants:" in out
-        assert "    a.com (A)       a@x  tid-a  client cid-a" in out
-        assert "  * (name unknown)  b@x  tid-b  client cid-b" in out
+        assert (
+            "    A (a.com)\n"
+            "      Account:   a@x\n"
+            "      Tenant ID: tid-a\n"
+            "      Client ID: cid-a\n"
+            "  * (name unknown)\n"
+            "      Account:   b@x\n"
+            "      Tenant ID: tid-b\n"
+            "      Client ID: cid-b\n"
+        ) in out
 
     def test_status_not_authenticated_returns_one(self, capsys):
         """Tests that status exits 1 and points at login when unauthenticated."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -616,16 +616,49 @@ class TestCmdAuth:
         assert "Authentication error: no redirect uri" in capsys.readouterr().out
 
     def test_logout_reports_removed_session(self, capsys):
-        """Tests that logout confirms when a session was removed."""
-        with patch("napt.cli.auth_logout", return_value=True):
-            assert cmd_auth_logout(_args()) == 0
-        assert "[OK] Signed out" in capsys.readouterr().out
+        """Tests that logout confirms which tenants were signed out."""
+        with patch("napt.cli.auth_logout", return_value=["tid-a"]) as lo:
+            assert cmd_auth_logout(_args(all=False)) == 0
+        assert lo.call_args.kwargs["all_tenants"] is False
+        assert "[OK] Signed out of 1 tenant(s): tid-a" in capsys.readouterr().out
+
+    def test_logout_all_passes_flag(self, capsys):
+        """Tests that --all is forwarded to the auth module."""
+        with patch("napt.cli.auth_logout", return_value=["a", "b"]) as lo:
+            assert cmd_auth_logout(_args(all=True)) == 0
+        assert lo.call_args.kwargs["all_tenants"] is True
 
     def test_logout_reports_nothing_to_do(self, capsys):
         """Tests that logout says so when no session was cached."""
-        with patch("napt.cli.auth_logout", return_value=False):
-            assert cmd_auth_logout(_args()) == 0
+        with patch("napt.cli.auth_logout", return_value=[]):
+            assert cmd_auth_logout(_args(all=False)) == 0
         assert "No interactive session" in capsys.readouterr().out
+
+    def test_status_lists_known_tenants(self, capsys, tmp_path, monkeypatch):
+        """Tests that interactive status lists remembered tenants, marking the active."""
+        from napt.upload.auth import AuthConfig, AuthStore, _save_auth_store
+
+        monkeypatch.setenv("NAPT_USER_DIR", str(tmp_path))
+        _save_auth_store(
+            AuthStore(
+                active="tid-b",
+                tenants={
+                    "tid-a": AuthConfig("cid-a", "tid-a", "a@x"),
+                    "tid-b": AuthConfig("cid-b", "tid-b", "b@x"),
+                },
+            )
+        )
+        status = AuthStatus(
+            method="interactive (browser)",
+            account="b@x",
+            permissions=["DeviceManagementApps.ReadWrite.All", "Group.Read.All"],
+        )
+        with patch("napt.cli.auth_status", return_value=status):
+            assert cmd_auth_status(_args()) == 0
+        out = capsys.readouterr().out
+        assert "Known tenants:" in out
+        assert "* tid-b  b@x  client cid-b" in out
+        assert "  tid-a  a@x  client cid-a" in out
 
     def test_status_not_authenticated_returns_one(self, capsys):
         """Tests that status exits 1 and points at login when unauthenticated."""

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -132,29 +132,31 @@ def test_get_access_token_reports_expired_session(user_dir, chain_fails) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_auth_config_prefers_args_then_env_then_saved(
-    user_dir, monkeypatch
-) -> None:
-    """Tests the per-field precedence: explicit > env var > saved file."""
+def test_resolve_auth_config_prefers_args_over_saved(user_dir) -> None:
+    """Tests the per-field precedence: explicit argument > saved file."""
     assert resolve_auth_config() is None
 
     auth._save_auth_config(AuthConfig("saved-client", "saved-tenant"))
     assert resolve_auth_config() == AuthConfig("saved-client", "saved-tenant")
 
-    monkeypatch.setenv("AZURE_CLIENT_ID", "env-client")
-    assert resolve_auth_config() == AuthConfig("env-client", "saved-tenant")
-
     assert resolve_auth_config(tenant_id="arg-tenant") == AuthConfig(
-        "env-client", "arg-tenant"
+        "saved-client", "arg-tenant"
     )
 
 
-def test_resolve_auth_config_returns_none_when_incomplete(
-    user_dir, monkeypatch
-) -> None:
-    """Tests that a client ID without a tenant ID is not enough."""
+def test_resolve_auth_config_ignores_azure_env_vars(user_dir, monkeypatch) -> None:
+    """Tests that AZURE_* variables never configure interactive sign-in."""
     monkeypatch.setenv("AZURE_CLIENT_ID", "env-client")
+    monkeypatch.setenv("AZURE_TENANT_ID", "env-tenant")
     assert resolve_auth_config() is None
+
+    auth._save_auth_config(AuthConfig("saved-client", "saved-tenant"))
+    assert resolve_auth_config() == AuthConfig("saved-client", "saved-tenant")
+
+
+def test_resolve_auth_config_returns_none_when_incomplete(user_dir) -> None:
+    """Tests that a client ID without a tenant ID is not enough."""
+    assert resolve_auth_config(client_id="cid") is None
 
 
 def test_load_auth_config_rejects_malformed_file(user_dir) -> None:

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -13,6 +13,7 @@ from napt.exceptions import AuthError, ConfigError
 from napt.upload import auth
 from napt.upload.auth import (
     AuthConfig,
+    AuthStore,
     get_access_token,
     get_status,
     load_auth_config,
@@ -50,6 +51,15 @@ def chain_fails():
     cred.get_token.side_effect = ClientAuthenticationError("no cred")
     with patch("napt.upload.auth.get_credential", return_value=cred):
         yield cred
+
+
+def _remember(*configs: AuthConfig, active: str | None = None) -> None:
+    """Seeds the auth store with the given tenants; the last one is active."""
+    store = AuthStore(
+        active=active or configs[-1].tenant_id,
+        tenants={c.tenant_id: c for c in configs},
+    )
+    auth._save_auth_store(store)
 
 
 def _fake_app(
@@ -90,12 +100,13 @@ def test_get_access_token_tells_user_to_login_when_nothing_configured(
 
 def test_get_access_token_uses_cached_session(user_dir, chain_fails) -> None:
     """Tests that a cached interactive session is used silently."""
-    auth._save_auth_config(AuthConfig("cid", "tid"))
-    app = _fake_app(accounts=[{"username": "u"}], silent={"access_token": "cached"})
+    _remember(AuthConfig("cid", "tid", "u@x"))
+    app = _fake_app(accounts=[{"username": "u@x"}], silent={"access_token": "cached"})
 
     with patch("napt.upload.auth._build_public_client", return_value=app):
         assert get_access_token() == "cached"
 
+    app.get_accounts.assert_called_once_with(username="u@x")
     app.acquire_token_interactive.assert_not_called()
 
 
@@ -103,7 +114,7 @@ def test_get_access_token_never_opens_browser_without_session(
     user_dir, chain_fails
 ) -> None:
     """Tests that a configured app with no cached account fails instead of prompting."""
-    auth._save_auth_config(AuthConfig("cid", "tid"))
+    _remember(AuthConfig("cid", "tid", "u@x"))
     app = _fake_app(accounts=[])
 
     with patch("napt.upload.auth._build_public_client", return_value=app):
@@ -115,9 +126,9 @@ def test_get_access_token_never_opens_browser_without_session(
 
 def test_get_access_token_reports_expired_session(user_dir, chain_fails) -> None:
     """Tests that a session that can no longer refresh asks for a new login."""
-    auth._save_auth_config(AuthConfig("cid", "tid"))
+    _remember(AuthConfig("cid", "tid", "u@x"))
     app = _fake_app(
-        accounts=[{"username": "u"}],
+        accounts=[{"username": "u@x"}],
         silent={"error": "invalid_grant", "error_description": "AADSTS70008 expired"},
     )
 
@@ -132,15 +143,34 @@ def test_get_access_token_reports_expired_session(user_dir, chain_fails) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_auth_config_prefers_args_over_saved(user_dir) -> None:
-    """Tests the per-field precedence: explicit argument > saved file."""
+def test_resolve_auth_config_uses_active_tenant_by_default(user_dir) -> None:
+    """Tests that the active tenant's client ID and username are used."""
     assert resolve_auth_config() is None
 
-    auth._save_auth_config(AuthConfig("saved-client", "saved-tenant"))
-    assert resolve_auth_config() == AuthConfig("saved-client", "saved-tenant")
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
+    assert resolve_auth_config() == AuthConfig("cid-b", "tid-b", "b@x")
 
-    assert resolve_auth_config(tenant_id="arg-tenant") == AuthConfig(
-        "saved-client", "arg-tenant"
+
+def test_resolve_auth_config_switches_tenant_by_id(user_dir) -> None:
+    """Tests that --tenant-id alone selects a remembered tenant's settings."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
+    assert resolve_auth_config(tenant_id="tid-a") == AuthConfig("cid-a", "tid-a", "a@x")
+
+
+def test_resolve_auth_config_unknown_tenant_needs_client_id(user_dir) -> None:
+    """Tests that a never-seen tenant needs an explicit client ID."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"))
+    assert resolve_auth_config(tenant_id="tid-new") is None
+    assert resolve_auth_config(tenant_id="tid-new", client_id="cid-new") == AuthConfig(
+        "cid-new", "tid-new", None
+    )
+
+
+def test_resolve_auth_config_drops_username_when_client_changes(user_dir) -> None:
+    """Tests that a different app registration does not inherit the session."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"))
+    assert resolve_auth_config(client_id="cid-other") == AuthConfig(
+        "cid-other", "tid-a", None
     )
 
 
@@ -150,8 +180,8 @@ def test_resolve_auth_config_ignores_azure_env_vars(user_dir, monkeypatch) -> No
     monkeypatch.setenv("AZURE_TENANT_ID", "env-tenant")
     assert resolve_auth_config() is None
 
-    auth._save_auth_config(AuthConfig("saved-client", "saved-tenant"))
-    assert resolve_auth_config() == AuthConfig("saved-client", "saved-tenant")
+    _remember(AuthConfig("saved-client", "saved-tenant", "s@x"))
+    assert resolve_auth_config() == AuthConfig("saved-client", "saved-tenant", "s@x")
 
 
 def test_resolve_auth_config_returns_none_when_incomplete(user_dir) -> None:
@@ -193,9 +223,64 @@ def test_login_saves_config_and_reports_permissions(user_dir) -> None:
     assert status.method == "interactive (browser)"
     assert status.account == "admin@contoso.com"
     assert status.missing == []
-    assert load_auth_config() == AuthConfig("cid", "tid")
+    assert load_auth_config() == AuthConfig("cid", "tid", "admin@contoso.com")
     kwargs = app.acquire_token_interactive.call_args.kwargs
     assert kwargs["parent_window_handle"] is None
+
+
+def test_login_reuses_valid_session_without_prompt(user_dir) -> None:
+    """Tests that switching to a signed-in tenant is silent."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
+    token = _jwt({"preferred_username": "a@x", "tid": "tid-a"})
+    app = _fake_app(accounts=[{"username": "a@x"}], silent={"access_token": token})
+
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+    ):
+        status = login(tenant_id="tid-a")
+
+    assert status.account == "a@x"
+    app.acquire_token_interactive.assert_not_called()
+    assert auth.load_auth_store().active == "tid-a"
+
+
+def test_login_prompts_when_cached_session_expired(user_dir) -> None:
+    """Tests that an unrefreshable session falls through to interactive."""
+    _remember(AuthConfig("cid", "tid", "u@x"))
+    token = _jwt({"preferred_username": "u@x"})
+    app = _fake_app(
+        accounts=[{"username": "u@x"}],
+        silent={"error": "invalid_grant", "error_description": "expired"},
+        interactive={"access_token": token},
+    )
+
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+    ):
+        status = login()
+
+    assert status.account == "u@x"
+    app.acquire_token_interactive.assert_called_once()
+
+
+def test_login_keeps_other_tenants(user_dir) -> None:
+    """Tests that signing in to a new tenant preserves the others."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"))
+    token = _jwt({"preferred_username": "b@x", "tid": "tid-b"})
+    app = _fake_app(interactive={"access_token": token})
+
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+    ):
+        login(client_id="cid-b", tenant_id="tid-b")
+
+    store = auth.load_auth_store()
+    assert store.active == "tid-b"
+    assert store.tenants["tid-a"] == AuthConfig("cid-a", "tid-a", "a@x")
+    assert store.tenants["tid-b"] == AuthConfig("cid-b", "tid-b", "b@x")
 
 
 def test_login_uses_broker_when_available(user_dir) -> None:
@@ -253,23 +338,37 @@ def test_login_surfaces_msal_error(user_dir) -> None:
     assert load_auth_config() is None
 
 
-def test_logout_removes_all_accounts(user_dir) -> None:
-    """Tests that logout removes every cached account and keeps the config."""
-    auth._save_auth_config(AuthConfig("cid", "tid"))
-    (user_dir / "token_cache.bin").write_bytes(b"")
-    accounts = [{"username": "a"}, {"username": "b"}]
-    app = _fake_app(accounts=accounts)
+def test_logout_signs_out_active_tenant_only(user_dir) -> None:
+    """Tests that logout removes the active tenant's account and keeps its IDs."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
+    app = _fake_app(accounts=[{"username": "b@x"}])
 
     with patch("napt.upload.auth._build_public_client", return_value=app):
-        assert logout() is True
+        assert logout() == ["tid-b"]
 
-    assert app.remove_account.call_count == 2
-    assert load_auth_config() == AuthConfig("cid", "tid")
+    app.get_accounts.assert_called_once_with(username="b@x")
+    app.remove_account.assert_called_once()
+    store = auth.load_auth_store()
+    assert store.tenants["tid-b"] == AuthConfig("cid-b", "tid-b", None)
+    assert store.tenants["tid-a"] == AuthConfig("cid-a", "tid-a", "a@x")
+    assert store.active == "tid-b"
 
 
-def test_logout_without_session_returns_false(user_dir) -> None:
+def test_logout_all_signs_out_every_tenant(user_dir) -> None:
+    """Tests that --all clears every remembered tenant's session."""
+    _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
+    app = _fake_app(accounts=[{"username": "x"}])
+
+    with patch("napt.upload.auth._build_public_client", return_value=app):
+        assert sorted(logout(all_tenants=True)) == ["tid-a", "tid-b"]
+
+    store = auth.load_auth_store()
+    assert all(c.username is None for c in store.tenants.values())
+
+
+def test_logout_without_session_returns_empty(user_dir) -> None:
     """Tests that logout is a no-op when nothing was ever cached."""
-    assert logout() is False
+    assert logout() == []
 
 
 def test_get_status_reports_service_principal(user_dir, monkeypatch) -> None:

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -460,7 +460,7 @@ def test_login_stores_tenant_domain_and_name(user_dir) -> None:
     assert saved is not None
     assert saved.domain == "contoso.com"
     assert saved.display_name == "Contoso"
-    assert saved.label == "contoso.com (Contoso)"
+    assert saved.label == "Contoso (contoso.com)"
     assert get.call_args.kwargs["headers"]["Authorization"] == f"Bearer {token}"
 
 
@@ -494,4 +494,19 @@ def test_logout_keeps_tenant_label(user_dir) -> None:
         logout()
     saved = auth.load_auth_store().tenants["tid"]
     assert saved.username is None
-    assert saved.label == "x.com (X)"
+    assert saved.label == "X (x.com)"
+
+
+def test_resolve_auth_config_accepts_domain_for_tenant(user_dir) -> None:
+    """Tests that --tenant-id may be a remembered tenant's default domain."""
+    _remember(
+        AuthConfig("cid-a", "tid-a", "a@x", domain="a.com", display_name="A"),
+        AuthConfig("cid-b", "tid-b", "b@x", domain="b.com", display_name="B"),
+    )
+    resolved = resolve_auth_config(tenant_id="A.com")
+    assert resolved is not None
+    assert resolved.tenant_id == "tid-a"
+    assert resolved.client_id == "cid-a"
+    assert resolved.username == "a@x"
+    # Unknown domains are passed through untouched so the error names them.
+    assert resolve_auth_config(tenant_id="nope.com") is None

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -401,3 +401,29 @@ def test_status_handles_opaque_token() -> None:
     assert status.account is None
     assert status.permissions == []
     assert set(status.missing) == set(auth.REQUIRED_PERMISSIONS)
+
+
+def test_login_canceled_in_broker_explains_hidden_error(user_dir) -> None:
+    """Tests that a WAM cancel points at the redirect-URI cause shown in the window."""
+
+    class _Status:
+        def __str__(self) -> str:
+            return "Response_Status.Status_UserCanceled"
+
+    app = _fake_app(
+        interactive={
+            "error": "broker_error",
+            "error_description": "User canceled the flow. Status: ...",
+            "_broker_status": _Status(),
+            "correlation_id": "abc-123",
+        }
+    )
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=True),
+    ):
+        with pytest.raises(AuthError, match="canceled") as exc:
+            login(client_id="cid", tenant_id="tid")
+    msg = str(exc.value)
+    assert "AADSTS500113" in msg
+    assert "correlation_id abc-123" in msg

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -427,3 +427,71 @@ def test_login_canceled_in_broker_explains_hidden_error(user_dir) -> None:
     msg = str(exc.value)
     assert "AADSTS500113" in msg
     assert "correlation_id abc-123" in msg
+
+
+def _org_response(
+    domains: list[dict] | None, name: str | None = "Contoso"
+) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {
+        "value": [{"displayName": name, "verifiedDomains": domains or []}]
+    }
+    return resp
+
+
+def test_login_stores_tenant_domain_and_name(user_dir) -> None:
+    """Tests that a successful login records the default domain and display name."""
+    token = _jwt({"preferred_username": "a@contoso.com", "tid": "tid"})
+    app = _fake_app(interactive={"access_token": token})
+    org = _org_response(
+        [
+            {"name": "contoso.onmicrosoft.com", "isInitial": True, "isDefault": False},
+            {"name": "contoso.com", "isInitial": False, "isDefault": True},
+        ]
+    )
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.upload.auth.requests.get", return_value=org) as get,
+    ):
+        login(client_id="cid", tenant_id="tid")
+
+    saved = load_auth_config()
+    assert saved is not None
+    assert saved.domain == "contoso.com"
+    assert saved.display_name == "Contoso"
+    assert saved.label == "contoso.com (Contoso)"
+    assert get.call_args.kwargs["headers"]["Authorization"] == f"Bearer {token}"
+
+
+def test_login_without_user_read_leaves_label_empty(user_dir) -> None:
+    """Tests that a Graph 403 on /organization never blocks or mislabels login."""
+    import requests as _requests
+
+    token = _jwt({"preferred_username": "a@msp.com"})
+    app = _fake_app(interactive={"access_token": token})
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+        patch(
+            "napt.upload.auth.requests.get",
+            side_effect=_requests.HTTPError("403 Forbidden"),
+        ),
+    ):
+        status = login(client_id="cid", tenant_id="tid")
+
+    assert status.account == "a@msp.com"
+    saved = load_auth_config()
+    assert saved is not None
+    assert saved.label is None  # no UPN-domain guess
+
+
+def test_logout_keeps_tenant_label(user_dir) -> None:
+    """Tests that signing out clears the account but keeps the tenant label."""
+    _remember(AuthConfig("cid", "tid", "u@x", domain="x.com", display_name="X"))
+    app = _fake_app(accounts=[{"username": "u@x"}])
+    with patch("napt.upload.auth._build_public_client", return_value=app):
+        logout()
+    saved = auth.load_auth_store().tenants["tid"]
+    assert saved.username is None
+    assert saved.label == "x.com (X)"

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -2,36 +2,301 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from unittest.mock import MagicMock, patch
 
+from azure.core.exceptions import ClientAuthenticationError
 import pytest
 
-from napt.exceptions import AuthError
-from napt.upload.auth import get_access_token
+from napt.exceptions import AuthError, ConfigError
+from napt.upload import auth
+from napt.upload.auth import (
+    AuthConfig,
+    get_access_token,
+    get_status,
+    load_auth_config,
+    login,
+    logout,
+    resolve_auth_config,
+)
 
 
-def test_get_access_token_returns_token_on_phase1_success() -> None:
-    """Tests that get_access_token returns the token when Phase 1 succeeds."""
+def _jwt(claims: dict) -> str:
+    """Builds an unsigned JWT-shaped string carrying the given claims."""
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=")
+    return f"eyJhbGciOiJub25lIn0.{payload.decode()}.sig"
+
+
+@pytest.fixture
+def user_dir(tmp_path, monkeypatch):
+    """Points NAPT's user data dir at a temp dir and clears AZURE_* env vars."""
+    monkeypatch.setenv("NAPT_USER_DIR", str(tmp_path))
+    for var in (
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_CLIENT_CERTIFICATE_PATH",
+        "AZURE_FEDERATED_TOKEN_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def chain_fails():
+    """Makes the non-interactive azure-identity chain report no credential."""
+    cred = MagicMock()
+    cred.get_token.side_effect = ClientAuthenticationError("no cred")
+    with patch("napt.upload.auth.get_credential", return_value=cred):
+        yield cred
+
+
+def _fake_app(
+    accounts: list | None = None,
+    silent: dict | None = None,
+    interactive: dict | None = None,
+) -> MagicMock:
+    app = MagicMock()
+    app.get_accounts.return_value = accounts or []
+    app.acquire_token_silent_with_error.return_value = silent
+    app.acquire_token_interactive.return_value = interactive
+    return app
+
+
+# ---------------------------------------------------------------------------
+# get_access_token
+# ---------------------------------------------------------------------------
+
+
+def test_get_access_token_returns_token_when_chain_succeeds() -> None:
+    """Tests that the non-interactive chain's token is returned as-is."""
     mock_token = MagicMock()
     mock_token.token = "test-bearer-token"
-    mock_credential = MagicMock()
-    mock_credential.get_token.return_value = mock_token
+    cred = MagicMock()
+    cred.get_token.return_value = mock_token
 
-    with patch("napt.upload.auth.get_credential", return_value=mock_credential):
-        result = get_access_token()
-
-    assert result == "test-bearer-token"
+    with patch("napt.upload.auth.get_credential", return_value=cred):
+        assert get_access_token() == "test-bearer-token"
 
 
-def test_get_access_token_raises_auth_error_when_all_fail_non_tty() -> None:
-    """Tests that AuthError is raised when Phase 1 fails and stdout is not a TTY."""
-    from azure.core.exceptions import ClientAuthenticationError
+def test_get_access_token_tells_user_to_login_when_nothing_configured(
+    user_dir, chain_fails
+) -> None:
+    """Tests that an unconfigured interactive user is pointed at 'napt auth login'."""
+    with pytest.raises(AuthError, match="napt auth login"):
+        get_access_token()
 
-    mock_credential = MagicMock()
-    mock_credential.get_token.side_effect = ClientAuthenticationError("no cred")
 
-    with patch("napt.upload.auth.get_credential", return_value=mock_credential):
-        with patch("napt.upload.auth.sys.stdout") as mock_stdout:
-            mock_stdout.isatty.return_value = False
-            with pytest.raises(AuthError):
-                get_access_token()
+def test_get_access_token_uses_cached_session(user_dir, chain_fails) -> None:
+    """Tests that a cached interactive session is used silently."""
+    auth._save_auth_config(AuthConfig("cid", "tid"))
+    app = _fake_app(accounts=[{"username": "u"}], silent={"access_token": "cached"})
+
+    with patch("napt.upload.auth._build_public_client", return_value=app):
+        assert get_access_token() == "cached"
+
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_get_access_token_never_opens_browser_without_session(
+    user_dir, chain_fails
+) -> None:
+    """Tests that a configured app with no cached account fails instead of prompting."""
+    auth._save_auth_config(AuthConfig("cid", "tid"))
+    app = _fake_app(accounts=[])
+
+    with patch("napt.upload.auth._build_public_client", return_value=app):
+        with pytest.raises(AuthError, match="napt auth login"):
+            get_access_token()
+
+    app.acquire_token_interactive.assert_not_called()
+
+
+def test_get_access_token_reports_expired_session(user_dir, chain_fails) -> None:
+    """Tests that a session that can no longer refresh asks for a new login."""
+    auth._save_auth_config(AuthConfig("cid", "tid"))
+    app = _fake_app(
+        accounts=[{"username": "u"}],
+        silent={"error": "invalid_grant", "error_description": "AADSTS70008 expired"},
+    )
+
+    with patch("napt.upload.auth._build_public_client", return_value=app):
+        with pytest.raises(AuthError, match="invalid_grant") as excinfo:
+            get_access_token()
+    assert "napt auth login" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_auth_config_prefers_args_then_env_then_saved(
+    user_dir, monkeypatch
+) -> None:
+    """Tests the per-field precedence: explicit > env var > saved file."""
+    assert resolve_auth_config() is None
+
+    auth._save_auth_config(AuthConfig("saved-client", "saved-tenant"))
+    assert resolve_auth_config() == AuthConfig("saved-client", "saved-tenant")
+
+    monkeypatch.setenv("AZURE_CLIENT_ID", "env-client")
+    assert resolve_auth_config() == AuthConfig("env-client", "saved-tenant")
+
+    assert resolve_auth_config(tenant_id="arg-tenant") == AuthConfig(
+        "env-client", "arg-tenant"
+    )
+
+
+def test_resolve_auth_config_returns_none_when_incomplete(
+    user_dir, monkeypatch
+) -> None:
+    """Tests that a client ID without a tenant ID is not enough."""
+    monkeypatch.setenv("AZURE_CLIENT_ID", "env-client")
+    assert resolve_auth_config() is None
+
+
+def test_load_auth_config_rejects_malformed_file(user_dir) -> None:
+    """Tests that a corrupt auth.json raises ConfigError with a remedy."""
+    (user_dir / "auth.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(ConfigError, match="napt auth login"):
+        load_auth_config()
+
+
+# ---------------------------------------------------------------------------
+# login / logout / status
+# ---------------------------------------------------------------------------
+
+
+def test_login_saves_config_and_reports_permissions(user_dir) -> None:
+    """Tests that a successful login persists IDs and decodes the token."""
+    token = _jwt(
+        {
+            "preferred_username": "admin@contoso.com",
+            "tid": "tid",
+            "appid": "cid",
+            "scp": "DeviceManagementApps.ReadWrite.All Group.Read.All",
+            "exp": 1_900_000_000,
+        }
+    )
+    app = _fake_app(interactive={"access_token": token})
+
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+    ):
+        status = login(client_id="cid", tenant_id="tid")
+
+    assert status.method == "interactive (browser)"
+    assert status.account == "admin@contoso.com"
+    assert status.missing == []
+    assert load_auth_config() == AuthConfig("cid", "tid")
+    kwargs = app.acquire_token_interactive.call_args.kwargs
+    assert kwargs["parent_window_handle"] is None
+
+
+def test_login_uses_broker_when_available(user_dir) -> None:
+    """Tests that the broker path passes the console window handle."""
+    token = _jwt({"scp": "Group.Read.All", "preferred_username": "u@x"})
+    app = _fake_app(interactive={"access_token": token})
+
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app) as build,
+        patch("napt.upload.auth._broker_available", return_value=True),
+    ):
+        status = login(client_id="cid", tenant_id="tid")
+
+    assert status.method == "interactive (broker)"
+    assert status.missing == ["DeviceManagementApps.ReadWrite.All"]
+    assert build.call_args.kwargs["use_broker"] is True
+    kwargs = app.acquire_token_interactive.call_args.kwargs
+    assert kwargs["parent_window_handle"] is not None
+
+
+def test_login_no_broker_flag_forces_browser(user_dir) -> None:
+    """Tests that use_broker=False bypasses an available broker."""
+    app = _fake_app(interactive={"access_token": _jwt({})})
+
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app) as build,
+        patch("napt.upload.auth._broker_available", return_value=True),
+    ):
+        login(client_id="cid", tenant_id="tid", use_broker=False)
+
+    assert build.call_args.kwargs["use_broker"] is False
+
+
+def test_login_without_config_raises(user_dir) -> None:
+    """Tests that login with no IDs anywhere explains how to supply them."""
+    with pytest.raises(AuthError, match="--client-id"):
+        login()
+
+
+def test_login_surfaces_msal_error(user_dir) -> None:
+    """Tests that an MSAL error dict becomes an AuthError with the code."""
+    app = _fake_app(
+        interactive={
+            "error": "invalid_client",
+            "error_description": "AADSTS50011: redirect URI mismatch\nTrace: x",
+        }
+    )
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._broker_available", return_value=False),
+    ):
+        with pytest.raises(AuthError, match="invalid_client: AADSTS50011") as exc:
+            login(client_id="cid", tenant_id="tid")
+    assert "redirect URI" in str(exc.value)
+    assert load_auth_config() is None
+
+
+def test_logout_removes_all_accounts(user_dir) -> None:
+    """Tests that logout removes every cached account and keeps the config."""
+    auth._save_auth_config(AuthConfig("cid", "tid"))
+    (user_dir / "token_cache.bin").write_bytes(b"")
+    accounts = [{"username": "a"}, {"username": "b"}]
+    app = _fake_app(accounts=accounts)
+
+    with patch("napt.upload.auth._build_public_client", return_value=app):
+        assert logout() is True
+
+    assert app.remove_account.call_count == 2
+    assert load_auth_config() == AuthConfig("cid", "tid")
+
+
+def test_logout_without_session_returns_false(user_dir) -> None:
+    """Tests that logout is a no-op when nothing was ever cached."""
+    assert logout() is False
+
+
+def test_get_status_reports_service_principal(user_dir, monkeypatch) -> None:
+    """Tests that an application token is described as a service principal."""
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "s")
+    token = MagicMock()
+    token.token = _jwt(
+        {"appid": "cid", "tid": "tid", "roles": ["DeviceManagementApps.ReadWrite.All"]}
+    )
+    cred = MagicMock()
+    cred.get_token.return_value = token
+
+    with patch("napt.upload.auth.get_credential", return_value=cred):
+        status = get_status()
+
+    assert status is not None
+    assert status.method == "service principal"
+    assert status.account == "cid"
+    assert status.missing == ["Group.Read.All"]
+
+
+def test_get_status_returns_none_when_unauthenticated(user_dir, chain_fails) -> None:
+    """Tests that status is None with no env credential and no session."""
+    assert get_status() is None
+
+
+def test_status_handles_opaque_token() -> None:
+    """Tests that an undecodable token still yields a status object."""
+    status = auth._status_from_token("not-a-jwt", "service principal")
+    assert status.account is None
+    assert status.permissions == []
+    assert set(status.missing) == set(auth.REQUIRED_PERMISSIONS)


### PR DESCRIPTION
## Description
Replaces device code authentication with an explicit `napt auth login` that uses the authorization code flow with PKCE (system browser) or the Windows Web Account Manager broker, caches tokens in the OS credential store, and remembers every tenant you sign in to. Adds `napt auth status` and `napt auth logout`, and adds OIDC (workload identity federation) to the non-interactive CI/CD chain.

## Motivation
Device code flow is the OAuth flow most often abused to bypass MFA, and Microsoft-managed Conditional Access policies now block it tenant-wide by default in a growing share of tenants, so NAPT's only interactive path was heading toward "just fails". The replacement follows the pattern used by `az`/`gh`: sign in once explicitly, then every command authenticates silently; CI supplies a credential through environment variables, preferably without a secret at all.

## Changes
- **BREAKING: Device code flow removed.** Interactive sign-in is now `napt auth login` (auth code + PKCE, or the Windows broker when `pymsalruntime` is installed). App registrations need the `http://localhost` and `ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>` redirect URIs under *Mobile and desktop applications*; "Allow public client flows" is no longer needed.
- **BREAKING: Managed identity removed** from the credential chain; use a service principal or OIDC federation.
- `napt upload` / `napt promote` never open a browser; without a credential they fail with `Not authenticated. Run 'napt auth login'`.
- New `napt auth login [--tenant-id] [--client-id] [--no-broker]`, `napt auth status`, `napt auth logout [--all]`.
- Tokens cached via `msal-extensions` in the OS credential store (DPAPI / Keychain / libsecret); never in plain files.
- Tenant-keyed store (`%LOCALAPPDATA%\napt\auth.json`, `NAPT_USER_DIR` to relocate) remembers client ID, signed-in account, and the tenant's default domain + display name per tenant. `login --tenant-id <id or domain>` switches between signed-in tenants silently; cached accounts are selected by username, so two tenants with different admin accounts no longer collide.
- `napt auth status` reports the credential NAPT would use (same resolution as `upload`), account, tenant, expiry, and Graph permissions; exits 1 and names any required permission that is missing. Lists known tenants.
- `WorkloadIdentityCredential` added for CI/CD OIDC (e.g. GitHub Actions `azure/login`); documented as the recommended CI setup over client secrets.
- `AZURE_*` environment variables are a CI credential only; they no longer configure interactive sign-in.
- Failure messages name the specific fix (missing redirect URI, unconsented delegated permissions, expired session, WAM cancel after an error shown in the broker window) and include the MSAL `correlation_id`.
- Removed the unused `napt upload --tenant-id` option.
- Dependencies: `msal`, `msal-extensions` declared directly; `msal[broker]` gated to `sys_platform == 'win32'`.
- Docs: Authentication and App Registration Setup rewritten (user-guide, common-tasks), changelog entries, `AUTH` added to the log-prefix list in CLAUDE.md.

## Testing
- [x] Unit tests added/updated — 31 auth tests, 13 CLI tests; full suite 785 passing
- [ ] Integration tests added/updated — none needed; existing integration suite passes
- [x] Manual testing performed — live `napt auth login` via the Windows broker against the dev tenant, `napt auth status` (tenant label, permissions), error paths (missing redirect URI / WAM cancel)

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors
