### PR TITLE
chore: Reformat with black

### DIFF
--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -189,9 +189,7 @@ def _configured_targets(
     for ring in deployment["rings"]:
         for group in ring["groups"]:
             try:
-                target = resolve_assignment_target(
-                    access_token, group, group_id_cache
-                )
+                target = resolve_assignment_target(access_token, group, group_id_cache)
             except ConfigError:
                 continue
             key = _target_key(target)
@@ -373,5 +371,3 @@ def detect_drift(
 
     findings.sort(key=lambda f: (f["app_id"], f["kind"], f["detail"]))
     return findings
-
-

--- a/napt/promote/reconcile.py
+++ b/napt/promote/reconcile.py
@@ -137,9 +137,7 @@ def reconcile_publications(
                 f"published: {'; '.join(problems)} - re-run publish to finish"
             )
             logger.warning("PROMOTE", f"{app_id}: {detail}")
-            findings.append(
-                {"app_id": app_id, "kind": "incomplete", "detail": detail}
-            )
+            findings.append({"app_id": app_id, "kind": "incomplete", "detail": detail})
             continue
 
         install_match = matches.get(ENTRY_INSTALL)

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -116,9 +116,7 @@ def _in_reading_order(
 
     """
     ordered = {key: mapping[key] for key in order if key in mapping}
-    ordered.update(
-        {key: value for key, value in mapping.items() if key not in ordered}
-    )
+    ordered.update({key: value for key, value in mapping.items() if key not in ordered})
     return ordered
 
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -417,8 +417,7 @@ def _action(app_id: str = "a") -> dict[str, Any]:
         "app_id": app_id,
         "name": f"App {app_id}",
         "summary": (
-            "Start rolling out 1.0: assign the update entry to the "
-            "pilot ring (g)."
+            "Start rolling out 1.0: assign the update entry to the pilot ring (g)."
         ),
         "type": "promote",
         "entry": "update",

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -763,9 +763,7 @@ class TestLoadPlanFile:
     def test_missing_app_id_raises(self, tmp_path):
         """Tests that a plan without a declared app id raises StateError."""
         plan_path = tmp_path / "plan.json"
-        plan_path.write_text(
-            '{"schemaVersion": 1, "actions": []}', encoding="utf-8"
-        )
+        plan_path.write_text('{"schemaVersion": 1, "actions": []}', encoding="utf-8")
 
         with pytest.raises(StateError, match="Corrupted plan file"):
             load_plan_file(plan_path)
@@ -794,9 +792,7 @@ class TestLoadPlanFile:
         """Tests that the file's app id and name are injected into actions."""
         plan_path = tmp_path / "plan.json"
         action = {
-            key: value
-            for key, value in _promote_action().items()
-            if key != "app_id"
+            key: value for key, value in _promote_action().items() if key != "app_id"
         }
         plan_path.write_text(
             json.dumps(

--- a/tests/test_promote_preflight.py
+++ b/tests/test_promote_preflight.py
@@ -76,9 +76,7 @@ class TestUnresolvableGroups:
 
     def test_actions_without_groups_are_skipped(self):
         """Tests that actions with no groups key produce no lookups."""
-        with patch(
-            "napt.promote.preflight.resolve_assignment_target"
-        ) as resolve_mock:
+        with patch("napt.promote.preflight.resolve_assignment_target") as resolve_mock:
             failures = unresolvable_groups(TOKEN, [{"type": "odd_action"}])
 
         assert failures == []

--- a/tests/test_promote_reconcile.py
+++ b/tests/test_promote_reconcile.py
@@ -69,9 +69,7 @@ class TestReconcilePublications:
             _stamped("test-app", "update", SHA, "update-1"),
         ]
 
-        with patch(
-            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
-        ):
+        with patch("napt.promote.reconcile.get_mobile_app", side_effect=_committed):
             findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
 
         assert [f["kind"] for f in findings] == ["recovered"]
@@ -90,9 +88,7 @@ class TestReconcilePublications:
         state_path = _write_pending(tmp_path)
         apps = [_stamped("test-app", "install", SHA, "install-1")]
 
-        with patch(
-            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
-        ):
+        with patch("napt.promote.reconcile.get_mobile_app", side_effect=_committed):
             findings = reconcile_publications(
                 TOKEN, _configs(build_types="app_only"), tmp_path, apps
             )
@@ -108,9 +104,7 @@ class TestReconcilePublications:
         state_path = _write_pending(tmp_path)
         apps = [_stamped("test-app", "update", SHA, "update-1")]
 
-        with patch(
-            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
-        ):
+        with patch("napt.promote.reconcile.get_mobile_app", side_effect=_committed):
             findings = reconcile_publications(
                 TOKEN, _configs(build_types="update_only"), tmp_path, apps
             )
@@ -126,9 +120,7 @@ class TestReconcilePublications:
         state_path = _write_pending(tmp_path)
         apps = [_stamped("test-app", "install", SHA, "install-1")]
 
-        with patch(
-            "napt.promote.reconcile.get_mobile_app", side_effect=_committed
-        ):
+        with patch("napt.promote.reconcile.get_mobile_app", side_effect=_committed):
             findings = reconcile_publications(TOKEN, _configs(), tmp_path, apps)
 
         assert [f["kind"] for f in findings] == ["incomplete"]
@@ -181,9 +173,7 @@ class TestReconcilePublications:
             "intune_app_id": "i",
             "intune_update_app_id": "u",
         }
-        save_deployment_state(
-            state, deployment_state_path(tmp_path, "test-app")
-        )
+        save_deployment_state(state, deployment_state_path(tmp_path, "test-app"))
         apps = [_stamped("test-app", "install", "a" * 64, "install-1")]
 
         with patch("napt.promote.reconcile.get_mobile_app") as get_mock:


### PR DESCRIPTION
## Description

Reformats seven files that had drifted from black's output, so that a clean `black napt/ tests/` run no longer touches unrelated files.

## Motivation

Every `/ship` run reformatted these files and the changes had to be reverted to keep feature PRs focused. Landing the reformat on its own removes that noise.

## Changes

- Rewrapped lines that fit within 88 chars in `napt/promote/drift.py`, `napt/promote/reconcile.py`, `napt/state/deployment.py`, and four `tests/test_promote*.py` files
- Dropped trailing blank lines in `napt/promote/drift.py`
- Merged the implicit string concatenation black produced in `tests/test_promote.py` into a single literal

No behavior changes.

## Testing

- `black --check napt/ tests/` clean
- `ruff check napt/ tests/` clean
- 801 unit tests pass

## Checklist

- [x] Formatting and lint pass
- [x] Tests pass
- [x] No changelog entry needed (no user-facing impact)