### PR TITLE
feat: Add napt auth setup to provision app registration

### DIFF
--- a/docs/api/upload.md
+++ b/docs/api/upload.md
@@ -6,4 +6,6 @@
 
 ::: napt.upload.auth
 
+::: napt.upload.entra
+
 ::: napt.upload.graph

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,9 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         clears them all
     - Tokens are cached in the OS credential store (DPAPI, Keychain,
         libsecret), never in plain files
-- **OIDC federation for CI/CD** - `AZURE_FEDERATED_TOKEN_FILE` (as set by
-    GitHub Actions `azure/login`) is now honored, so pipelines can run
-    without a client secret; documented as the recommended CI/CD setup
+- **OIDC federation for CI/CD** - An existing Azure CLI session (what OIDC
+    login steps such as GitHub Actions `azure/login` leave behind) is now
+    honored, so pipelines can run without a client secret; documented as
+    the recommended CI/CD setup
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,10 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         clears them all
     - Tokens are cached in the OS credential store (DPAPI, Keychain,
         libsecret), never in plain files
-- **OIDC federation for CI/CD** - An existing Azure CLI session (what OIDC
-    login steps such as GitHub Actions `azure/login` leave behind) is now
-    honored, so pipelines can run without a client secret; documented as
-    the recommended CI/CD setup
+- **OIDC federation for CI/CD** - An Azure CLI session signed in as a
+    service principal (what OIDC login steps such as GitHub Actions
+    `azure/login` leave behind) is now honored, so pipelines can run
+    without a client secret; documented as the recommended CI/CD setup.
+    A CLI signed in as a person is refused so Intune activity is always
+    attributed to the NAPT registration
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`napt auth setup`** - Create the NAPT app registration in a tenant
+    without touching the portal: signs in as an administrator, then creates
+    (or completes) the registration with its redirect URIs, application and
+    delegated Graph permissions, service principal, and admin consent
+    - `--federated-issuer` / `--federated-subject` (plus optional
+        `--federated-audience` and `--federated-name`) also add a federated
+        credential for OIDC-based CI/CD, so no client secret is needed; the
+        values come from your CI platform's OIDC documentation
+    - Stamps the registration's internal notes with
+        `napt/v1 spec=<n> version=<napt version> provisioned=<date>`; admin
+        notes below the stamp are preserved
+    - Safe to re-run: compares the registration against what the installed
+        NAPT needs and adds only what is missing, so updating after a NAPT
+        release is the same command. `--name` and `--client-id` target an
+        existing registration
+    - A name match without a NAPT stamp is reported and left untouched
+        until `--adopt` is given; nothing existing is ever removed
+    - `--print-only` prints the equivalent portal checklist for tenants
+        where the automated path is not allowed
 - **`napt auth login` / `status` / `logout`** - Sign in to Microsoft Graph
     once and let every later command authenticate silently
     - `login` opens the Windows account picker (Web Account Manager) when

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -485,8 +485,20 @@ Upload a packaged app to Microsoft Intune. Requires `napt package` to have run f
 
 ### App Registration Setup (one time per organization)
 
-Follow [App Registration Setup](user-guide.md#app-registration-setup) in the
-user guide.
+Fastest path, as an Application Administrator:
+
+```bash
+napt auth setup --tenant-id "<Directory (tenant) ID>"            # portal-free
+
+# Also trust a CI platform through OIDC (GitHub Actions, main branch shown):
+napt auth setup --tenant-id "<Directory (tenant) ID>" \
+  --federated-issuer https://token.actions.githubusercontent.com \
+  --federated-subject repo:owner/intune-apps:ref:refs/heads/main
+```
+
+To do it by hand, follow
+[App Registration Setup](user-guide.md#app-registration-setup) in the user
+guide (or run `napt auth setup ... --print-only` for the checklist).
 In short: register an app, add `DeviceManagementApps.ReadWrite.All` and
 `Group.Read.All` as both application and delegated Graph permissions, grant
 admin consent, and add the `http://localhost` and

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -485,7 +485,7 @@ Upload a packaged app to Microsoft Intune. Requires `napt package` to have run f
 
 ### App Registration Setup (one time per organization)
 
-Fastest path, as an Application Administrator:
+Fastest path, as at least an Application Administrator:
 
 ```bash
 napt auth setup --tenant-id "<Directory (tenant) ID>"            # portal-free

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -590,19 +590,24 @@ napt upload recipes/Google/chrome.yaml
 With OIDC federation (recommended):
 
 ```yaml
-# GitHub Actions example
+# GitHub Actions example; the federated credential is scoped to the
+# "intune" environment, so only jobs that declare it receive tokens
 permissions:
   id-token: write
   contents: read
 
-steps:
-  - uses: azure/login@v2
-    with:
-      client-id: ${{ secrets.AZURE_CLIENT_ID }}
-      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      allow-no-subscriptions: true
-  - name: Upload to Intune
-    run: napt upload recipes/Google/chrome.yaml
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: intune
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+      - name: Upload to Intune
+        run: napt upload recipes/Google/chrome.yaml
 ```
 
 With a client secret:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -295,14 +295,12 @@ source it picked:
 | Method | When it's used |
 |--------|---------------|
 | Service principal (`EnvironmentCredential`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` (or `AZURE_CLIENT_CERTIFICATE_PATH`) are set — CI/CD |
-| Workload identity federation (`WorkloadIdentityCredential`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE` are set — CI/CD with OIDC, e.g. GitHub Actions `azure/login`. Recommended over a client secret whenever your CI platform supports it |
 | Interactive session (`napt auth login`) | Nothing above is set and you have signed in on this machine — developers |
+| Azure CLI (`AzureCliCredential`) | Nothing above applies and `az login` has been run in this environment — CI/CD with OIDC through a login step such as GitHub Actions `azure/login`. Recommended over a client secret whenever your CI platform supports it |
 
 NAPT never opens a browser on its own.
 If no credential is available, commands fail with
 `Not authenticated. Run 'napt auth login'`.
-This mirrors `az`/`gh`: sign in explicitly once, then everything else is
-silent.
 
 #### App Registration Setup
 
@@ -389,8 +387,7 @@ The remembered tenants and the cache live under `%LOCALAPPDATA%\napt`
 `~/.config/napt` (Linux); set `NAPT_USER_DIR` to relocate them.
 The `AZURE_*` environment variables play no part in interactive sign-in;
 they are how CI/CD supplies a credential (below), and when they are set
-they take precedence over your session — the same rule `gh` (`GH_TOKEN`)
-and `aws` (`AWS_ACCESS_KEY_ID`) follow.
+they take precedence over your session.
 
 Check what you are holding at any time:
 
@@ -443,35 +440,51 @@ napt auth login --tenant-id contosodev.onmicrosoft.com                          
 No secret to store or rotate.
 Create a federated credential on the app registration that trusts your CI
 platform's OIDC issuer for the workflow that runs NAPT.
-For GitHub Actions on the `main` branch:
+Scope it to a deployment environment rather than a branch, so only the
+jobs that declare that environment — the ones that touch Intune — can
+obtain tokens; merges to `main` stay gated by your branch protection and
+PR review as usual.
+For GitHub Actions and an environment named `intune`:
 
 ```bash
 napt auth setup --tenant-id "<Directory (tenant) ID>" \
   --federated-issuer https://token.actions.githubusercontent.com \
-  --federated-subject repo:owner/name:ref:refs/heads/main
+  --federated-subject "repo:owner@<owner id>/name@<repository id>:environment:intune"
 ```
 
+Use the subject your repository actually emits.
+GitHub's immutable format above embeds the owner and repository IDs so a
+renamed or recreated repository cannot inherit the trust; repositories
+created or renamed after 2026-07-15 emit it by default, older ones until
+opted in emit `repo:owner/name:environment:intune`.
+See [Migrate GitHub Actions federated credentials to immutable subjects](https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-github-immutable-subjects)
+and GitHub's OIDC reference for the IDs and the opt-in.
 Other platforms use their own subject format (see their OIDC
 documentation); by hand, the same values go under **Certificates & secrets**
 → **Federated credentials** → **Add credential** → **Other issuer**.
-Then let `azure/login` mint the federated token before NAPT runs:
+Then sign in with `azure/login` before NAPT runs:
 
 ```yaml
 permissions:
   id-token: write
   contents: read
 
-steps:
-  - uses: azure/login@v2
-    with:
-      client-id: ${{ secrets.AZURE_CLIENT_ID }}
-      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      allow-no-subscriptions: true
-  - run: napt upload recipes/Google/chrome.yaml
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: intune
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+      - run: napt upload recipes/Google/chrome.yaml
 ```
 
-`azure/login` exports `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and
-`AZURE_FEDERATED_TOKEN_FILE`; NAPT picks them up automatically.
+`azure/login` exchanges the workflow's OIDC token for an Azure CLI session;
+NAPT then obtains its Graph token from that session (`AzureCliCredential`),
+so the job needs no `AZURE_*` variables at all.
 
 **CI/CD setup — client secret:**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -304,10 +304,6 @@ If no credential is available, commands fail with
 This mirrors `az`/`gh`: sign in explicitly once, then everything else is
 silent.
 
-Device code flow is not supported.
-It is the flow most often abused to bypass MFA, and Microsoft-managed
-Conditional Access policies increasingly block it tenant-wide.
-
 #### App Registration Setup
 
 Create the app registration once per organization.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -333,10 +333,43 @@ Two ways to do it:
     - `ms-appx-web://Microsoft.AAD.BrokerPlugin/<Application (client) ID>`
       (Windows broker sign-in)
 
-**Automatic (`napt auth setup`):** planned for a later release — it will
-create the registration above through Graph, which needs an account holding
-the Application Administrator (or Global Administrator) role.
-Until then, use the manual steps.
+**Automatic (`napt auth setup`):**
+
+```bash
+napt auth setup --tenant-id "<Directory (tenant) ID>"
+```
+
+Signs you in through the browser as an account holding the
+**Application Administrator** (or Global Administrator) role and does
+everything in the manual list through Microsoft Graph: creates the
+registration (or finds one named `NAPT` — `--name` / `--client-id` to
+target another), adds the redirect URIs and the application + delegated
+permissions, creates the service principal, and grants admin consent.
+It then remembers the tenant and client ID so the next step is just
+`napt auth login`.
+
+The registration is stamped in its **Internal notes** (Branding &
+properties) with a provenance line such as
+`napt/v1 spec=1 version=0.10.0 provisioned=2026-08-18`; any notes an
+administrator adds below it are preserved.
+Re-running is safe: NAPT compares the registration against what the
+installed version needs and adds only what is missing — so when a NAPT
+release needs a new permission, updating is just running `napt auth setup`
+again.
+A registration that matches by name but carries no stamp (one made in the
+portal, for example) is not touched until you pass `--adopt`, which adds
+NAPT's redirect URIs, Graph permissions, and admin consent to it and
+stamps it; nothing existing is ever removed.
+Naming the registration explicitly with `--client-id` counts as that
+consent.
+
+Add `--federated-issuer` and `--federated-subject` to also create the
+federated credential for [OIDC CI/CD](#app-registration-setup) in the same
+run; the values come from your CI platform's OIDC documentation.
+The administrator sign-in uses the Microsoft Graph Command Line Tools app
+(the same one `Connect-MgGraph` uses) and is never persisted by NAPT.
+If your tenant blocks that app, `--print-only` prints the portal checklist
+with the exact values for someone to click through instead.
 
 **Developer setup:**
 
@@ -411,10 +444,19 @@ napt auth login --tenant-id contosodev.onmicrosoft.com                          
 **CI/CD setup — OIDC federation (recommended):**
 
 No secret to store or rotate.
-In the app registration, go to **Certificates & secrets** →
-**Federated credentials** → **Add credential** → **GitHub Actions deploying
-Azure resources**, and enter your organization, repository, and the entity
-(branch, environment, or tag) the workflow runs as.
+Create a federated credential on the app registration that trusts your CI
+platform's OIDC issuer for the workflow that runs NAPT.
+For GitHub Actions on the `main` branch:
+
+```bash
+napt auth setup --tenant-id "<Directory (tenant) ID>" \
+  --federated-issuer https://token.actions.githubusercontent.com \
+  --federated-subject repo:owner/name:ref:refs/heads/main
+```
+
+Other platforms use their own subject format (see their OIDC
+documentation); by hand, the same values go under **Certificates & secrets**
+→ **Federated credentials** → **Add credential** → **Other issuer**.
 Then let `azure/login` mint the federated token before NAPT runs:
 
 ```yaml

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -340,7 +340,7 @@ napt auth setup --tenant-id "<Directory (tenant) ID>"
 ```
 
 Signs you in through the browser as an account holding the
-**Application Administrator** (or Global Administrator) role and does
+**Application Administrator** role (or higher) and does
 everything in the manual list through Microsoft Graph: creates the
 registration (or finds one named `NAPT` — `--name` / `--client-id` to
 target another), adds the redirect URIs and the application + delegated
@@ -367,7 +367,8 @@ Add `--federated-issuer` and `--federated-subject` to also create the
 federated credential for [OIDC CI/CD](#app-registration-setup) in the same
 run; the values come from your CI platform's OIDC documentation.
 The administrator sign-in uses the Microsoft Graph Command Line Tools app
-(the same one `Connect-MgGraph` uses) and is never persisted by NAPT.
+(the same one `Connect-MgGraph` uses); NAPT does not store that account or
+its tokens, though your browser may keep its own sign-in.
 If your tenant blocks that app, `--print-only` prints the portal checklist
 with the exact values for someone to click through instead.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -296,7 +296,7 @@ source it picked:
 |--------|---------------|
 | Service principal (`EnvironmentCredential`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` (or `AZURE_CLIENT_CERTIFICATE_PATH`) are set — CI/CD |
 | Interactive session (`napt auth login`) | Nothing above is set and you have signed in on this machine — developers |
-| Azure CLI (`AzureCliCredential`) | Nothing above applies and `az login` has been run in this environment — CI/CD with OIDC through a login step such as GitHub Actions `azure/login`. Recommended over a client secret whenever your CI platform supports it |
+| Azure CLI (`AzureCliCredential`) | Nothing above applies and the Azure CLI is signed in as a service principal — CI/CD with OIDC through a login step such as GitHub Actions `azure/login`. Recommended over a client secret whenever your CI platform supports it. A CLI signed in as a person is refused, since its tokens belong to the Azure CLI's own application, not the NAPT registration |
 
 NAPT never opens a browser on its own.
 If no credential is available, commands fail with

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1225,7 +1225,10 @@ def cmd_auth_setup(args: argparse.Namespace) -> int:
         print("          redirect URIs, Microsoft Graph permissions, and admin")
         print("          consent, and stamps the registration's internal notes;")
         print("          it never removes existing settings.")
-        print("          Use --name to create a separate registration instead.")
+        print(
+            "          To create a new registration instead, re-run with "
+            f"--name <a name other than '{result.display_name}'>."
+        )
         return 1
 
     if result.adopted:
@@ -1835,14 +1838,16 @@ def main() -> None:
         "setup",
         help="Create or complete the NAPT app registration in a tenant",
         description=(
-            "Create the NAPT app registration in Microsoft Entra ID, or bring\n"
-            "an existing one up to spec: redirect URIs, Microsoft Graph\n"
-            "permissions (application and delegated), service principal, and\n"
-            "admin consent. Optionally trusts a GitHub repository through OIDC\n"
-            "so CI/CD needs no client secret.\n\n"
-            "Signs in through the browser as an account holding the\n"
-            "Application Administrator or Global Administrator role; that\n"
-            "session is not kept. Safe to re-run: only missing pieces are added.\n\n"
+            "Create the NAPT app registration in Microsoft Entra ID, or bring an\n"
+            "existing one up to spec: redirect URIs, Microsoft Graph permissions\n"
+            "(application and delegated), service principal, and admin consent.\n"
+            "Optionally adds a federated credential so a CI/CD platform can obtain\n"
+            "tokens through OIDC without a client secret.\n\n"
+            "Requires an account holding at least the Application Administrator\n"
+            "role. NAPT does not store that account or its tokens (your browser\n"
+            "may keep its own sign-in). Re-running is safe: NAPT compares the\n"
+            "registration with what this version needs and adds what is missing,\n"
+            "never removing anything.\n\n"
             "Examples:\n"
             "  napt auth setup --tenant-id <id>\n"
             "  napt auth setup --tenant-id <id> \\\n"

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1134,7 +1134,7 @@ def cmd_auth_status(args: argparse.Namespace) -> int:
         print("  Interactive:  run 'napt auth login'")
         print("  CI/CD:        set AZURE_CLIENT_ID, AZURE_TENANT_ID and either")
         print("                AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH,")
-        print("                or use OIDC federation")
+        print("                or sign in with 'az login' (e.g. azure/login in CI)")
         _print_known_tenants()
         return 1
 

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -1177,7 +1177,7 @@ def cmd_auth_setup(args: argparse.Namespace) -> int:
 
     Args:
         args: Parsed command-line arguments containing the tenant ID,
-            optional name, client ID, GitHub OIDC settings, and flags.
+            optional name, client ID, federated credential settings, and flags.
 
     Returns:
         Exit code (0 for success, 1 for failure).

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -121,6 +121,16 @@ from napt.upload.auth import (
     login as auth_login,
     logout as auth_logout,
 )
+from napt.upload.entra import (
+    APPLICATION_PERMISSIONS,
+    BROKER_REDIRECT_TEMPLATE,
+    DELEGATED_PERMISSIONS,
+    FEDERATED_AUDIENCE_DEFAULT,
+    LOCALHOST_REDIRECT,
+    SPEC_VERSION,
+    SetupSpec,
+    setup_app_registration,
+)
 from napt.upload.graph import list_mobile_apps
 from napt.validation import validate_recipe
 
@@ -1134,6 +1144,122 @@ def cmd_auth_status(args: argparse.Namespace) -> int:
     return 0 if not status.missing else 1
 
 
+def _print_setup_checklist(spec: SetupSpec) -> None:
+    """Prints the portal steps equivalent to what 'napt auth setup' automates."""
+    client_id = spec.client_id or "<Application (client) ID>"
+    print(f"App registration checklist for tenant {spec.tenant_id}:")
+    print()
+    print("  1. Entra admin center -> App registrations -> New registration")
+    print(f"     Name: {spec.display_name}; accounts in this directory only")
+    print("  2. Authentication -> Add a platform -> Mobile and desktop applications")
+    print(f"     - {LOCALHOST_REDIRECT}")
+    print(f"     - {BROKER_REDIRECT_TEMPLATE.format(client_id=client_id)}")
+    print("  3. API permissions -> Add a permission -> Microsoft Graph")
+    print(f"     Application: {', '.join(APPLICATION_PERMISSIONS)}")
+    print(f"     Delegated:   {', '.join(DELEGATED_PERMISSIONS)}")
+    print("  4. Grant admin consent")
+    if spec.federated_subject:
+        print("  5. Certificates & secrets -> Federated credentials -> Add credential")
+        print(f"     Name:     {spec.federated_credential_name}")
+        print(f"     Issuer:   {spec.federated_issuer}")
+        print(f"     Subject:  {spec.federated_subject}")
+        print(f"     Audience: {spec.federated_audience}")
+    print()
+    print("Then: napt auth login --tenant-id <tenant id> --client-id <client id>")
+
+
+def cmd_auth_setup(args: argparse.Namespace) -> int:
+    """Handler for 'napt auth setup' command.
+
+    Creates or completes the NAPT app registration in a tenant through
+    Microsoft Graph, or with --print-only prints the equivalent portal
+    checklist without signing in.
+
+    Args:
+        args: Parsed command-line arguments containing the tenant ID,
+            optional name, client ID, GitHub OIDC settings, and flags.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+
+    """
+    logger = get_logger(verbose=args.verbose, debug=args.debug)
+    set_global_logger(logger)
+
+    try:
+        spec = SetupSpec(
+            tenant_id=args.tenant_id,
+            display_name=args.name,
+            client_id=args.client_id,
+            federated_issuer=args.federated_issuer,
+            federated_subject=args.federated_subject,
+            federated_audience=args.federated_audience,
+            federated_name=args.federated_name,
+            adopt=args.adopt,
+        )
+    except ConfigError as err:
+        print(f"Error: {err}")
+        return 1
+
+    if args.print_only:
+        _print_setup_checklist(spec)
+        return 0
+
+    try:
+        result = setup_app_registration(spec)
+    except (AuthError, ConfigError, NetworkError) as err:
+        print(f"Error: {err}")
+        if args.verbose or args.debug:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+    print()
+    if result.needs_adopt:
+        print(
+            f"[WARNING] Found existing registration '{result.display_name}' "
+            f"({result.client_id}) that NAPT did not create."
+        )
+        print("          Re-run with --adopt to manage it. Adopting adds NAPT's")
+        print("          redirect URIs, Microsoft Graph permissions, and admin")
+        print("          consent, and stamps the registration's internal notes;")
+        print("          it never removes existing settings.")
+        print("          Use --name to create a separate registration instead.")
+        return 1
+
+    if result.adopted:
+        print(
+            f"[OK] Adopted '{result.display_name}' ({result.client_id}) -- "
+            f"stamped as napt/v1 spec={SPEC_VERSION}. Changes made:"
+        )
+    elif result.changes:
+        print("[OK] App registration is ready. Changes made:")
+    else:
+        print(
+            f"[OK] App registration '{result.display_name}' is at spec "
+            f"{SPEC_VERSION}; nothing to change."
+        )
+    for change in result.changes:
+        print(f"  - {change}")
+    print()
+    print(f"Name:       {result.display_name}")
+    print(f"Tenant ID:  {result.tenant_id}")
+    print(f"Client ID:  {result.client_id}")
+    print()
+    print("Next steps:")
+    print("  Interactive: napt auth login")
+    print("  CI/CD:       set AZURE_TENANT_ID and AZURE_CLIENT_ID to the values above")
+    if spec.federated_subject:
+        print("               and let your CI platform's OIDC login mint the token")
+        print("               (e.g. azure/login on GitHub Actions) -- no secret needed")
+    else:
+        print("               plus AZURE_CLIENT_SECRET, or re-run with")
+        print("               --federated-issuer/--federated-subject to add an OIDC")
+        print("               federated credential instead")
+    return 0
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Handler for 'napt init' command.
 
@@ -1590,6 +1716,7 @@ def main() -> None:
         description=(
             "Manage the credential NAPT uses for Intune.\n\n"
             "Examples:\n"
+            "  napt auth setup --tenant-id <id>\n"
             "  napt auth login --tenant-id <id> --client-id <id>\n"
             "  napt auth login\n"
             "  napt auth status\n"
@@ -1703,6 +1830,99 @@ def main() -> None:
         help="Show detailed debugging output (implies --verbose)",
     )
     parser_auth_status.set_defaults(func=cmd_auth_status)
+
+    parser_auth_setup = auth_sub.add_parser(
+        "setup",
+        help="Create or complete the NAPT app registration in a tenant",
+        description=(
+            "Create the NAPT app registration in Microsoft Entra ID, or bring\n"
+            "an existing one up to spec: redirect URIs, Microsoft Graph\n"
+            "permissions (application and delegated), service principal, and\n"
+            "admin consent. Optionally trusts a GitHub repository through OIDC\n"
+            "so CI/CD needs no client secret.\n\n"
+            "Signs in through the browser as an account holding the\n"
+            "Application Administrator or Global Administrator role; that\n"
+            "session is not kept. Safe to re-run: only missing pieces are added.\n\n"
+            "Examples:\n"
+            "  napt auth setup --tenant-id <id>\n"
+            "  napt auth setup --tenant-id <id> \\\n"
+            "      --federated-issuer https://token.actions.githubusercontent.com \\\n"
+            "      --federated-subject repo:contoso/intune-apps:ref:refs/heads/main\n"
+            "  napt auth setup --tenant-id <id> --print-only"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser_auth_setup.add_argument(
+        "--tenant-id",
+        required=True,
+        help="Directory (tenant) ID to provision in",
+    )
+    parser_auth_setup.add_argument(
+        "--name",
+        default="NAPT",
+        help="Display name of the app registration to find or create (default: NAPT)",
+    )
+    parser_auth_setup.add_argument(
+        "--client-id",
+        default=None,
+        help="Bring this existing registration up to spec instead of matching by name",
+    )
+    parser_auth_setup.add_argument(
+        "--federated-issuer",
+        default=None,
+        metavar="URL",
+        help=(
+            "OIDC issuer of a CI platform to trust, e.g. "
+            "https://token.actions.githubusercontent.com (requires --federated-subject)"
+        ),
+    )
+    parser_auth_setup.add_argument(
+        "--federated-subject",
+        default=None,
+        metavar="SUBJECT",
+        help=(
+            "Subject claim the platform presents for the trusted workflow, in the "
+            "platform's format, e.g. repo:owner/name:ref:refs/heads/main"
+        ),
+    )
+    parser_auth_setup.add_argument(
+        "--federated-audience",
+        default=FEDERATED_AUDIENCE_DEFAULT,
+        metavar="AUDIENCE",
+        help=f"Audience claim (default: {FEDERATED_AUDIENCE_DEFAULT})",
+    )
+    parser_auth_setup.add_argument(
+        "--federated-name",
+        default=None,
+        metavar="NAME",
+        help="Name of the federated credential (default: derived from the subject)",
+    )
+    parser_auth_setup.add_argument(
+        "--adopt",
+        action="store_true",
+        help=(
+            "Manage a registration matched by name that NAPT did not create "
+            "(adds what is missing, never removes anything)"
+        ),
+    )
+    parser_auth_setup.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print the portal checklist instead of changing anything",
+    )
+    parser_auth_setup.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show progress and high-level status updates",
+    )
+    parser_auth_setup.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Show detailed debugging output (implies --verbose)",
+    )
+    parser_auth_setup.set_defaults(func=cmd_auth_setup)
 
     # 'promote' command with subcommands
     parser_promote = subparsers.add_parser(

--- a/napt/upload/__init__.py
+++ b/napt/upload/__init__.py
@@ -20,7 +20,7 @@ to Microsoft Intune via the Graph API.
 Authentication needs no configuration file:
 
 - Developers: run `napt auth login` once (browser or OS broker); later commands use the cached session silently
-- CI/CD: set AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET (EnvironmentCredential), or use OIDC federation (WorkloadIdentityCredential)
+- CI/CD: set AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET (EnvironmentCredential), or sign in with an OIDC login step such as GitHub Actions `azure/login` (AzureCliCredential)
 
 Modules:
     manager - Upload orchestration (load config, auth, upload flow).

--- a/napt/upload/__init__.py
+++ b/napt/upload/__init__.py
@@ -26,6 +26,7 @@ Modules:
     manager - Upload orchestration (load config, auth, upload flow).
     graph - Graph API and Azure Blob Storage HTTP calls.
     auth - Credential resolution (azure-identity chain, MSAL interactive session).
+    entra - App registration provisioning for `napt auth setup`.
     intunewin - .intunewin ZIP parser (reads Detection.xml encryption metadata).
 
 Example:

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -34,11 +34,13 @@ Interactive (a person at a terminal):
         switches the active one.
 
 CI/CD through a login step:
-    3. AzureCliCredential -- an existing `az login` session, which is what
-        OIDC login steps such as GitHub Actions `azure/login` leave behind.
-        Recommended over client secrets when the CI platform supports it:
-        no secret to store or rotate. Last in the chain so a developer's
-        `napt auth login` always wins over a stray Azure CLI session.
+    3. AzureCliCredential -- an existing `az login` session signed in as a
+        service principal, which is what OIDC login steps such as GitHub
+        Actions `azure/login` leave behind. Recommended over client secrets
+        when the CI platform supports it: no secret to store or rotate.
+        Last in the chain so a developer's `napt auth login` always wins,
+        and a session signed in as a person is refused rather than used,
+        since its token belongs to the Azure CLI's own application.
 
 `napt auth login` uses the authorization code flow with PKCE against a
 loopback redirect, or -- on Windows, when the MSAL broker runtime is
@@ -125,6 +127,13 @@ _HINT_NOT_LOGGED_IN = (
     "  CI/CD:        set AZURE_CLIENT_ID, AZURE_TENANT_ID and either\n"
     "                AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH,\n"
     "                or sign in with 'az login' (e.g. azure/login in CI)\n"
+)
+
+_HINT_AZURE_CLI_USER = (
+    "Found an Azure CLI session signed in as a user. NAPT uses Azure CLI\n"
+    "sessions only for service principals (CI/CD, e.g. azure/login with the\n"
+    "NAPT app registration's client ID). For interactive use, run\n"
+    "'napt auth login'.\n"
 )
 
 _HINT_SESSION_EXPIRED = (
@@ -463,15 +472,28 @@ def _describe_noninteractive_method() -> str:
 
 
 def _azure_cli_token() -> str | None:
-    """Returns a Graph token from an existing ``az login`` session, or ``None``.
+    """Returns a Graph token from an ``az login`` service principal session.
 
     ``None`` covers every way the Azure CLI can be unavailable: not
-    installed, not signed in, or unable to issue a token for Graph.
+    installed, not signed in, or unable to issue a token for Graph. A
+    session signed in as a person is refused: its token is issued to the
+    Azure CLI's own application, so Entra and Intune would attribute NAPT's
+    actions to that app rather than the NAPT registration.
+
+    Raises:
+        AuthError: If the Azure CLI is signed in as a user.
     """
     try:
-        return AzureCliCredential().get_token(*GRAPH_SCOPES).token
+        token = AzureCliCredential().get_token(*GRAPH_SCOPES).token
     except ClientAuthenticationError:
         return None
+    claims = _decode_claims(token)
+    is_app_only = claims.get("idtyp") == "app" or (
+        "scp" not in claims and bool(claims.get("roles"))
+    )
+    if not is_app_only:
+        raise AuthError(_HINT_AZURE_CLI_USER)
+    return token
 
 
 # ---------------------------------------------------------------------------

--- a/napt/upload/auth.py
+++ b/napt/upload/auth.py
@@ -23,18 +23,22 @@ Non-interactive (CI/CD):
     1. EnvironmentCredential -- service principal via AZURE_CLIENT_ID,
         AZURE_TENANT_ID and either AZURE_CLIENT_SECRET or
         AZURE_CLIENT_CERTIFICATE_PATH.
-    2. WorkloadIdentityCredential -- federated (OIDC) identity, e.g. GitHub
-        Actions with `azure/login`. Recommended over client secrets when the
-        CI platform supports it: no secret to store or rotate.
 
 Interactive (a person at a terminal):
-    3. The active tenant's session established earlier with
+    2. The active tenant's session established earlier with
         `napt auth login`. Tokens are cached by MSAL in an OS-encrypted store
         (DPAPI on Windows, Keychain on macOS, libsecret on Linux) and
         refreshed silently; the browser or Windows broker is only
         opened by `napt auth login` itself, never by `napt upload`. Several
         tenants can be signed in at once; `napt auth login --tenant-id`
         switches the active one.
+
+CI/CD through a login step:
+    3. AzureCliCredential -- an existing `az login` session, which is what
+        OIDC login steps such as GitHub Actions `azure/login` leave behind.
+        Recommended over client secrets when the CI platform supports it:
+        no secret to store or rotate. Last in the chain so a developer's
+        `napt auth login` always wins over a stray Azure CLI session.
 
 `napt auth login` uses the authorization code flow with PKCE against a
 loopback redirect, or -- on Windows, when the MSAL broker runtime is
@@ -73,11 +77,7 @@ import sys
 from typing import Any
 
 from azure.core.exceptions import ClientAuthenticationError
-from azure.identity import (
-    ChainedTokenCredential,
-    EnvironmentCredential,
-    WorkloadIdentityCredential,
-)
+from azure.identity import AzureCliCredential, EnvironmentCredential
 import msal
 import msal_extensions
 import requests
@@ -108,7 +108,7 @@ GRAPH_SCOPES = ["https://graph.microsoft.com/.default"]
 logging.getLogger("azure.identity").setLevel(logging.ERROR)
 
 # Graph permissions NAPT needs, whether granted as application permissions
-# (service principal, workload identity) or delegated permissions (interactive).
+# (service principal, Azure CLI session) or delegated permissions (interactive).
 REQUIRED_PERMISSIONS = ("DeviceManagementApps.ReadWrite.All", "Group.Read.All")
 
 _AUTHORITY_BASE = "https://login.microsoftonline.com"
@@ -124,7 +124,7 @@ _HINT_NOT_LOGGED_IN = (
     "  Interactive:  run 'napt auth login'\n"
     "  CI/CD:        set AZURE_CLIENT_ID, AZURE_TENANT_ID and either\n"
     "                AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH,\n"
-    "                or use OIDC federation (WorkloadIdentityCredential)\n"
+    "                or sign in with 'az login' (e.g. azure/login in CI)\n"
 )
 
 _HINT_SESSION_EXPIRED = (
@@ -442,36 +442,36 @@ def _status_from_token(token: str, method: str) -> AuthStatus:
 # ---------------------------------------------------------------------------
 
 
-def get_credential() -> ChainedTokenCredential:
-    """Builds the non-interactive credential chain.
+def get_credential() -> EnvironmentCredential:
+    """Builds the service principal credential from environment variables.
 
-    Service principal (environment variables), then workload identity
-    federation (only when its ``AZURE_FEDERATED_TOKEN_FILE`` etc. variables
-    are present). Both use the `.default` scope, suitable for application
-    permissions.
+    Reads ``AZURE_CLIENT_ID``, ``AZURE_TENANT_ID`` and either
+    ``AZURE_CLIENT_SECRET`` or ``AZURE_CLIENT_CERTIFICATE_PATH``, and uses
+    the `.default` scope, suitable for application permissions.
 
     Returns:
-        A ChainedTokenCredential for non-interactive authentication.
+        The environment-backed credential; acquiring a token from it fails
+        with ClientAuthenticationError when the variables are not all set.
     """
-    credentials: list[Any] = [EnvironmentCredential()]
-    if all(
-        os.environ.get(var)
-        for var in (
-            "AZURE_TENANT_ID",
-            "AZURE_CLIENT_ID",
-            "AZURE_FEDERATED_TOKEN_FILE",
-        )
-    ):
-        credentials.append(WorkloadIdentityCredential())
-    return ChainedTokenCredential(*credentials)
+    return EnvironmentCredential()
 
 
 def _describe_noninteractive_method() -> str:
-    if os.environ.get("AZURE_CLIENT_SECRET") or os.environ.get(
-        "AZURE_CLIENT_CERTIFICATE_PATH"
-    ):
-        return "service principal"
-    return "workload identity (OIDC)"
+    if os.environ.get("AZURE_CLIENT_CERTIFICATE_PATH"):
+        return "service principal (certificate)"
+    return "service principal"
+
+
+def _azure_cli_token() -> str | None:
+    """Returns a Graph token from an existing ``az login`` session, or ``None``.
+
+    ``None`` covers every way the Azure CLI can be unavailable: not
+    installed, not signed in, or unable to issue a token for Graph.
+    """
+    try:
+        return AzureCliCredential().get_token(*GRAPH_SCOPES).token
+    except ClientAuthenticationError:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -787,13 +787,16 @@ def get_status() -> AuthStatus | None:
         pass
 
     config = _interactive_config()
-    if config is None:
-        return None
-    broker = _broker_available()
-    token = _acquire_silent(config, use_broker=broker)
-    if token is None:
-        return None
-    return _status_from_token(token, _interactive_method(broker))
+    if config is not None:
+        broker = _broker_available()
+        token = _acquire_silent(config, use_broker=broker)
+        if token is not None:
+            return _status_from_token(token, _interactive_method(broker))
+
+    token = _azure_cli_token()
+    if token is not None:
+        return _status_from_token(token, "azure cli")
+    return None
 
 
 def get_access_token() -> str:
@@ -801,8 +804,9 @@ def get_access_token() -> str:
 
     Tries the non-interactive chain from
     [get_credential][napt.upload.auth.get_credential] first, then the session
-    saved by `napt auth login`. Never opens a browser: an interactive user
-    who has not logged in is told to run `napt auth login`.
+    saved by `napt auth login`, then an existing Azure CLI (`az login`)
+    session. Never opens a browser: an interactive user who has not logged
+    in is told to run `napt auth login`.
 
     Returns:
         Bearer token string for use in Authorization headers.
@@ -831,5 +835,9 @@ def get_access_token() -> str:
         token = _acquire_silent(config, use_broker=_broker_available())
         if token is not None:
             return token
+
+    token = _azure_cli_token()
+    if token is not None:
+        return token
 
     raise AuthError(_HINT_NOT_LOGGED_IN)

--- a/napt/upload/entra.py
+++ b/napt/upload/entra.py
@@ -35,9 +35,9 @@ complete registration changes nothing.
 
 The run is bootstrapped with a short-lived token from the Microsoft Graph
 Command Line Tools first-party application -- the same one `Connect-MgGraph`
-uses -- requested in the browser and kept in memory only. It needs an
-account holding the Application Administrator (or Global Administrator)
-role; NAPT never persists that account's session.
+uses -- requested in the browser and held in memory only. It needs an
+account holding at least the Application Administrator role. NAPT does not
+store that account or its tokens; the browser may keep its own sign-in.
 
 Redirect URIs and permissions are always written to the application object,
 never to the service principal, where a directory sync could drop them.
@@ -125,8 +125,8 @@ _REPLICATION_WAIT = 5.0
 _HINT_BOOTSTRAP_FAILED = (
     "Could not sign in to create the app registration.\n\n"
     "This step signs in with the Microsoft Graph Command Line Tools app and\n"
-    "needs an account holding the Application Administrator or Global\n"
-    "Administrator role. If your tenant blocks that app, use\n"
+    "needs an account holding at least the Application Administrator\n"
+    "role. If your tenant blocks that app, use\n"
     "'napt auth setup --print-only' and complete the steps in the portal.\n"
 )
 

--- a/napt/upload/entra.py
+++ b/napt/upload/entra.py
@@ -1,0 +1,723 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entra ID app registration provisioning for `napt auth setup`.
+
+Creates -- or brings up to spec -- the app registration that
+[napt.upload.auth][] signs in with, so an administrator never has to click
+through the portal:
+
+- The application object with `http://localhost` and the Windows broker
+    redirect URI as a Mobile-and-desktop platform, and the Microsoft Graph
+    permissions NAPT needs declared as both application permissions (CI/CD)
+    and delegated permissions (interactive sign-in).
+- Its service principal, with tenant-wide admin consent for both kinds of
+    permission.
+- Optionally, a federated identity credential that lets a CI/CD platform's
+    workflow obtain tokens through OIDC with no client secret. The issuer
+    and subject come from the user; NAPT carries no platform-specific
+    knowledge.
+
+Every step is idempotent: an existing registration (found by display name
+or ``--client-id``) is patched with only what is missing, and rerunning on a
+complete registration changes nothing.
+
+The run is bootstrapped with a short-lived token from the Microsoft Graph
+Command Line Tools first-party application -- the same one `Connect-MgGraph`
+uses -- requested in the browser and kept in memory only. It needs an
+account holding the Application Administrator (or Global Administrator)
+role; NAPT never persists that account's session.
+
+Redirect URIs and permissions are always written to the application object,
+never to the service principal, where a directory sync could drop them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+import re
+import time
+
+import msal
+
+from napt import __version__
+from napt.exceptions import AuthError, ConfigError, NetworkError
+from napt.upload.auth import (
+    _AUTHORITY_BASE,
+    _LOGIN_TIMEOUT,
+    AuthConfig,
+    _msal_error,
+    _remember,
+    load_auth_store,
+)
+from napt.upload.graph import _graph_request, _json_headers
+
+__all__ = [
+    "BROKER_REDIRECT_TEMPLATE",
+    "FEDERATED_AUDIENCE_DEFAULT",
+    "LOCALHOST_REDIRECT",
+    "SPEC_VERSION",
+    "SetupResult",
+    "SetupSpec",
+    "setup_app_registration",
+]
+
+_GRAPH_V1 = "https://graph.microsoft.com/v1.0"
+
+# Microsoft Graph Command Line Tools: first-party public client with the
+# loopback redirect registered, used only to obtain the bootstrap token.
+_GRAPH_CLI_TOOLS_CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
+
+# Microsoft Graph's own application ID, the resource every permission targets.
+_MS_GRAPH_APP_ID = "00000003-0000-0000-c000-000000000000"
+
+_BOOTSTRAP_SCOPES = [
+    "https://graph.microsoft.com/Application.ReadWrite.All",
+    "https://graph.microsoft.com/AppRoleAssignment.ReadWrite.All",
+    "https://graph.microsoft.com/DelegatedPermissionGrant.ReadWrite.All",
+]
+
+LOCALHOST_REDIRECT = "http://localhost"
+BROKER_REDIRECT_TEMPLATE = "ms-appx-web://Microsoft.AAD.BrokerPlugin/{client_id}"
+
+# Application permissions (app roles) for CI/CD and the delegated scopes for
+# interactive sign-in. User.Read is what the portal adds to every new
+# registration; it lets `napt auth login` look up the tenant's name.
+APPLICATION_PERMISSIONS = ("DeviceManagementApps.ReadWrite.All", "Group.Read.All")
+DELEGATED_PERMISSIONS = (
+    "DeviceManagementApps.ReadWrite.All",
+    "Group.Read.All",
+    "User.Read",
+)
+
+# Audience Entra expects on federated tokens from any external issuer.
+FEDERATED_AUDIENCE_DEFAULT = "api://AzureADTokenExchange"
+
+# Provenance stamp written to the application's internal notes (the
+# "Internal notes" box under Branding & properties), mirroring the
+# ``napt/v1`` stamp on Intune apps. SPEC_VERSION describes what NAPT expects
+# of a registration -- bump it whenever APPLICATION_PERMISSIONS,
+# DELEGATED_PERMISSIONS, or the redirect URIs change, so a re-run of
+# `napt auth setup` reports the registration as out of date.
+SPEC_VERSION = 1
+_STAMP_PREFIX = "napt/v1"
+_STAMP_RE = re.compile(
+    r"^napt/v1 spec=(?P<spec>\d+) version=(?P<version>\S+) provisioned=(?P<date>\S+)$"
+)
+
+# A just-created service principal can take a few seconds to replicate; the
+# consent endpoints 404 until it does.
+_REPLICATION_ATTEMPTS = 6
+_REPLICATION_WAIT = 5.0
+
+_HINT_BOOTSTRAP_FAILED = (
+    "Could not sign in to create the app registration.\n\n"
+    "This step signs in with the Microsoft Graph Command Line Tools app and\n"
+    "needs an account holding the Application Administrator or Global\n"
+    "Administrator role. If your tenant blocks that app, use\n"
+    "'napt auth setup --print-only' and complete the steps in the portal.\n"
+)
+
+
+@dataclass(frozen=True)
+class SetupSpec:
+    """What `napt auth setup` should provision.
+
+    Attributes:
+        tenant_id: Directory (tenant) ID to provision in.
+        display_name: Display name of the app registration to find or
+            create.
+        client_id: Existing registration to bring up to spec instead of
+            matching by display name.
+        federated_issuer: OIDC issuer URL of the CI platform to trust (for
+            example GitHub Actions' ``https://token.actions.githubusercontent.com``),
+            or ``None`` for no federated credential.
+        federated_subject: Subject claim the platform presents for the
+            workflow that may obtain tokens; its format is defined by the
+            platform (for GitHub Actions, ``repo:owner/name:ref:refs/heads/main``).
+        federated_audience: Audience claim; Entra's standard value is the
+            default.
+        federated_name: Display name of the credential; derived from the
+            subject when not given.
+        adopt: Take over a registration matched by display name that NAPT
+            did not create (no provenance stamp). Not needed when
+            ``client_id`` names the registration explicitly.
+    """
+
+    tenant_id: str
+    display_name: str = "NAPT"
+    client_id: str | None = None
+    federated_issuer: str | None = None
+    federated_subject: str | None = None
+    federated_audience: str = FEDERATED_AUDIENCE_DEFAULT
+    federated_name: str | None = None
+    adopt: bool = False
+
+    def __post_init__(self) -> None:
+        """Rejects a federated credential given only an issuer or only a subject."""
+        if bool(self.federated_issuer) != bool(self.federated_subject):
+            raise ConfigError(
+                "A federated credential needs both an issuer and a subject "
+                "(--federated-issuer and --federated-subject)"
+            )
+
+    @property
+    def federated_credential_name(self) -> str | None:
+        """Name of the federated credential: given, or derived from the subject."""
+        if not self.federated_subject:
+            return None
+        if self.federated_name:
+            return self.federated_name
+        # Entra allows letters, digits, and hyphens, up to 120 characters.
+        derived = re.sub(r"[^A-Za-z0-9]+", "-", self.federated_subject).strip("-")
+        return f"napt-{derived}"[:120]
+
+
+@dataclass
+class SetupResult:
+    """What `napt auth setup` found or created.
+
+    Attributes:
+        tenant_id: Tenant the registration lives in.
+        client_id: Application (client) ID to use with NAPT.
+        display_name: The registration's display name.
+        created: Whether the application object was created by this run.
+        adopted: Whether this run took over a registration NAPT did not
+            create.
+        needs_adopt: The registration matched by name carries no NAPT stamp
+            and ``adopt`` was not given; nothing was changed.
+        previous_spec: Spec version the registration was stamped with before
+            this run, or ``None`` if it had no stamp.
+        changes: Human-readable list of what this run added; empty when the
+            registration was already complete.
+    """
+
+    tenant_id: str
+    client_id: str
+    display_name: str
+    created: bool = False
+    adopted: bool = False
+    needs_adopt: bool = False
+    previous_spec: int | None = None
+    changes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Provenance stamp
+# ---------------------------------------------------------------------------
+
+
+def _render_stamp() -> str:
+    today = datetime.now(UTC).date().isoformat()
+    return (
+        f"{_STAMP_PREFIX} spec={SPEC_VERSION} version={__version__} provisioned={today}"
+    )
+
+
+def _parse_stamp(notes: str | None) -> dict[str, str] | None:
+    """Returns the stamp's fields from the notes text, or ``None`` if absent."""
+    for line in (notes or "").splitlines():
+        match = _STAMP_RE.match(line.strip())
+        if match:
+            return match.groupdict()
+    return None
+
+
+def _with_stamp(notes: str | None) -> str:
+    """Returns ``notes`` with the stamp line replaced or prepended.
+
+    Every other line an administrator wrote is preserved verbatim.
+    """
+    kept = [
+        line
+        for line in (notes or "").splitlines()
+        if not line.strip().startswith(_STAMP_PREFIX + " ")
+    ]
+    return "\n".join([_render_stamp(), *kept]).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_token(tenant_id: str) -> str:
+    """Signs an administrator in through the browser for the provisioning run.
+
+    Uses an in-memory MSAL cache so the administrator's session is gone when
+    the process exits.
+
+    Raises:
+        AuthError: If the sign-in fails or is canceled.
+    """
+    app = msal.PublicClientApplication(
+        _GRAPH_CLI_TOOLS_CLIENT_ID,
+        authority=f"{_AUTHORITY_BASE}/{tenant_id}",
+    )
+    print("Opening your browser to sign in as an administrator...")
+    try:
+        result = app.acquire_token_interactive(
+            _BOOTSTRAP_SCOPES, prompt="select_account", timeout=_LOGIN_TIMEOUT
+        )
+    except Exception as err:  # MSAL surfaces transport failures as raw errors
+        raise AuthError(f"{_HINT_BOOTSTRAP_FAILED}Details: {err}") from err
+    if "access_token" not in result:
+        raise AuthError(f"{_HINT_BOOTSTRAP_FAILED}Details: {_msal_error(result)}")
+    return result["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Graph helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(token: str, path: str, context: str) -> dict:
+    return _graph_request("GET", f"{_GRAPH_V1}{path}", context, _json_headers(token))
+
+
+def _post(token: str, path: str, body: dict, context: str) -> dict:
+    return _graph_request(
+        "POST",
+        f"{_GRAPH_V1}{path}",
+        context,
+        _json_headers(token),
+        json=body,
+        idempotent=False,
+    )
+
+
+def _patch(token: str, path: str, body: dict, context: str) -> None:
+    _graph_request("PATCH", f"{_GRAPH_V1}{path}", context, _json_headers(token), body)
+
+
+def _post_after_replication(token: str, path: str, body: dict, context: str) -> dict:
+    """POSTs, retrying a 404 that means the target has not replicated yet."""
+    for attempt in range(1, _REPLICATION_ATTEMPTS + 1):
+        try:
+            return _post(token, path, body, context)
+        except NetworkError as err:
+            if "HTTP 404" not in str(err) or attempt == _REPLICATION_ATTEMPTS:
+                raise
+            time.sleep(_REPLICATION_WAIT)
+    raise NetworkError(f"{context}: retry attempts exhausted")  # pragma: no cover
+
+
+def _graph_permission_ids(token: str) -> tuple[dict[str, str], dict[str, str], str]:
+    """Maps permission names to IDs on Microsoft Graph's service principal.
+
+    Returns:
+        ``(app_roles, scopes, graph_sp_id)`` -- app role IDs by value,
+        delegated scope IDs by value, and the Graph service principal's
+        object ID in this tenant.
+
+    Raises:
+        ConfigError: If a required permission name is unknown to Graph.
+    """
+    data = _get(
+        token,
+        f"/servicePrincipals?$filter=appId eq '{_MS_GRAPH_APP_ID}'"
+        "&$select=id,appRoles,oauth2PermissionScopes",
+        "Looking up Microsoft Graph permissions",
+    )
+    graph_sp = (data.get("value") or [{}])[0]
+    roles = {r["value"]: r["id"] for r in graph_sp.get("appRoles", [])}
+    scopes = {s["value"]: s["id"] for s in graph_sp.get("oauth2PermissionScopes", [])}
+    missing = [p for p in APPLICATION_PERMISSIONS if p not in roles] + [
+        p for p in DELEGATED_PERMISSIONS if p not in scopes
+    ]
+    if missing or "id" not in graph_sp:
+        raise ConfigError(
+            "Microsoft Graph did not report the permissions NAPT needs: "
+            f"{', '.join(missing) or 'service principal not found'}"
+        )
+    return roles, scopes, graph_sp["id"]
+
+
+# ---------------------------------------------------------------------------
+# Application object
+# ---------------------------------------------------------------------------
+
+
+def _find_application(token: str, spec: SetupSpec) -> dict | None:
+    """Finds the registration by client ID or display name.
+
+    Raises:
+        ConfigError: If several registrations share the display name.
+    """
+    select = "$select=id,appId,displayName,notes,publicClient,requiredResourceAccess"
+    if spec.client_id:
+        data = _get(
+            token,
+            f"/applications?$filter=appId eq '{spec.client_id}'&{select}",
+            "Looking up app registration by client ID",
+        )
+        apps = data.get("value") or []
+        if not apps:
+            raise ConfigError(
+                f"No app registration with client ID {spec.client_id} in "
+                f"tenant {spec.tenant_id}"
+            )
+        return apps[0]
+    name = spec.display_name.replace("'", "''")
+    data = _get(
+        token,
+        f"/applications?$filter=displayName eq '{name}'&{select}",
+        "Looking up app registration by name",
+    )
+    apps = data.get("value") or []
+    if len(apps) > 1:
+        ids = ", ".join(a["appId"] for a in apps)
+        raise ConfigError(
+            f"{len(apps)} app registrations are named '{spec.display_name}' "
+            f"({ids}). Re-run with --client-id to choose one."
+        )
+    return apps[0] if apps else None
+
+
+def _required_resource_access(
+    roles: dict[str, str], scopes: dict[str, str]
+) -> list[dict]:
+    return [{"id": roles[p], "type": "Role"} for p in APPLICATION_PERMISSIONS] + [
+        {"id": scopes[p], "type": "Scope"} for p in DELEGATED_PERMISSIONS
+    ]
+
+
+def _merge_resource_access(existing: list[dict], wanted: list[dict]) -> list[dict]:
+    """Returns ``existing`` with NAPT's Graph entries added; other resources kept."""
+    merged = [r for r in existing if r.get("resourceAppId") != _MS_GRAPH_APP_ID]
+    graph_entry = next(
+        (r for r in existing if r.get("resourceAppId") == _MS_GRAPH_APP_ID),
+        {"resourceAppId": _MS_GRAPH_APP_ID, "resourceAccess": []},
+    )
+    have = {(a["id"], a["type"]) for a in graph_entry.get("resourceAccess", [])}
+    access = list(graph_entry.get("resourceAccess", []))
+    access.extend(a for a in wanted if (a["id"], a["type"]) not in have)
+    merged.append({"resourceAppId": _MS_GRAPH_APP_ID, "resourceAccess": access})
+    return merged
+
+
+def _ensure_application(
+    token: str,
+    spec: SetupSpec,
+    roles: dict[str, str],
+    scopes: dict[str, str],
+    result: SetupResult,
+) -> dict:
+    """Creates the application or patches a found one up to spec.
+
+    Returns:
+        The application object with at least ``id`` and ``appId``.
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    wanted_access = _required_resource_access(roles, scopes)
+    app = _find_application(token, spec)
+
+    if app is None:
+        app = _post(
+            token,
+            "/applications",
+            {
+                "displayName": spec.display_name,
+                "signInAudience": "AzureADMyOrg",
+                "notes": _render_stamp(),
+                "publicClient": {"redirectUris": [LOCALHOST_REDIRECT]},
+                "requiredResourceAccess": [
+                    {"resourceAppId": _MS_GRAPH_APP_ID, "resourceAccess": wanted_access}
+                ],
+            },
+            "Creating app registration",
+        )
+        result.created = True
+        result.changes.append(f"Created app registration '{spec.display_name}'")
+        # The broker redirect embeds the client ID, known only after creation.
+        _patch(
+            token,
+            f"/applications/{app['id']}",
+            {
+                "publicClient": {
+                    "redirectUris": [
+                        LOCALHOST_REDIRECT,
+                        BROKER_REDIRECT_TEMPLATE.format(client_id=app["appId"]),
+                    ]
+                }
+            },
+            "Adding redirect URIs",
+        )
+        result.changes.append("Added redirect URIs (browser and Windows broker)")
+        return app
+
+    stamp = _parse_stamp(app.get("notes"))
+    if stamp is None:
+        if not spec.client_id and not spec.adopt:
+            result.needs_adopt = True
+            return app
+        result.adopted = True
+        logger.info(
+            "AUTH",
+            f"Adopting registration '{app.get('displayName')}' ({app['appId']}) "
+            "that NAPT did not create",
+        )
+    else:
+        result.previous_spec = int(stamp["spec"])
+        if result.previous_spec < SPEC_VERSION:
+            logger.info(
+                "AUTH",
+                f"Registration is at spec {result.previous_spec}; NAPT "
+                f"{__version__} expects spec {SPEC_VERSION}. Updating.",
+            )
+
+    patch: dict = {}
+    wanted_uris = [
+        LOCALHOST_REDIRECT,
+        BROKER_REDIRECT_TEMPLATE.format(client_id=app["appId"]),
+    ]
+    have_uris = (app.get("publicClient") or {}).get("redirectUris") or []
+    missing_uris = [u for u in wanted_uris if u not in have_uris]
+    if missing_uris:
+        patch["publicClient"] = {"redirectUris": have_uris + missing_uris}
+        result.changes.append("Added redirect URIs: " + ", ".join(missing_uris))
+
+    existing_access = app.get("requiredResourceAccess") or []
+    merged_access = _merge_resource_access(existing_access, wanted_access)
+    if merged_access != existing_access:
+        patch["requiredResourceAccess"] = merged_access
+        result.changes.append("Added Microsoft Graph API permissions")
+
+    if (
+        stamp is None
+        or stamp["spec"] != str(SPEC_VERSION)
+        or stamp["version"] != __version__
+    ):
+        patch["notes"] = _with_stamp(app.get("notes"))
+        result.changes.append(
+            f"Stamped internal notes: {_STAMP_PREFIX} spec={SPEC_VERSION} "
+            f"version={__version__}"
+        )
+
+    if patch:
+        _patch(token, f"/applications/{app['id']}", patch, "Updating app registration")
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Service principal and consent
+# ---------------------------------------------------------------------------
+
+
+def _ensure_service_principal(token: str, app: dict, result: SetupResult) -> str:
+    """Returns the service principal object ID, creating it if needed."""
+    data = _get(
+        token,
+        f"/servicePrincipals?$filter=appId eq '{app['appId']}'&$select=id",
+        "Looking up service principal",
+    )
+    sps = data.get("value") or []
+    if sps:
+        return sps[0]["id"]
+    sp = _post(
+        token,
+        "/servicePrincipals",
+        {"appId": app["appId"]},
+        "Creating service principal",
+    )
+    result.changes.append("Created service principal")
+    return sp["id"]
+
+
+def _ensure_app_role_consent(
+    token: str,
+    sp_id: str,
+    graph_sp_id: str,
+    roles: dict[str, str],
+    result: SetupResult,
+) -> None:
+    """Grants admin consent for application permissions (app role assignments)."""
+    data = _get(
+        token,
+        f"/servicePrincipals/{sp_id}/appRoleAssignments?$select=appRoleId,resourceId",
+        "Listing application permission grants",
+    )
+    granted = {
+        a["appRoleId"]
+        for a in data.get("value") or []
+        if a.get("resourceId") == graph_sp_id
+    }
+    for permission in APPLICATION_PERMISSIONS:
+        role_id = roles[permission]
+        if role_id in granted:
+            continue
+        _post_after_replication(
+            token,
+            f"/servicePrincipals/{sp_id}/appRoleAssignments",
+            {"principalId": sp_id, "resourceId": graph_sp_id, "appRoleId": role_id},
+            f"Granting application permission {permission}",
+        )
+        result.changes.append(f"Granted application permission {permission}")
+
+
+def _ensure_delegated_consent(
+    token: str, sp_id: str, graph_sp_id: str, result: SetupResult
+) -> None:
+    """Grants tenant-wide admin consent for the delegated permissions."""
+    data = _get(
+        token,
+        "/oauth2PermissionGrants"
+        f"?$filter=clientId eq '{sp_id}' and consentType eq 'AllPrincipals'"
+        f" and resourceId eq '{graph_sp_id}'",
+        "Listing delegated permission grants",
+    )
+    grants = data.get("value") or []
+    if not grants:
+        _post_after_replication(
+            token,
+            "/oauth2PermissionGrants",
+            {
+                "clientId": sp_id,
+                "consentType": "AllPrincipals",
+                "resourceId": graph_sp_id,
+                "scope": " ".join(DELEGATED_PERMISSIONS),
+            },
+            "Granting delegated permissions",
+        )
+        result.changes.append(
+            "Granted delegated permissions " + ", ".join(DELEGATED_PERMISSIONS)
+        )
+        return
+    grant = grants[0]
+    have = set((grant.get("scope") or "").split())
+    missing = [p for p in DELEGATED_PERMISSIONS if p not in have]
+    if not missing:
+        return
+    _patch(
+        token,
+        f"/oauth2PermissionGrants/{grant['id']}",
+        {"scope": " ".join(sorted(have | set(missing)))},
+        "Updating delegated permission grant",
+    )
+    result.changes.append("Granted delegated permissions " + ", ".join(missing))
+
+
+# ---------------------------------------------------------------------------
+# Federated credential
+# ---------------------------------------------------------------------------
+
+
+def _ensure_federated_credential(
+    token: str, app: dict, spec: SetupSpec, result: SetupResult
+) -> None:
+    """Adds the OIDC federated credential when ``spec`` asks for one."""
+    name = spec.federated_credential_name
+    issuer = spec.federated_issuer
+    subject = spec.federated_subject
+    if not name or not issuer or not subject:
+        return
+    data = _get(
+        token,
+        f"/applications/{app['id']}/federatedIdentityCredentials",
+        "Listing federated credentials",
+    )
+    for cred in data.get("value") or []:
+        if cred.get("issuer") == issuer and cred.get("subject") == subject:
+            return
+    _post(
+        token,
+        f"/applications/{app['id']}/federatedIdentityCredentials",
+        {
+            "name": name,
+            "issuer": issuer,
+            "subject": subject,
+            "audiences": [spec.federated_audience],
+            "description": "NAPT CI/CD (OIDC)",
+        },
+        "Adding federated credential",
+    )
+    result.changes.append(f"Added federated credential for {subject} ({issuer})")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def setup_app_registration(spec: SetupSpec) -> SetupResult:
+    """Creates or completes the NAPT app registration in a tenant.
+
+    Signs an administrator in, then finds or creates the application,
+    adds any missing redirect URIs and Graph permissions, ensures the
+    service principal exists with admin consent for every permission, and
+    adds the GitHub federated credential when requested. Finally records
+    the tenant and client ID as the active tenant for `napt auth login`.
+
+    Args:
+        spec: What to provision.
+
+    Returns:
+        The registration's IDs and the list of changes made.
+
+    Raises:
+        AuthError: If the administrator sign-in fails or lacks the rights
+            to manage applications.
+        ConfigError: If the display name is ambiguous, a given client ID
+            does not exist, or Graph reports unexpected permission data.
+        NetworkError: On Graph API failures.
+
+    Example:
+        Provision a tenant and trust a CI workflow through OIDC:
+            ```python
+            from napt.upload.entra import SetupSpec, setup_app_registration
+
+            result = setup_app_registration(
+                SetupSpec(
+                    tenant_id="<tenant id>",
+                    federated_issuer="https://token.actions.githubusercontent.com",
+                    federated_subject="repo:contoso/intune-apps:ref:refs/heads/main",
+                )
+            )
+            print(result.client_id, result.changes)
+            ```
+
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    token = _bootstrap_token(spec.tenant_id)
+
+    roles, scopes, graph_sp_id = _graph_permission_ids(token)
+    result = SetupResult(
+        tenant_id=spec.tenant_id, client_id="", display_name=spec.display_name
+    )
+
+    app = _ensure_application(token, spec, roles, scopes, result)
+    result.client_id = app["appId"]
+    result.display_name = app.get("displayName") or spec.display_name
+    if result.needs_adopt:
+        return result
+    logger.info("AUTH", f"App registration: {result.display_name} ({result.client_id})")
+
+    sp_id = _ensure_service_principal(token, app, result)
+    _ensure_app_role_consent(token, sp_id, graph_sp_id, roles, result)
+    _ensure_delegated_consent(token, sp_id, graph_sp_id, result)
+    _ensure_federated_credential(token, app, spec, result)
+
+    # Keep an existing session for this tenant when the client ID is unchanged.
+    known = load_auth_store().tenants.get(spec.tenant_id)
+    if known is not None and known.client_id == result.client_id:
+        _remember(known)
+    else:
+        _remember(AuthConfig(client_id=result.client_id, tenant_id=spec.tenant_id))
+    logger.verbose("AUTH", "Saved tenant and client ID for 'napt auth login'")
+    return result

--- a/napt/upload/entra.py
+++ b/napt/upload/entra.py
@@ -659,7 +659,7 @@ def setup_app_registration(spec: SetupSpec) -> SetupResult:
     Signs an administrator in, then finds or creates the application,
     adds any missing redirect URIs and Graph permissions, ensures the
     service principal exists with admin consent for every permission, and
-    adds the GitHub federated credential when requested. Finally records
+    adds the OIDC federated credential when requested. Finally records
     the tenant and client ID as the active tenant for `napt auth login`.
 
     Args:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from napt.cli import (
     _resolve_build_dir_from_recipe,
     cmd_auth_login,
     cmd_auth_logout,
+    cmd_auth_setup,
     cmd_auth_status,
     cmd_build,
     cmd_discover,
@@ -706,6 +707,134 @@ class TestCmdAuth:
         with patch("napt.cli.auth_status", side_effect=AuthError("expired")):
             assert cmd_auth_status(_args()) == 1
         assert "Authentication error: expired" in capsys.readouterr().out
+
+    @staticmethod
+    def _setup_args(**overrides):
+        defaults = {
+            "tenant_id": "tid",
+            "name": "NAPT",
+            "client_id": None,
+            "federated_issuer": None,
+            "federated_subject": None,
+            "federated_audience": "api://AzureADTokenExchange",
+            "federated_name": None,
+            "adopt": False,
+            "print_only": False,
+        }
+        defaults.update(overrides)
+        return _args(**defaults)
+
+    def test_setup_warns_and_exits_one_when_adopt_is_needed(self, capsys):
+        """Tests that an unstamped name match prints the adopt warning and fails."""
+        from napt.upload.entra import SetupResult
+
+        result = SetupResult(
+            tenant_id="tid", client_id="cid", display_name="NAPT", needs_adopt=True
+        )
+        with patch("napt.cli.setup_app_registration", return_value=result) as setup:
+            assert cmd_auth_setup(self._setup_args()) == 1
+        assert setup.call_args.args[0].adopt is False
+        out = capsys.readouterr().out
+        assert "[WARNING] Found existing registration 'NAPT' (cid)" in out
+        assert "Re-run with --adopt" in out
+        assert "never removes existing settings" in out
+
+    def test_setup_reports_adoption(self, capsys):
+        """Tests that --adopt is forwarded and an adopted registration is announced."""
+        from napt.upload.entra import SPEC_VERSION, SetupResult
+
+        result = SetupResult(
+            tenant_id="tid",
+            client_id="cid",
+            display_name="NAPT",
+            adopted=True,
+            changes=["Stamped internal notes: napt/v1 spec=1 version=x"],
+        )
+        with patch("napt.cli.setup_app_registration", return_value=result) as setup:
+            assert cmd_auth_setup(self._setup_args(adopt=True)) == 0
+        assert setup.call_args.args[0].adopt is True
+        out = capsys.readouterr().out
+        assert (
+            f"[OK] Adopted 'NAPT' (cid) -- stamped as napt/v1 spec={SPEC_VERSION}"
+            in (out)
+        )
+
+    def test_setup_reports_changes_and_next_steps(self, capsys):
+        """Tests that a provisioning run lists its changes and the IDs to use."""
+        from napt.upload.entra import SetupResult
+
+        result = SetupResult(
+            tenant_id="tid",
+            client_id="cid",
+            display_name="NAPT",
+            created=True,
+            changes=["Created app registration 'NAPT'", "Created service principal"],
+        )
+        with patch("napt.cli.setup_app_registration", return_value=result) as setup:
+            assert (
+                cmd_auth_setup(
+                    self._setup_args(
+                        federated_issuer="https://issuer", federated_subject="sub"
+                    )
+                )
+                == 0
+            )
+        spec = setup.call_args.args[0]
+        assert spec.tenant_id == "tid"
+        assert spec.federated_issuer == "https://issuer"
+        assert spec.federated_subject == "sub"
+        out = capsys.readouterr().out
+        assert "[OK] App registration is ready" in out
+        assert "  - Created service principal" in out
+        assert "Client ID:  cid" in out
+        assert "OIDC login mint the token" in out
+
+    def test_setup_rejects_half_specified_federated_credential(self, capsys):
+        """Tests that --federated-issuer without --federated-subject fails early."""
+        with patch("napt.cli.setup_app_registration") as setup:
+            code = cmd_auth_setup(self._setup_args(federated_issuer="https://issuer"))
+        assert code == 1
+        setup.assert_not_called()
+        assert "both an issuer and a subject" in capsys.readouterr().out
+
+    def test_setup_reports_nothing_to_change(self, capsys):
+        """Tests that a complete registration is reported as already done."""
+        from napt.upload.entra import SetupResult
+
+        result = SetupResult(tenant_id="tid", client_id="cid", display_name="NAPT")
+        with patch("napt.cli.setup_app_registration", return_value=result):
+            assert cmd_auth_setup(self._setup_args()) == 0
+        out = capsys.readouterr().out
+        assert "is at spec 1; nothing to change" in out
+        assert "--federated-issuer/--federated-subject" in out
+
+    def test_setup_print_only_never_calls_graph(self, capsys):
+        """Tests that --print-only prints the checklist without signing in."""
+        with patch("napt.cli.setup_app_registration") as setup:
+            code = cmd_auth_setup(
+                self._setup_args(
+                    print_only=True,
+                    client_id="cid",
+                    federated_issuer="https://issuer",
+                    federated_subject="repo:o/r:ref:refs/heads/main",
+                )
+            )
+        assert code == 0
+        setup.assert_not_called()
+        out = capsys.readouterr().out
+        assert "ms-appx-web://Microsoft.AAD.BrokerPlugin/cid" in out
+        assert "DeviceManagementApps.ReadWrite.All" in out
+        assert "Issuer:   https://issuer" in out
+        assert "Subject:  repo:o/r:ref:refs/heads/main" in out
+        assert "Audience: api://AzureADTokenExchange" in out
+
+    def test_setup_error_returns_one(self, capsys):
+        """Tests that setup failures are reported and return 1."""
+        with patch(
+            "napt.cli.setup_app_registration", side_effect=ConfigError("ambiguous")
+        ):
+            assert cmd_auth_setup(self._setup_args()) == 1
+        assert "Error: ambiguous" in capsys.readouterr().out
 
 
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -738,6 +738,10 @@ class TestCmdAuth:
         assert "[WARNING] Found existing registration 'NAPT' (cid)" in out
         assert "Re-run with --adopt" in out
         assert "never removes existing settings" in out
+        assert (
+            "To create a new registration instead, re-run with "
+            "--name <a name other than 'NAPT'>." in out
+        )
 
     def test_setup_reports_adoption(self, capsys):
         """Tests that --adopt is forwarded and an adopted registration is announced."""

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -557,3 +557,33 @@ def test_azure_cli_token_is_none_when_unavailable() -> None:
     cred.get_token.side_effect = ClientAuthenticationError("az not found")
     with patch("napt.upload.auth.AzureCliCredential", return_value=cred):
         assert auth._azure_cli_token() is None
+
+
+def _cli_cred(token: str) -> MagicMock:
+    access = MagicMock()
+    access.token = token
+    cred = MagicMock()
+    cred.get_token.return_value = access
+    return cred
+
+
+def test_azure_cli_token_accepts_service_principal_session() -> None:
+    """Tests that an app-only az session (azure/login in CI) is used."""
+    token = _jwt({"idtyp": "app", "appid": "cid", "roles": ["Group.Read.All"]})
+    with patch("napt.upload.auth.AzureCliCredential", return_value=_cli_cred(token)):
+        assert auth._azure_cli_token() == token
+
+
+def test_azure_cli_token_refuses_user_session() -> None:
+    """Tests that a person's az login is refused with a pointer to napt auth login."""
+    token = _jwt(
+        {
+            "idtyp": "user",
+            "preferred_username": "dev@x",
+            "scp": "DeviceManagementApps.ReadWrite.All Group.Read.All",
+        }
+    )
+    with patch("napt.upload.auth.AzureCliCredential", return_value=_cli_cred(token)):
+        with pytest.raises(AuthError, match="signed in as a user") as exc:
+            auth._azure_cli_token()
+    assert "napt auth login" in str(exc.value)

--- a/tests/upload/test_auth.py
+++ b/tests/upload/test_auth.py
@@ -49,7 +49,11 @@ def chain_fails():
     """Makes the non-interactive azure-identity chain report no credential."""
     cred = MagicMock()
     cred.get_token.side_effect = ClientAuthenticationError("no cred")
-    with patch("napt.upload.auth.get_credential", return_value=cred):
+    with (
+        patch("napt.upload.auth.get_credential", return_value=cred),
+        # Keep the developer's real `az login` session out of the tests.
+        patch("napt.upload.auth._azure_cli_token", return_value=None),
+    ):
         yield cred
 
 
@@ -510,3 +514,46 @@ def test_resolve_auth_config_accepts_domain_for_tenant(user_dir) -> None:
     assert resolved.username == "a@x"
     # Unknown domains are passed through untouched so the error names them.
     assert resolve_auth_config(tenant_id="nope.com") is None
+
+
+# ---------------------------------------------------------------------------
+# Azure CLI session (OIDC login steps in CI)
+# ---------------------------------------------------------------------------
+
+
+def test_get_access_token_falls_back_to_azure_cli(user_dir, chain_fails) -> None:
+    """Tests that an az login session is used when nothing else is configured."""
+    with patch("napt.upload.auth._azure_cli_token", return_value="cli-token"):
+        assert get_access_token() == "cli-token"
+
+
+def test_napt_session_wins_over_azure_cli(user_dir, chain_fails) -> None:
+    """Tests that a developer's napt auth login beats a stray az login."""
+    _remember(AuthConfig("cid", "tid", "u@x"))
+    app = _fake_app(accounts=[{"username": "u@x"}], silent={"access_token": "napt"})
+    with (
+        patch("napt.upload.auth._build_public_client", return_value=app),
+        patch("napt.upload.auth._azure_cli_token", return_value="cli-token") as cli,
+    ):
+        assert get_access_token() == "napt"
+    cli.assert_not_called()
+
+
+def test_get_status_reports_azure_cli(user_dir, chain_fails) -> None:
+    """Tests that status names the Azure CLI as the source and decodes its token."""
+    token = _jwt(
+        {"appid": "cid", "tid": "tid", "roles": list(auth.REQUIRED_PERMISSIONS)}
+    )
+    with patch("napt.upload.auth._azure_cli_token", return_value=token):
+        status = get_status()
+    assert status is not None
+    assert status.method == "azure cli"
+    assert status.missing == []
+
+
+def test_azure_cli_token_is_none_when_unavailable() -> None:
+    """Tests that a missing or signed-out Azure CLI yields None, not an error."""
+    cred = MagicMock()
+    cred.get_token.side_effect = ClientAuthenticationError("az not found")
+    with patch("napt.upload.auth.AzureCliCredential", return_value=cred):
+        assert auth._azure_cli_token() is None

--- a/tests/upload/test_entra.py
+++ b/tests/upload/test_entra.py
@@ -152,7 +152,7 @@ def test_spec_requires_issuer_and_subject_together() -> None:
 
 
 def test_setup_creates_everything_in_a_fresh_tenant(user_dir, bootstrap) -> None:
-    """Tests the full create path: app, redirect patch, SP, both consents."""
+    """Tests that a fresh tenant gets the full create path: app, URIs, SP, consents."""
     graph = FakeGraph(
         {
             ("GET", "/servicePrincipals"): [

--- a/tests/upload/test_entra.py
+++ b/tests/upload/test_entra.py
@@ -1,0 +1,690 @@
+"""Tests for napt.upload.entra."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from napt.exceptions import AuthError, ConfigError, NetworkError
+from napt.upload import auth, entra
+from napt.upload.auth import AuthConfig, AuthStore
+from napt.upload.entra import SetupSpec, setup_app_registration
+
+GRAPH_SP_ID = "graph-sp"
+ROLE_IDS = {"DeviceManagementApps.ReadWrite.All": "role-dm", "Group.Read.All": "role-g"}
+SCOPE_IDS = {
+    "DeviceManagementApps.ReadWrite.All": "scope-dm",
+    "Group.Read.All": "scope-g",
+    "User.Read": "scope-u",
+}
+
+
+def _graph_sp_response() -> dict:
+    return {
+        "value": [
+            {
+                "id": GRAPH_SP_ID,
+                "appRoles": [{"value": v, "id": i} for v, i in ROLE_IDS.items()],
+                "oauth2PermissionScopes": [
+                    {"value": v, "id": i} for v, i in SCOPE_IDS.items()
+                ],
+            }
+        ]
+    }
+
+
+def _stamp(spec: int = entra.SPEC_VERSION, version: str | None = None) -> str:
+    version = version or entra.__version__
+    return f"napt/v1 spec={spec} version={version} provisioned=2026-08-18"
+
+
+def _complete_app(app_id: str = "cid", object_id: str = "obj") -> dict:
+    """An application object that already matches the spec, stamped by NAPT."""
+    return {
+        "id": object_id,
+        "appId": app_id,
+        "displayName": "NAPT",
+        "notes": _stamp(),
+        "publicClient": {
+            "redirectUris": [
+                entra.LOCALHOST_REDIRECT,
+                entra.BROKER_REDIRECT_TEMPLATE.format(client_id=app_id),
+            ]
+        },
+        "requiredResourceAccess": [
+            {
+                "resourceAppId": entra._MS_GRAPH_APP_ID,
+                "resourceAccess": [
+                    {"id": ROLE_IDS[p], "type": "Role"}
+                    for p in entra.APPLICATION_PERMISSIONS
+                ]
+                + [
+                    {"id": SCOPE_IDS[p], "type": "Scope"}
+                    for p in entra.DELEGATED_PERMISSIONS
+                ],
+            }
+        ],
+    }
+
+
+class FakeGraph:
+    """Routes _graph_request calls to canned responses and records writes."""
+
+    def __init__(self, responses: dict[tuple[str, str], dict | list[dict]]):
+        # Keys are (method, path-after-v1.0 up to '?'); values are a dict, or a
+        # list of dicts returned in sequence for repeated calls.
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def __call__(self, method, url, context, headers, json=None, **kwargs):
+        path = url.replace(entra._GRAPH_V1, "").split("?")[0]
+        self.calls.append((method, path, json))
+        key = (method, path)
+        if key not in self.responses:
+            raise AssertionError(f"unexpected Graph call {method} {path}")
+        canned = self.responses[key]
+        if isinstance(canned, list):
+            return canned.pop(0) if len(canned) > 1 else canned[0]
+        return canned
+
+    def writes(self) -> list[tuple[str, str, dict | None]]:
+        return [c for c in self.calls if c[0] != "GET"]
+
+
+@pytest.fixture
+def user_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("NAPT_USER_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def bootstrap():
+    with patch("napt.upload.entra._bootstrap_token", return_value="tok") as b:
+        yield b
+
+
+def _run(graph: FakeGraph, spec: SetupSpec):
+    with (
+        patch("napt.upload.entra._graph_request", graph),
+        patch("napt.upload.entra.time.sleep"),
+    ):
+        return setup_app_registration(spec)
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+
+def test_spec_federated_credential_name_is_derived_or_given() -> None:
+    """Tests that the credential name defaults to a sanitized subject."""
+    derived = SetupSpec(
+        tenant_id="t",
+        federated_issuer="https://token.actions.githubusercontent.com",
+        federated_subject="repo:o/r:ref:refs/heads/main",
+    )
+    assert derived.federated_credential_name == "napt-repo-o-r-ref-refs-heads-main"
+    assert derived.federated_audience == entra.FEDERATED_AUDIENCE_DEFAULT
+
+    given = SetupSpec(
+        tenant_id="t",
+        federated_issuer="https://gitlab.example.com",
+        federated_subject="project_path:g/p:ref_type:branch:ref:main",
+        federated_name="gitlab-main",
+    )
+    assert given.federated_credential_name == "gitlab-main"
+
+    assert SetupSpec(tenant_id="t").federated_credential_name is None
+
+
+def test_spec_requires_issuer_and_subject_together() -> None:
+    """Tests that a half-specified federated credential is rejected early."""
+    with pytest.raises(ConfigError, match="both an issuer and a subject"):
+        SetupSpec(tenant_id="t", federated_issuer="https://x")
+    with pytest.raises(ConfigError, match="both an issuer and a subject"):
+        SetupSpec(tenant_id="t", federated_subject="s")
+
+
+# ---------------------------------------------------------------------------
+# Fresh tenant
+# ---------------------------------------------------------------------------
+
+
+def test_setup_creates_everything_in_a_fresh_tenant(user_dir, bootstrap) -> None:
+    """Tests the full create path: app, redirect patch, SP, both consents."""
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): [
+                _graph_sp_response(),  # Graph's own SP
+                {"value": []},  # NAPT SP does not exist yet
+            ],
+            ("GET", "/applications"): {"value": []},
+            ("POST", "/applications"): {"id": "obj", "appId": "new-cid"},
+            ("PATCH", "/applications/obj"): {},
+            ("POST", "/servicePrincipals"): {"id": "sp"},
+            ("GET", "/servicePrincipals/sp/appRoleAssignments"): {"value": []},
+            ("POST", "/servicePrincipals/sp/appRoleAssignments"): {},
+            ("GET", "/oauth2PermissionGrants"): {"value": []},
+            ("POST", "/oauth2PermissionGrants"): {},
+        }
+    )
+
+    result = _run(graph, SetupSpec(tenant_id="tid"))
+
+    assert result.created is True
+    assert result.client_id == "new-cid"
+    bootstrap.assert_called_once_with("tid")
+
+    create = next(
+        j for m, p, j in graph.writes() if (m, p) == ("POST", "/applications")
+    )
+    assert create is not None
+    assert create["signInAudience"] == "AzureADMyOrg"
+    assert create["publicClient"]["redirectUris"] == [entra.LOCALHOST_REDIRECT]
+    access = create["requiredResourceAccess"][0]
+    assert access["resourceAppId"] == entra._MS_GRAPH_APP_ID
+    assert {(a["id"], a["type"]) for a in access["resourceAccess"]} == {
+        ("role-dm", "Role"),
+        ("role-g", "Role"),
+        ("scope-dm", "Scope"),
+        ("scope-g", "Scope"),
+        ("scope-u", "Scope"),
+    }
+
+    redirect_patch = next(
+        j for m, p, j in graph.writes() if (m, p) == ("PATCH", "/applications/obj")
+    )
+    assert redirect_patch is not None
+    assert redirect_patch["publicClient"]["redirectUris"] == [
+        "http://localhost",
+        "ms-appx-web://Microsoft.AAD.BrokerPlugin/new-cid",
+    ]
+
+    role_posts = [
+        j
+        for m, p, j in graph.writes()
+        if p == "/servicePrincipals/sp/appRoleAssignments"
+    ]
+    assert {j["appRoleId"] for j in role_posts if j} == {"role-dm", "role-g"}
+    assert all(j and j["resourceId"] == GRAPH_SP_ID for j in role_posts)
+
+    grant = next(j for m, p, j in graph.writes() if p == "/oauth2PermissionGrants")
+    assert grant is not None
+    assert grant["consentType"] == "AllPrincipals"
+    assert grant["scope"].split() == list(entra.DELEGATED_PERMISSIONS)
+
+    # Nothing touches the service principal's redirect URIs or permissions.
+    assert not any(p == "/servicePrincipals/sp" for _, p, _ in graph.writes())
+
+    store = auth.load_auth_store()
+    assert store.active == "tid"
+    assert store.tenants["tid"] == AuthConfig("new-cid", "tid")
+    assert len(result.changes) >= 5
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_setup_is_a_no_op_on_a_complete_registration(user_dir, bootstrap) -> None:
+    """Tests that a registration already matching the spec is left untouched."""
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): [
+                _graph_sp_response(),
+                {"value": [{"id": "sp"}]},
+            ],
+            ("GET", "/applications"): {"value": [_complete_app()]},
+            ("GET", "/servicePrincipals/sp/appRoleAssignments"): {
+                "value": [
+                    {"appRoleId": "role-dm", "resourceId": GRAPH_SP_ID},
+                    {"appRoleId": "role-g", "resourceId": GRAPH_SP_ID},
+                ]
+            },
+            ("GET", "/oauth2PermissionGrants"): {
+                "value": [
+                    {
+                        "id": "grant",
+                        "scope": "User.Read Group.Read.All "
+                        "DeviceManagementApps.ReadWrite.All",
+                    }
+                ]
+            },
+        }
+    )
+
+    result = _run(graph, SetupSpec(tenant_id="tid"))
+
+    assert result.created is False
+    assert result.changes == []
+    assert graph.writes() == []
+
+
+def test_setup_adds_only_what_is_missing(user_dir, bootstrap) -> None:
+    """Tests that an old-style registration gains the broker URI and scopes only."""
+    app = _complete_app()
+    app["publicClient"] = {"redirectUris": ["http://localhost"]}
+    # Only the application roles were declared; delegated scopes are missing.
+    app["requiredResourceAccess"] = [
+        {
+            "resourceAppId": entra._MS_GRAPH_APP_ID,
+            "resourceAccess": [
+                {"id": "role-dm", "type": "Role"},
+                {"id": "role-g", "type": "Role"},
+            ],
+        },
+        {
+            "resourceAppId": "other-api",
+            "resourceAccess": [{"id": "x", "type": "Scope"}],
+        },
+    ]
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): [
+                _graph_sp_response(),
+                {"value": [{"id": "sp"}]},
+            ],
+            ("GET", "/applications"): {"value": [app]},
+            ("PATCH", "/applications/obj"): {},
+            ("GET", "/servicePrincipals/sp/appRoleAssignments"): {
+                "value": [
+                    {"appRoleId": "role-dm", "resourceId": GRAPH_SP_ID},
+                    {"appRoleId": "role-g", "resourceId": GRAPH_SP_ID},
+                ]
+            },
+            ("GET", "/oauth2PermissionGrants"): {
+                "value": [{"id": "grant", "scope": "User.Read"}]
+            },
+            ("PATCH", "/oauth2PermissionGrants/grant"): {},
+        }
+    )
+
+    result = _run(graph, SetupSpec(tenant_id="tid"))
+
+    app_patch = next(
+        j for m, p, j in graph.writes() if (m, p) == ("PATCH", "/applications/obj")
+    )
+    assert app_patch is not None
+    assert app_patch["publicClient"]["redirectUris"] == [
+        "http://localhost",
+        "ms-appx-web://Microsoft.AAD.BrokerPlugin/cid",
+    ]
+    graph_access = next(
+        r
+        for r in app_patch["requiredResourceAccess"]
+        if r["resourceAppId"] == entra._MS_GRAPH_APP_ID
+    )
+    assert {(a["id"], a["type"]) for a in graph_access["resourceAccess"]} == {
+        ("role-dm", "Role"),
+        ("role-g", "Role"),
+        ("scope-dm", "Scope"),
+        ("scope-g", "Scope"),
+        ("scope-u", "Scope"),
+    }
+    # The unrelated API's permissions are preserved verbatim.
+    assert {
+        "resourceAppId": "other-api",
+        "resourceAccess": [{"id": "x", "type": "Scope"}],
+    } in (app_patch["requiredResourceAccess"])
+
+    grant_patch = next(
+        j for m, p, j in graph.writes() if p == "/oauth2PermissionGrants/grant"
+    )
+    assert grant_patch is not None
+    assert grant_patch["scope"].split() == sorted(entra.DELEGATED_PERMISSIONS)
+    assert any("redirect" in c.lower() for c in result.changes)
+    assert any("delegated" in c.lower() for c in result.changes)
+
+
+def test_setup_keeps_existing_session_for_same_client(user_dir, bootstrap) -> None:
+    """Tests that re-running setup does not sign out a tenant already logged in."""
+    auth._save_auth_store(
+        AuthStore(
+            active="tid",
+            tenants={"tid": AuthConfig("cid", "tid", "me@x", "x.com", "X")},
+        )
+    )
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): [
+                _graph_sp_response(),
+                {"value": [{"id": "sp"}]},
+            ],
+            ("GET", "/applications"): {"value": [_complete_app()]},
+            ("GET", "/servicePrincipals/sp/appRoleAssignments"): {
+                "value": [
+                    {"appRoleId": "role-dm", "resourceId": GRAPH_SP_ID},
+                    {"appRoleId": "role-g", "resourceId": GRAPH_SP_ID},
+                ]
+            },
+            ("GET", "/oauth2PermissionGrants"): {
+                "value": [{"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}]
+            },
+        }
+    )
+    _run(graph, SetupSpec(tenant_id="tid"))
+    assert auth.load_auth_store().tenants["tid"] == AuthConfig(
+        "cid", "tid", "me@x", "x.com", "X"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lookup edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_setup_rejects_ambiguous_display_name(user_dir, bootstrap) -> None:
+    """Tests that two registrations with the same name need --client-id."""
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): _graph_sp_response(),
+            ("GET", "/applications"): {
+                "value": [{"id": "a", "appId": "1"}, {"id": "b", "appId": "2"}]
+            },
+        }
+    )
+    with pytest.raises(ConfigError, match="--client-id"):
+        _run(graph, SetupSpec(tenant_id="tid"))
+
+
+def test_setup_with_unknown_client_id_fails(user_dir, bootstrap) -> None:
+    """Tests that an explicit --client-id must exist."""
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): _graph_sp_response(),
+            ("GET", "/applications"): {"value": []},
+        }
+    )
+    with pytest.raises(ConfigError, match="No app registration with client ID"):
+        _run(graph, SetupSpec(tenant_id="tid", client_id="nope"))
+
+
+def test_setup_fails_when_graph_lacks_permission_names(user_dir, bootstrap) -> None:
+    """Tests that missing Graph permission definitions are reported, not KeyError."""
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): {
+                "value": [
+                    {"id": GRAPH_SP_ID, "appRoles": [], "oauth2PermissionScopes": []}
+                ]
+            }
+        }
+    )
+    with pytest.raises(ConfigError, match="DeviceManagementApps.ReadWrite.All"):
+        _run(graph, SetupSpec(tenant_id="tid"))
+
+
+def test_bootstrap_failure_is_an_auth_error(user_dir) -> None:
+    """Tests that a canceled or blocked administrator sign-in is explained."""
+    fake_app = type(
+        "App",
+        (),
+        {
+            "acquire_token_interactive": lambda self, *a, **k: {
+                "error": "access_denied",
+                "error_description": "AADSTS65001: consent required",
+            }
+        },
+    )()
+    with patch("napt.upload.entra.msal.PublicClientApplication", return_value=fake_app):
+        with pytest.raises(AuthError, match="access_denied") as exc:
+            setup_app_registration(SetupSpec(tenant_id="tid"))
+    assert "--print-only" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Replication and federated credential
+# ---------------------------------------------------------------------------
+
+
+def test_consent_retries_until_service_principal_replicates(
+    user_dir, bootstrap
+) -> None:
+    """Tests that a 404 right after SP creation is retried, other errors are not."""
+    attempts = {"n": 0}
+
+    def flaky_graph(method, url, context, headers, json=None, **kwargs):
+        path = url.replace(entra._GRAPH_V1, "").split("?")[0]
+        if (method, path) == ("POST", "/servicePrincipals/sp/appRoleAssignments"):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise NetworkError(f"{context}: HTTP 404\nnot found")
+            return {}
+        return FakeGraph(
+            {
+                ("GET", "/servicePrincipals"): _graph_sp_response(),
+                ("GET", "/applications"): {"value": [_complete_app()]},
+                ("GET", "/servicePrincipals/sp/appRoleAssignments"): {
+                    "value": [{"appRoleId": "role-g", "resourceId": GRAPH_SP_ID}]
+                },
+                ("GET", "/oauth2PermissionGrants"): {
+                    "value": [
+                        {"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}
+                    ]
+                },
+            }
+        )(method, url, context, headers, json, **kwargs)
+
+    # Second /servicePrincipals GET must return the NAPT SP; FakeGraph above is
+    # rebuilt per call, so answer it explicitly.
+    def graph(method, url, context, headers, json=None, **kwargs):
+        path = url.replace(entra._GRAPH_V1, "").split("?")[0]
+        if (method, path) == ("GET", "/servicePrincipals") and "appId eq 'cid'" in url:
+            return {"value": [{"id": "sp"}]}
+        return flaky_graph(method, url, context, headers, json, **kwargs)
+
+    with (
+        patch("napt.upload.entra._graph_request", graph),
+        patch("napt.upload.entra.time.sleep") as sleep,
+    ):
+        result = setup_app_registration(SetupSpec(tenant_id="tid"))
+
+    assert attempts["n"] == 2
+    sleep.assert_called_once()
+    assert "Granted application permission DeviceManagementApps.ReadWrite.All" in (
+        result.changes
+    )
+
+
+def test_setup_adds_federated_credential_once(user_dir, bootstrap) -> None:
+    """Tests that the OIDC credential is created when absent and skipped when present."""
+
+    def base() -> dict:
+        # Fresh per run: FakeGraph consumes sequenced responses as it goes.
+        return {
+            ("GET", "/servicePrincipals"): [
+                _graph_sp_response(),
+                {"value": [{"id": "sp"}]},
+            ],
+            ("GET", "/applications"): {"value": [_complete_app()]},
+            ("GET", "/servicePrincipals/sp/appRoleAssignments"): {
+                "value": [
+                    {"appRoleId": "role-dm", "resourceId": GRAPH_SP_ID},
+                    {"appRoleId": "role-g", "resourceId": GRAPH_SP_ID},
+                ]
+            },
+            ("GET", "/oauth2PermissionGrants"): {
+                "value": [{"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}]
+            },
+        }
+
+    issuer = "https://token.actions.githubusercontent.com"
+    subject = "repo:contoso/apps:environment:prod"
+    spec = SetupSpec(
+        tenant_id="tid",
+        federated_issuer=issuer,
+        federated_subject=subject,
+        federated_name="github-prod",
+    )
+
+    graph = FakeGraph(
+        {
+            **base(),
+            ("GET", "/applications/obj/federatedIdentityCredentials"): {"value": []},
+            ("POST", "/applications/obj/federatedIdentityCredentials"): {},
+        }
+    )
+    result = _run(graph, spec)
+    cred = next(
+        j
+        for m, p, j in graph.writes()
+        if p == "/applications/obj/federatedIdentityCredentials"
+    )
+    assert cred == {
+        "name": "github-prod",
+        "issuer": issuer,
+        "subject": subject,
+        "audiences": [entra.FEDERATED_AUDIENCE_DEFAULT],
+        "description": "NAPT CI/CD (OIDC)",
+    }
+    assert any("federated" in c for c in result.changes)
+
+    graph = FakeGraph(
+        {
+            **base(),
+            ("GET", "/applications/obj/federatedIdentityCredentials"): {
+                "value": [{"issuer": issuer, "subject": subject}]
+            },
+        }
+    )
+    result = _run(graph, spec)
+    assert result.changes == []
+    assert graph.writes() == []
+
+
+# ---------------------------------------------------------------------------
+# Provenance stamp and adoption
+# ---------------------------------------------------------------------------
+
+
+def _existing_tenant_responses(app: dict) -> dict:
+    return {
+        ("GET", "/servicePrincipals"): [
+            _graph_sp_response(),
+            {"value": [{"id": "sp"}]},
+        ],
+        ("GET", "/applications"): {"value": [app]},
+        ("PATCH", "/applications/obj"): {},
+        ("GET", "/servicePrincipals/sp/appRoleAssignments"): {
+            "value": [
+                {"appRoleId": "role-dm", "resourceId": GRAPH_SP_ID},
+                {"appRoleId": "role-g", "resourceId": GRAPH_SP_ID},
+            ]
+        },
+        ("GET", "/oauth2PermissionGrants"): {
+            "value": [{"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}]
+        },
+    }
+
+
+def test_stamp_round_trip_preserves_admin_notes() -> None:
+    """Tests that the stamp line is replaced in place and other notes survive."""
+    notes = (
+        "Owned by Endpoint team\nnapt/v1 spec=0 version=0.9.0 provisioned=2026-01-01\n"
+    )
+    parsed = entra._parse_stamp(notes)
+    assert parsed == {"spec": "0", "version": "0.9.0", "date": "2026-01-01"}
+
+    updated = entra._with_stamp(notes)
+    lines = updated.splitlines()
+    assert lines[0].startswith(f"napt/v1 spec={entra.SPEC_VERSION} version=")
+    assert lines[1:] == ["Owned by Endpoint team"]
+    assert entra._parse_stamp(None) is None
+    assert entra._parse_stamp("napt/v1 spec=x") is None
+
+
+def test_setup_create_writes_stamp(user_dir, bootstrap) -> None:
+    """Tests that a newly created registration carries the provenance stamp."""
+    graph = FakeGraph(
+        {
+            ("GET", "/servicePrincipals"): [_graph_sp_response(), {"value": []}],
+            ("GET", "/applications"): {"value": []},
+            ("POST", "/applications"): {"id": "obj", "appId": "new"},
+            ("PATCH", "/applications/obj"): {},
+            ("POST", "/servicePrincipals"): {"id": "sp"},
+            ("GET", "/servicePrincipals/sp/appRoleAssignments"): {"value": []},
+            ("POST", "/servicePrincipals/sp/appRoleAssignments"): {},
+            ("GET", "/oauth2PermissionGrants"): {"value": []},
+            ("POST", "/oauth2PermissionGrants"): {},
+        }
+    )
+    _run(graph, SetupSpec(tenant_id="tid"))
+    create = next(
+        j for m, p, j in graph.writes() if (m, p) == ("POST", "/applications")
+    )
+    assert create is not None
+    assert entra._parse_stamp(create["notes"]) == {
+        "spec": str(entra.SPEC_VERSION),
+        "version": entra.__version__,
+        "date": create["notes"].split("provisioned=")[1],
+    }
+
+
+def test_setup_refuses_unstamped_name_match_without_adopt(user_dir, bootstrap) -> None:
+    """Tests that a portal-made registration of the same name is reported, not touched."""
+    app = _complete_app()
+    app["notes"] = "Created by hand"
+    graph = FakeGraph(_existing_tenant_responses(app))
+
+    result = _run(graph, SetupSpec(tenant_id="tid"))
+
+    assert result.needs_adopt is True
+    assert result.client_id == "cid"
+    assert result.changes == []
+    assert graph.writes() == []
+    assert auth.load_auth_store().active is None  # nothing remembered either
+
+
+def test_setup_adopts_unstamped_registration_with_flag(user_dir, bootstrap) -> None:
+    """Tests that --adopt stamps the registration and keeps the admin's notes."""
+    app = _complete_app()
+    app["notes"] = "Created by hand"
+    graph = FakeGraph(_existing_tenant_responses(app))
+
+    result = _run(graph, SetupSpec(tenant_id="tid", adopt=True))
+
+    assert result.adopted is True
+    assert result.needs_adopt is False
+    patch = next(
+        j for m, p, j in graph.writes() if (m, p) == ("PATCH", "/applications/obj")
+    )
+    assert patch is not None
+    assert list(patch) == ["notes"]  # nothing else needed changing
+    assert patch["notes"].splitlines()[1] == "Created by hand"
+    assert entra._parse_stamp(patch["notes"]) is not None
+    assert result.changes == [
+        f"Stamped internal notes: napt/v1 spec={entra.SPEC_VERSION} "
+        f"version={entra.__version__}"
+    ]
+    assert auth.load_auth_store().active == "tid"
+
+
+def test_setup_explicit_client_id_implies_adopt(user_dir, bootstrap) -> None:
+    """Tests that naming the registration by --client-id needs no --adopt."""
+    app = _complete_app()
+    app["notes"] = None
+    graph = FakeGraph(_existing_tenant_responses(app))
+
+    result = _run(graph, SetupSpec(tenant_id="tid", client_id="cid"))
+
+    assert result.needs_adopt is False
+    assert result.adopted is True
+
+
+def test_setup_restamps_outdated_spec(user_dir, bootstrap) -> None:
+    """Tests that an older stamp is refreshed and reported as the previous spec."""
+    app = _complete_app()
+    app["notes"] = _stamp(spec=0, version="0.9.0")
+    graph = FakeGraph(_existing_tenant_responses(app))
+
+    result = _run(graph, SetupSpec(tenant_id="tid"))
+
+    assert result.previous_spec == 0
+    assert result.adopted is False
+    patch = next(
+        j for m, p, j in graph.writes() if (m, p) == ("PATCH", "/applications/obj")
+    )
+    assert patch is not None and list(patch) == ["notes"]
+    assert f"spec={entra.SPEC_VERSION}" in patch["notes"]


### PR DESCRIPTION
## Description
Adds `napt auth setup`, which creates — or brings up to spec — the NAPT app registration in a tenant through Microsoft Graph: redirect URIs, application and delegated Graph permissions, service principal, admin consent, and optionally a federated credential for OIDC-based CI/CD. Also replaces the untested workload-identity credential with an Azure CLI credential restricted to service-principal sessions, which is what `azure/login`-style OIDC steps actually leave behind.

## Motivation
After #102 the app registration was the last manual, error-prone step in onboarding (redirect URIs, two kinds of permissions, consent). Administrators should be able to provision it in one command, re-run it safely as NAPT's needs change, and have NAPT leave a visible record of what it manages. Separately, the OIDC path documented in #102 relied on `AZURE_FEDERATED_TOKEN_FILE`, which GitHub Actions' `azure/login` never sets; the CI path needed to use the Azure CLI session that step produces.

## Changes
- `napt auth setup --tenant-id <id> [--name] [--client-id] [--adopt] [--print-only]`
    - Bootstraps with a browser sign-in through the Microsoft Graph Command Line Tools app (at least Application Administrator); NAPT does not store that account
    - Creates the application (`http://localhost` + broker redirect URIs, `DeviceManagementApps.ReadWrite.All` / `Group.Read.All` as application and delegated permissions, `User.Read` delegated), its service principal, and tenant-wide admin consent; all writes go to the application object
    - Stamps the registration's internal notes with `napt/v1 spec=<n> version=<napt> provisioned=<date>`; admin notes below the stamp are preserved. `SPEC_VERSION` is bumped when NAPT's requirements change, and re-running reports and fixes drift
    - A name match without a stamp is reported and left untouched until `--adopt`; an explicit `--client-id` counts as consent. Nothing existing is ever removed
    - `--federated-issuer` / `--federated-subject` (+ `--federated-audience`, `--federated-name`) add an OIDC federated credential; values come from the CI platform's docs, so NAPT carries no platform-specific knowledge
    - `--print-only` prints the equivalent portal checklist with the exact values
    - Remembers the tenant and client ID so the next step is `napt auth login`
- Credential chain: service principal env vars → `napt auth login` session → Azure CLI session. `WorkloadIdentityCredential` removed (untestable here). The Azure CLI link accepts only app-only tokens; a CLI signed in as a person is refused so Intune activity is always attributed to the NAPT registration
- Docs: App Registration Setup (automatic path, adoption, stamp), OIDC setup scoped to a deployment environment using GitHub's immutable subject format, corrected `azure/login` explanation, device-code rationale moved out of the user guide, API page for `napt.upload.entra`

## Testing
- [x] Unit tests added/updated — 19 `entra` tests (create, idempotency, adopt, stamp, federated credential, replication retry), 8 CLI tests, 6 auth-chain tests; full suite 816 passing
- [ ] Integration tests added/updated — existing integration suite passes; no new network tests
- [x] Manual testing performed — live against the dev tenant: adopt warning on the portal-made registration, `--adopt` stamped it and added the federated credential, third run reported nothing to change; GitHub Actions job with `environment: intune` + `azure/login` ran `napt auth status` successfully (`Method: azure cli`) with a name-based subject, then again after migrating the repo to GitHub's immutable subject and removing the old credential

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors
