### PR TITLE
refactor: Move auth and Graph client into packages

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,0 +1,5 @@
+# auth
+
+::: napt.auth.credentials
+
+::: napt.auth.registration

--- a/docs/api/graph.md
+++ b/docs/api/graph.md
@@ -1,0 +1,5 @@
+# graph
+
+::: napt.graph.client
+
+::: napt.graph.intune

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,6 +18,10 @@ napt/
 ├── results.py               # Public API return types (dataclasses)
 ├── validation.py            # Recipe validation logic
 │
+├── auth/                    # Microsoft Entra ID authentication
+│   ├── credentials.py          # Token resolution and the napt auth login session
+│   └── registration.py         # App registration provisioning (napt auth setup)
+│
 ├── build/                   # PSADT package building
 │   ├── manager.py              # Package building orchestration
 │   ├── packager.py             # .intunewin package creation
@@ -36,6 +40,10 @@ napt/
 ├── download/                # HTTP file downloads
 │   └── download.py             # HTTP downloads with ETag support
 │
+├── graph/                   # Microsoft Graph client
+│   ├── client.py               # HTTP transport with retry and error mapping
+│   └── intune.py               # Win32 app upload, queries, and assignments
+│
 ├── psadt/                   # PSADT release management
 │   └── release.py              # PSADT release download and caching
 │
@@ -45,9 +53,8 @@ napt/
 │
 ├── upload/                  # Intune upload pipeline
 │   ├── manager.py              # Upload orchestration
-│   ├── graph.py                # Graph API and Azure Blob Storage calls
-│   ├── auth.py                 # Azure credential chain (env, managed identity, CLI, device code)
-│   └── intunewin.py            # .intunewin package parser
+│   ├── intunewin.py            # .intunewin package parser
+│   └── stamp.py                # Provenance stamp in the Intune app's notes
 │
 └── versioning/              # Version extraction and comparison
     ├── keys.py                 # Version key extraction (DiscoveredVersion)
@@ -112,6 +119,8 @@ Result (dataclass)
 - [Discovery API](discovery.md) - Discovery strategy implementations
 - [Build API](build.md) - Package building functions
 - [Upload API](upload.md) - Intune upload pipeline
+- [Auth API](auth.md) - Entra ID sign-in and app registration
+- [Graph API](graph.md) - Microsoft Graph transport and Intune calls
 - [Config API](config.md) - Configuration loading
 - [Exceptions API](exceptions.md) - Exception hierarchy
 

--- a/docs/api/upload.md
+++ b/docs/api/upload.md
@@ -4,8 +4,4 @@
 
 ::: napt.upload.intunewin
 
-::: napt.upload.auth
-
-::: napt.upload.entra
-
-::: napt.upload.graph
+::: napt.upload.stamp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
     - logging: api/logging.md
     - results: api/results.md
     - validation: api/validation.md
+    - auth: api/auth.md
     - build:
       - manager: api/build.md
       - template: api/template.md
@@ -97,6 +98,7 @@ nav:
       - discovery: api/discovery.md
       - manager: api/core.md
     - download: api/download.md
+    - graph: api/graph.md
     - psadt: api/psadt.md
     - state: api/state.md
     - upload: api/upload.md

--- a/napt/auth/__init__.py
+++ b/napt/auth/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Microsoft Entra ID authentication for NAPT.
+
+Backs the `napt auth` command group and supplies the Graph access token
+every Intune-facing command uses. Authentication needs no configuration
+file:
+
+- Developers: run `napt auth login` once (browser or OS broker); later
+    commands use the cached session silently.
+- CI/CD: set AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
+    (EnvironmentCredential), or sign in with an OIDC login step such as
+    GitHub Actions `azure/login` (AzureCliCredential).
+
+Modules:
+    credentials - Token resolution, the interactive session store, and
+        the `napt auth login/logout/status` operations.
+    registration - App registration provisioning for `napt auth setup`.
+"""

--- a/napt/auth/credentials.py
+++ b/napt/auth/credentials.py
@@ -16,7 +16,7 @@
 
 Every command that talks to Intune (`napt upload`, `napt promote apply`,
 `napt promote plan --reconcile/--check-drift`) calls
-[get_access_token][napt.upload.auth.get_access_token] once. The token comes
+[get_access_token][napt.auth.credentials.get_access_token] once. The token comes
 from the first source that works:
 
 Non-interactive (CI/CD):
@@ -58,7 +58,7 @@ use). See the authentication documentation for setup instructions.
 Example:
     Acquiring a token for Graph API:
         ```python
-        from napt.upload.auth import get_access_token
+        from napt.auth.credentials import get_access_token
 
         token = get_access_token()
         headers = {"Authorization": f"Bearer {token}"}
@@ -87,10 +87,12 @@ import requests
 from napt.exceptions import AuthError, ConfigError
 
 __all__ = [
+    "AUTHORITY_BASE",
     "AuthConfig",
     "AuthStatus",
     "AuthStore",
     "GRAPH_SCOPES",
+    "LOGIN_TIMEOUT",
     "REQUIRED_PERMISSIONS",
     "get_access_token",
     "get_credential",
@@ -99,6 +101,8 @@ __all__ = [
     "load_auth_store",
     "login",
     "logout",
+    "msal_error",
+    "remember_tenant",
     "resolve_auth_config",
 ]
 
@@ -113,13 +117,13 @@ logging.getLogger("azure.identity").setLevel(logging.ERROR)
 # (service principal, Azure CLI session) or delegated permissions (interactive).
 REQUIRED_PERMISSIONS = ("DeviceManagementApps.ReadWrite.All", "Group.Read.All")
 
-_AUTHORITY_BASE = "https://login.microsoftonline.com"
+AUTHORITY_BASE = "https://login.microsoftonline.com"
 _GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 _AUTH_CONFIG_FILENAME = "auth.json"
 _TOKEN_CACHE_FILENAME = "token_cache.bin"
 
 # Seconds `napt auth login` waits for the browser round-trip before giving up.
-_LOGIN_TIMEOUT = 300
+LOGIN_TIMEOUT = 300
 
 _HINT_NOT_LOGGED_IN = (
     "Not authenticated.\n\n"
@@ -532,13 +536,22 @@ def _build_public_client(
 ) -> msal.PublicClientApplication:
     return msal.PublicClientApplication(
         config.client_id,
-        authority=f"{_AUTHORITY_BASE}/{config.tenant_id}",
+        authority=f"{AUTHORITY_BASE}/{config.tenant_id}",
         token_cache=_build_token_cache(),
         enable_broker_on_windows=use_broker,
     )
 
 
-def _msal_error(result: dict[str, Any]) -> str:
+def msal_error(result: dict[str, Any]) -> str:
+    """Summarizes a failed MSAL token result as ``code: first line``.
+
+    Args:
+        result: The dict MSAL returns when no access token was issued.
+
+    Returns:
+        The error code followed by the first line of its description.
+
+    """
     code = result.get("error", "unknown_error")
     description = str(result.get("error_description", "")).splitlines()
     return f"{code}: {description[0]}" if description else str(code)
@@ -560,7 +573,7 @@ def _acquire_silent(config: AuthConfig, *, use_broker: bool) -> str | None:
         return None
     result = app.acquire_token_silent_with_error(GRAPH_SCOPES, account=accounts[0])
     if not result or "access_token" not in result:
-        detail = _msal_error(result) if result else "no token"
+        detail = msal_error(result) if result else "no token"
         raise AuthError(f"{_HINT_SESSION_EXPIRED}Details: {detail}")
     return result["access_token"]
 
@@ -577,8 +590,17 @@ def _interactive_method(broker: bool) -> str:
     return "interactive (broker)" if broker else "interactive (browser)"
 
 
-def _remember(config: AuthConfig) -> Path:
-    """Records ``config`` as the active tenant and returns the file path."""
+def remember_tenant(config: AuthConfig) -> Path:
+    """Records ``config`` in the auth store as the active tenant.
+
+    Args:
+        config: Tenant and client settings to store; replaces any entry
+            for the same tenant.
+
+    Returns:
+        Path of the auth store file that was written.
+
+    """
     store = load_auth_store()
     store.tenants[config.tenant_id] = config
     store.active = config.tenant_id
@@ -677,7 +699,7 @@ def login(
         logger.verbose("AUTH", f"Cached session unusable, signing in again: {err}")
         cached = None
     if cached is not None:
-        _remember(_with_tenant_label(config, cached))
+        remember_tenant(_with_tenant_label(config, cached))
         logger.info(
             "AUTH",
             f"Reusing signed-in session for {config.username} "
@@ -702,7 +724,7 @@ def login(
         result = app.acquire_token_interactive(
             GRAPH_SCOPES,
             prompt="select_account",
-            timeout=_LOGIN_TIMEOUT,
+            timeout=LOGIN_TIMEOUT,
             parent_window_handle=(
                 msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE if broker else None
             ),
@@ -713,7 +735,7 @@ def login(
 
     if "access_token" not in result:
         logger.debug("AUTH", f"MSAL interactive response: {result}")
-        detail = _msal_error(result)
+        detail = msal_error(result)
         if result.get("correlation_id"):
             detail += f" (correlation_id {result['correlation_id']})"
         # _broker_status is a pymsalruntime enum; compare by name.
@@ -734,7 +756,7 @@ def login(
         tenant_id=config.tenant_id,
         username=username,
     )
-    saved_to = _remember(_with_tenant_label(signed_in, result["access_token"]))
+    saved_to = remember_tenant(_with_tenant_label(signed_in, result["access_token"]))
     logger.verbose("AUTH", f"Saved sign-in settings to {saved_to}")
     return status
 
@@ -790,7 +812,7 @@ def logout(*, all_tenants: bool = False) -> list[str]:
 def get_status() -> AuthStatus | None:
     """Reports which credential NAPT would use right now, or ``None``.
 
-    Resolves a token exactly as [get_access_token][napt.upload.auth.get_access_token]
+    Resolves a token exactly as [get_access_token][napt.auth.credentials.get_access_token]
     does -- so the answer reflects what `napt upload` will do -- and
     decodes it for display.
 
@@ -825,7 +847,7 @@ def get_access_token() -> str:
     """Acquires a Microsoft Graph access token.
 
     Tries the non-interactive chain from
-    [get_credential][napt.upload.auth.get_credential] first, then the session
+    [get_credential][napt.auth.credentials.get_credential] first, then the session
     saved by `napt auth login`, then an existing Azure CLI (`az login`)
     session. Never opens a browser: an interactive user who has not logged
     in is told to run `napt auth login`.
@@ -840,7 +862,7 @@ def get_access_token() -> str:
     Example:
         Get a token and use it in a request:
             ```python
-            from napt.upload.auth import get_access_token
+            from napt.auth.credentials import get_access_token
 
             token = get_access_token()
             headers = {"Authorization": f"Bearer {token}"}

--- a/napt/auth/registration.py
+++ b/napt/auth/registration.py
@@ -15,7 +15,7 @@
 """Entra ID app registration provisioning for `napt auth setup`.
 
 Creates -- or brings up to spec -- the app registration that
-[napt.upload.auth][] signs in with, so an administrator never has to click
+[napt.auth.credentials][] signs in with, so an administrator never has to click
 through the portal:
 
 - The application object with `http://localhost` and the Windows broker
@@ -53,16 +53,16 @@ import time
 import msal
 
 from napt import __version__
-from napt.exceptions import AuthError, ConfigError, NetworkError
-from napt.upload.auth import (
-    _AUTHORITY_BASE,
-    _LOGIN_TIMEOUT,
+from napt.auth.credentials import (
+    AUTHORITY_BASE,
+    LOGIN_TIMEOUT,
     AuthConfig,
-    _msal_error,
-    _remember,
     load_auth_store,
+    msal_error,
+    remember_tenant,
 )
-from napt.upload.graph import _graph_request, _json_headers
+from napt.exceptions import AuthError, ConfigError, NetworkError
+from napt.graph.client import graph_request, json_headers
 
 __all__ = [
     "BROKER_REDIRECT_TEMPLATE",
@@ -264,17 +264,17 @@ def _bootstrap_token(tenant_id: str) -> str:
     """
     app = msal.PublicClientApplication(
         _GRAPH_CLI_TOOLS_CLIENT_ID,
-        authority=f"{_AUTHORITY_BASE}/{tenant_id}",
+        authority=f"{AUTHORITY_BASE}/{tenant_id}",
     )
     print("Opening your browser to sign in as an administrator...")
     try:
         result = app.acquire_token_interactive(
-            _BOOTSTRAP_SCOPES, prompt="select_account", timeout=_LOGIN_TIMEOUT
+            _BOOTSTRAP_SCOPES, prompt="select_account", timeout=LOGIN_TIMEOUT
         )
     except Exception as err:  # MSAL surfaces transport failures as raw errors
         raise AuthError(f"{_HINT_BOOTSTRAP_FAILED}Details: {err}") from err
     if "access_token" not in result:
-        raise AuthError(f"{_HINT_BOOTSTRAP_FAILED}Details: {_msal_error(result)}")
+        raise AuthError(f"{_HINT_BOOTSTRAP_FAILED}Details: {msal_error(result)}")
     return result["access_token"]
 
 
@@ -284,22 +284,22 @@ def _bootstrap_token(tenant_id: str) -> str:
 
 
 def _get(token: str, path: str, context: str) -> dict:
-    return _graph_request("GET", f"{_GRAPH_V1}{path}", context, _json_headers(token))
+    return graph_request("GET", f"{_GRAPH_V1}{path}", context, json_headers(token))
 
 
 def _post(token: str, path: str, body: dict, context: str) -> dict:
-    return _graph_request(
+    return graph_request(
         "POST",
         f"{_GRAPH_V1}{path}",
         context,
-        _json_headers(token),
+        json_headers(token),
         json=body,
         idempotent=False,
     )
 
 
 def _patch(token: str, path: str, body: dict, context: str) -> None:
-    _graph_request("PATCH", f"{_GRAPH_V1}{path}", context, _json_headers(token), body)
+    graph_request("PATCH", f"{_GRAPH_V1}{path}", context, json_headers(token), body)
 
 
 def _post_after_replication(token: str, path: str, body: dict, context: str) -> dict:
@@ -678,7 +678,7 @@ def setup_app_registration(spec: SetupSpec) -> SetupResult:
     Example:
         Provision a tenant and trust a CI workflow through OIDC:
             ```python
-            from napt.upload.entra import SetupSpec, setup_app_registration
+            from napt.auth.registration import SetupSpec, setup_app_registration
 
             result = setup_app_registration(
                 SetupSpec(
@@ -716,8 +716,10 @@ def setup_app_registration(spec: SetupSpec) -> SetupResult:
     # Keep an existing session for this tenant when the client ID is unchanged.
     known = load_auth_store().tenants.get(spec.tenant_id)
     if known is not None and known.client_id == result.client_id:
-        _remember(known)
+        remember_tenant(known)
     else:
-        _remember(AuthConfig(client_id=result.client_id, tenant_id=spec.tenant_id))
+        remember_tenant(
+            AuthConfig(client_id=result.client_id, tenant_id=spec.tenant_id)
+        )
     logger.verbose("AUTH", "Saved tenant and client ID for 'napt auth login'")
     return result

--- a/napt/cli.py
+++ b/napt/cli.py
@@ -87,6 +87,24 @@ from pathlib import Path
 import sys
 from typing import Any
 
+from napt.auth.credentials import (
+    AuthStatus,
+    get_access_token,
+    get_status as auth_status,
+    load_auth_store,
+    login as auth_login,
+    logout as auth_logout,
+)
+from napt.auth.registration import (
+    APPLICATION_PERMISSIONS,
+    BROKER_REDIRECT_TEMPLATE,
+    DELEGATED_PERMISSIONS,
+    FEDERATED_AUDIENCE_DEFAULT,
+    LOCALHOST_REDIRECT,
+    SPEC_VERSION,
+    SetupSpec,
+    setup_app_registration,
+)
 from napt.build import build_package, create_intunewin
 from napt.config import load_effective_config
 from napt.config.defaults import ORG_YAML_TEMPLATE
@@ -99,6 +117,7 @@ from napt.exceptions import (
     PackagingError,
     StateError,
 )
+from napt.graph.intune import list_mobile_apps
 from napt.logging import get_logger, set_global_logger
 from napt.promote import (
     apply_plan,
@@ -113,25 +132,6 @@ from napt.promote import (
 )
 from napt.state import summarize_deployment_states
 from napt.upload import upload_package
-from napt.upload.auth import (
-    AuthStatus,
-    get_access_token,
-    get_status as auth_status,
-    load_auth_store,
-    login as auth_login,
-    logout as auth_logout,
-)
-from napt.upload.entra import (
-    APPLICATION_PERMISSIONS,
-    BROKER_REDIRECT_TEMPLATE,
-    DELEGATED_PERMISSIONS,
-    FEDERATED_AUDIENCE_DEFAULT,
-    LOCALHOST_REDIRECT,
-    SPEC_VERSION,
-    SetupSpec,
-    setup_app_registration,
-)
-from napt.upload.graph import list_mobile_apps
 from napt.validation import validate_recipe
 
 

--- a/napt/graph/__init__.py
+++ b/napt/graph/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Microsoft Graph client for NAPT.
+
+Shared by every stage that talks to Intune or Entra ID: `napt upload`,
+`napt promote`, and `napt auth setup`.
+
+Modules:
+    client - HTTP transport with retry, throttling, and error mapping.
+    intune - Win32 app upload, app queries, and assignment calls.
+"""

--- a/napt/graph/client.py
+++ b/napt/graph/client.py
@@ -1,0 +1,280 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Microsoft Graph HTTP transport shared by every Graph caller in NAPT.
+
+Provides [graph_request][napt.graph.client.graph_request], the single
+function through which Intune app management, assignment, and app
+registration calls reach Graph, along with the header builders callers
+pass to it. Endpoint-specific wrappers live in
+[napt.graph.intune][] and [napt.auth.registration][].
+
+Graph calls retry transient failures -- HTTP 429 (honoring Retry-After),
+transient server errors, and connection drops -- with bounded exponential
+backoff before raising. Resource-creating POSTs retry only unambiguous
+throttling responses, so a lost reply to a processed create is never
+resubmitted as a duplicate.
+
+Example:
+    Reading a resource:
+        ```python
+        from napt.auth.credentials import get_access_token
+        from napt.graph.client import GRAPH_BASE, auth_headers, graph_request
+
+        token = get_access_token()
+        app = graph_request(
+            "GET",
+            f"{GRAPH_BASE}/deviceAppManagement/mobileApps/<id>",
+            "get app",
+            headers=auth_headers(token),
+        )
+        ```
+
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import requests
+
+from napt.exceptions import AuthError, ConfigError, NetworkError
+
+__all__ = [
+    "GRAPH_BASE",
+    "auth_headers",
+    "graph_request",
+    "json_headers",
+]
+
+# The Intune app management API (mobileApps, Win32LobApp) has never fully
+# graduated to v1.0. Fields critical to Win32 app uploads — allowedArchitectures,
+# maxRunTimeInMinutes, displayVersion, allowAvailableUninstall — are beta-only.
+# The Intune portal, Intune PowerShell SDK, and Microsoft's own tooling all use
+# the beta endpoint. Do not change this to v1.0.
+GRAPH_BASE = "https://graph.microsoft.com/beta"
+
+
+def auth_headers(access_token: str) -> dict[str, str]:
+    """Returns the Authorization header for a bodiless Graph request.
+
+    Args:
+        access_token: Bearer token for Graph API.
+
+    Returns:
+        Headers carrying the bearer token.
+
+    """
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def json_headers(access_token: str) -> dict[str, str]:
+    """Returns the headers for a Graph request with a JSON body.
+
+    Args:
+        access_token: Bearer token for Graph API.
+
+    Returns:
+        Headers carrying the bearer token and a JSON content type.
+
+    """
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _check_response(response: requests.Response, context: str) -> dict:
+    """Checks an HTTP response and raises the appropriate NAPT exception.
+
+    Args:
+        response: The HTTP response to check.
+        context: Short description of the operation for error messages.
+
+    Returns:
+        Parsed JSON body as a dict, or empty dict for 204 responses.
+
+    Raises:
+        AuthError: On 401 or 403.
+        ConfigError: On 400 (bad request — likely a metadata problem).
+        NetworkError: On 5xx or any other non-2xx status.
+
+    """
+    if response.status_code in (401, 403):
+        raise AuthError(
+            f"{context}: HTTP {response.status_code} — "
+            f"check that the authenticated account has Intune device "
+            f"administrator or app manager permissions.\n{response.text}"
+        )
+    if response.status_code == 400:
+        raise ConfigError(
+            f"{context}: HTTP 400 Bad Request — the app metadata may be "
+            f"invalid.\n{response.text}"
+        )
+    if response.status_code >= 500:
+        raise NetworkError(
+            f"{context}: HTTP {response.status_code} — Graph API server error."
+            f"\n{response.text}"
+        )
+    if not response.ok:
+        raise NetworkError(f"{context}: HTTP {response.status_code}\n{response.text}")
+    if response.status_code == 204 or not response.text:
+        return {}
+    return response.json()
+
+
+# Microsoft Graph throttles the Intune endpoints (HTTP 429 with a
+# Retry-After header, per app per tenant) and sheds load with transient
+# server errors. Most Graph calls NAPT makes are idempotent — reads,
+# full-set assignment writes, PATCHes and DELETEs by id — and retry the
+# full transient set. Resource-creating POSTs are not: a connection
+# drop or gateway error (500/502/504) can hide a create that actually
+# succeeded, and resubmitting would duplicate the resource, so they
+# retry only responses that guarantee the request was shed before
+# processing (429/503/509 per the Graph error contract). A surfaced
+# ambiguous failure converges on re-run through the upload flow's
+# provenance-stamp adoption.
+_GRAPH_RETRY_STATUS = (429, 500, 502, 503, 504, 509)
+_GRAPH_RETRY_STATUS_UNAMBIGUOUS = (429, 503, 509)
+_GRAPH_RETRY_ATTEMPTS = 5
+_GRAPH_RETRY_INITIAL_DELAY = 2.0
+# Ceiling for a wait taken from Retry-After; anything longer is served
+# by the normal failure path rather than a stalled run.
+_GRAPH_RETRY_MAX_WAIT = 300.0
+
+
+def _retry_wait(response: requests.Response | None, fallback: float) -> float:
+    """Returns the wait before the next retry attempt.
+
+    Honors a numeric ``Retry-After`` header when the response carries one
+    (Graph throttling responses do), capped at a ceiling; otherwise the
+    exponential-backoff fallback applies.
+
+    Args:
+        response: The throttled or failed response, or None for a
+            connection-level failure.
+        fallback: Current exponential backoff delay in seconds.
+
+    Returns:
+        Seconds to wait before the next attempt.
+
+    """
+    if response is not None:
+        retry_after = response.headers.get("Retry-After", "")
+        if retry_after.strip().isdigit():
+            return min(float(retry_after), _GRAPH_RETRY_MAX_WAIT)
+    return fallback
+
+
+def graph_request(
+    method: str,
+    url: str,
+    context: str,
+    headers: dict[str, str],
+    json: dict | None = None,
+    ok_statuses: tuple[int, ...] = (),
+    idempotent: bool = True,
+    deadline: float | None = None,
+) -> dict:
+    """Issues a Graph API request, retrying transient failures.
+
+    HTTP 429 (honoring ``Retry-After``) and transient server errors
+    retry with exponential backoff, as do connection-level failures.
+    Non-idempotent calls (resource-creating POSTs) retry only statuses
+    that guarantee the request was shed before processing, and never
+    connection failures — a lost reply to a processed create must not
+    be resubmitted. Every other response is checked immediately, so
+    permission and validation errors surface without retrying. The last
+    attempt's failure is raised with full response detail. Each request
+    carries a fresh ``client-request-id`` header for Microsoft support
+    correlation.
+
+    Args:
+        method: HTTP method name.
+        url: Full request URL.
+        context: Short description of the operation for error messages.
+        headers: Request headers, including authorization.
+        json: Optional JSON body.
+        ok_statuses: Statuses to treat as success with an empty body
+            (e.g. 404 for an idempotent delete).
+        idempotent: Whether resubmitting this request is always safe.
+            False restricts retries to unambiguous throttling responses.
+        deadline: Optional ``time.monotonic()`` budget; a retry wait
+            that would run past it surfaces the failure instead.
+
+    Returns:
+        Parsed JSON body as a dict, or empty dict for empty responses
+        and ``ok_statuses`` matches.
+
+    Raises:
+        AuthError: On 401 or 403.
+        ConfigError: On 400.
+        NetworkError: On any other non-2xx status once retries are
+            exhausted, or on a connection failure.
+
+    """
+    from napt.logging import get_global_logger
+
+    logger = get_global_logger()
+    retry_statuses = (
+        _GRAPH_RETRY_STATUS if idempotent else _GRAPH_RETRY_STATUS_UNAMBIGUOUS
+    )
+    delay = _GRAPH_RETRY_INITIAL_DELAY
+    for attempt in range(1, _GRAPH_RETRY_ATTEMPTS + 1):
+        err: Exception | None = None
+        resp: requests.Response | None = None
+        request_headers = {**headers, "client-request-id": str(uuid.uuid4())}
+        try:
+            resp = requests.request(
+                method, url, headers=request_headers, json=json, timeout=30
+            )
+        except requests.RequestException as exc:
+            if not idempotent:
+                # The request may have been processed before the
+                # connection died; resubmitting could duplicate the
+                # resource. Surface it — re-running converges through
+                # the flow-level stamp adoption.
+                raise NetworkError(f"{context}: {exc}") from exc
+            err = exc
+            detail = str(exc)
+        else:
+            if resp.status_code in ok_statuses:
+                return {}
+            if resp.status_code not in retry_statuses:
+                return _check_response(resp, context)
+            detail = f"HTTP {resp.status_code}"
+
+        if attempt == _GRAPH_RETRY_ATTEMPTS:
+            if resp is not None:
+                return _check_response(resp, context)
+            raise NetworkError(
+                f"{context} after {_GRAPH_RETRY_ATTEMPTS} attempts: {detail}"
+            ) from err
+
+        wait = _retry_wait(resp, delay)
+        if deadline is not None and time.monotonic() + wait >= deadline:
+            # No budget left for another attempt; surface this failure.
+            if resp is not None:
+                return _check_response(resp, context)
+            raise NetworkError(f"{context}: {detail}") from err
+        logger.warning(
+            "HTTP",
+            f"{context}: transient failure ({detail}); retrying in "
+            f"{wait:.0f}s (attempt {attempt}/{_GRAPH_RETRY_ATTEMPTS})",
+        )
+        time.sleep(wait)
+        delay *= 2
+
+    raise NetworkError(f"{context}: retry attempts exhausted")  # pragma: no cover

--- a/napt/graph/intune.py
+++ b/napt/graph/intune.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Microsoft Graph API and Azure Blob Storage client for Intune Win32 app upload.
+"""Intune app management calls: Win32 app upload, queries, and assignments.
 
 Implements the full upload flow for a Win32 LOB app:
 
@@ -29,21 +29,17 @@ get_mobile_app, update_win32_app) and group-based assignment plumbing
 assign_app) used by deployment promotion.
 
 All functions take an access_token as the first argument. Obtain one via
-napt.upload.auth.get_access_token().
-
-Graph calls retry transient failures — HTTP 429 (honoring Retry-After),
-transient server errors, and connection drops — with bounded exponential
-backoff before raising. Resource-creating POSTs retry only unambiguous
-throttling responses, so a lost reply to a processed create is never
-resubmitted as a duplicate. Azure Blob PUTs carry their own retry tuned
-for SAS-propagation 403s.
+[get_access_token][napt.auth.credentials.get_access_token]. Graph calls go
+through [graph_request][napt.graph.client.graph_request] and inherit its
+retry behavior; Azure Blob PUTs carry their own retry tuned for
+SAS-propagation 403s.
 
 Example:
     Full upload flow:
         ```python
         from pathlib import Path
-        from napt.upload.auth import get_access_token
-        from napt.upload.graph import (
+        from napt.auth.credentials import get_access_token
+        from napt.graph.intune import (
             create_win32_app, create_content_version,
             create_content_version_file, upload_to_azure_blob,
             commit_content_version_file, commit_content_version,
@@ -68,11 +64,11 @@ import base64
 from pathlib import Path
 import re
 import time
-import uuid
 
 import requests
 
-from napt.exceptions import AuthError, ConfigError, NetworkError
+from napt.exceptions import ConfigError, NetworkError
+from napt.graph.client import GRAPH_BASE, auth_headers, graph_request, json_headers
 from napt.upload.intunewin import IntunewinMetadata
 
 __all__ = [
@@ -95,12 +91,6 @@ __all__ = [
     "commit_content_version",
 ]
 
-# The Intune app management API (mobileApps, Win32LobApp) has never fully
-# graduated to v1.0. Fields critical to Win32 app uploads — allowedArchitectures,
-# maxRunTimeInMinutes, displayVersion, allowAvailableUninstall — are beta-only.
-# The Intune portal, Intune PowerShell SDK, and Microsoft's own tooling all use
-# the beta endpoint. Do not change this to v1.0.
-GRAPH_BASE = "https://graph.microsoft.com/beta"
 WIN32_LOB_APP_TYPE = "#microsoft.graph.win32LobApp"
 
 # Azure Block Blob: minimum recommended chunk size is 4 MiB; 6 MiB is a
@@ -109,202 +99,6 @@ CHUNK_SIZE = 6 * 1024 * 1024  # 6 MiB
 
 POLL_INTERVAL_SECONDS = 2
 POLL_MAX_SECONDS = 120
-
-
-def _auth_headers(access_token: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {access_token}"}
-
-
-def _json_headers(access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {access_token}",
-        "Content-Type": "application/json",
-    }
-
-
-def _check_response(response: requests.Response, context: str) -> dict:
-    """Checks an HTTP response and raises the appropriate NAPT exception.
-
-    Args:
-        response: The HTTP response to check.
-        context: Short description of the operation for error messages.
-
-    Returns:
-        Parsed JSON body as a dict, or empty dict for 204 responses.
-
-    Raises:
-        AuthError: On 401 or 403.
-        ConfigError: On 400 (bad request — likely a metadata problem).
-        NetworkError: On 5xx or any other non-2xx status.
-
-    """
-    if response.status_code in (401, 403):
-        raise AuthError(
-            f"{context}: HTTP {response.status_code} — "
-            f"check that the authenticated account has Intune device "
-            f"administrator or app manager permissions.\n{response.text}"
-        )
-    if response.status_code == 400:
-        raise ConfigError(
-            f"{context}: HTTP 400 Bad Request — the app metadata may be "
-            f"invalid.\n{response.text}"
-        )
-    if response.status_code >= 500:
-        raise NetworkError(
-            f"{context}: HTTP {response.status_code} — Graph API server error."
-            f"\n{response.text}"
-        )
-    if not response.ok:
-        raise NetworkError(f"{context}: HTTP {response.status_code}\n{response.text}")
-    if response.status_code == 204 or not response.text:
-        return {}
-    return response.json()
-
-
-# Microsoft Graph throttles the Intune endpoints (HTTP 429 with a
-# Retry-After header, per app per tenant) and sheds load with transient
-# server errors. Most Graph calls NAPT makes are idempotent — reads,
-# full-set assignment writes, PATCHes and DELETEs by id — and retry the
-# full transient set. Resource-creating POSTs are not: a connection
-# drop or gateway error (500/502/504) can hide a create that actually
-# succeeded, and resubmitting would duplicate the resource, so they
-# retry only responses that guarantee the request was shed before
-# processing (429/503/509 per the Graph error contract). A surfaced
-# ambiguous failure converges on re-run through the upload flow's
-# provenance-stamp adoption.
-_GRAPH_RETRY_STATUS = (429, 500, 502, 503, 504, 509)
-_GRAPH_RETRY_STATUS_UNAMBIGUOUS = (429, 503, 509)
-_GRAPH_RETRY_ATTEMPTS = 5
-_GRAPH_RETRY_INITIAL_DELAY = 2.0
-# Ceiling for a wait taken from Retry-After; anything longer is served
-# by the normal failure path rather than a stalled run.
-_GRAPH_RETRY_MAX_WAIT = 300.0
-
-
-def _retry_wait(response: requests.Response | None, fallback: float) -> float:
-    """Returns the wait before the next retry attempt.
-
-    Honors a numeric ``Retry-After`` header when the response carries one
-    (Graph throttling responses do), capped at a ceiling; otherwise the
-    exponential-backoff fallback applies.
-
-    Args:
-        response: The throttled or failed response, or None for a
-            connection-level failure.
-        fallback: Current exponential backoff delay in seconds.
-
-    Returns:
-        Seconds to wait before the next attempt.
-
-    """
-    if response is not None:
-        retry_after = response.headers.get("Retry-After", "")
-        if retry_after.strip().isdigit():
-            return min(float(retry_after), _GRAPH_RETRY_MAX_WAIT)
-    return fallback
-
-
-def _graph_request(
-    method: str,
-    url: str,
-    context: str,
-    headers: dict[str, str],
-    json: dict | None = None,
-    ok_statuses: tuple[int, ...] = (),
-    idempotent: bool = True,
-    deadline: float | None = None,
-) -> dict:
-    """Issues a Graph API request, retrying transient failures.
-
-    HTTP 429 (honoring ``Retry-After``) and transient server errors
-    retry with exponential backoff, as do connection-level failures.
-    Non-idempotent calls (resource-creating POSTs) retry only statuses
-    that guarantee the request was shed before processing, and never
-    connection failures — a lost reply to a processed create must not
-    be resubmitted. Every other response goes straight to
-    [_check_response][napt.upload.graph._check_response], so
-    permission and validation errors surface immediately. The last
-    attempt's failure is raised with full response detail. Each request
-    carries a fresh ``client-request-id`` header for Microsoft support
-    correlation.
-
-    Args:
-        method: HTTP method name.
-        url: Full request URL.
-        context: Short description of the operation for error messages.
-        headers: Request headers, including authorization.
-        json: Optional JSON body.
-        ok_statuses: Statuses to treat as success with an empty body
-            (e.g. 404 for an idempotent delete).
-        idempotent: Whether resubmitting this request is always safe.
-            False restricts retries to unambiguous throttling responses.
-        deadline: Optional ``time.monotonic()`` budget; a retry wait
-            that would run past it surfaces the failure instead.
-
-    Returns:
-        Parsed JSON body as a dict, or empty dict for empty responses
-        and ``ok_statuses`` matches.
-
-    Raises:
-        AuthError: On 401 or 403.
-        ConfigError: On 400.
-        NetworkError: On any other non-2xx status once retries are
-            exhausted, or on a connection failure.
-
-    """
-    from napt.logging import get_global_logger
-
-    logger = get_global_logger()
-    retry_statuses = (
-        _GRAPH_RETRY_STATUS if idempotent else _GRAPH_RETRY_STATUS_UNAMBIGUOUS
-    )
-    delay = _GRAPH_RETRY_INITIAL_DELAY
-    for attempt in range(1, _GRAPH_RETRY_ATTEMPTS + 1):
-        err: Exception | None = None
-        resp: requests.Response | None = None
-        request_headers = {**headers, "client-request-id": str(uuid.uuid4())}
-        try:
-            resp = requests.request(
-                method, url, headers=request_headers, json=json, timeout=30
-            )
-        except requests.RequestException as exc:
-            if not idempotent:
-                # The request may have been processed before the
-                # connection died; resubmitting could duplicate the
-                # resource. Surface it — re-running converges through
-                # the flow-level stamp adoption.
-                raise NetworkError(f"{context}: {exc}") from exc
-            err = exc
-            detail = str(exc)
-        else:
-            if resp.status_code in ok_statuses:
-                return {}
-            if resp.status_code not in retry_statuses:
-                return _check_response(resp, context)
-            detail = f"HTTP {resp.status_code}"
-
-        if attempt == _GRAPH_RETRY_ATTEMPTS:
-            if resp is not None:
-                return _check_response(resp, context)
-            raise NetworkError(
-                f"{context} after {_GRAPH_RETRY_ATTEMPTS} attempts: {detail}"
-            ) from err
-
-        wait = _retry_wait(resp, delay)
-        if deadline is not None and time.monotonic() + wait >= deadline:
-            # No budget left for another attempt; surface this failure.
-            if resp is not None:
-                return _check_response(resp, context)
-            raise NetworkError(f"{context}: {detail}") from err
-        logger.warning(
-            "HTTP",
-            f"{context}: transient failure ({detail}); retrying in "
-            f"{wait:.0f}s (attempt {attempt}/{_GRAPH_RETRY_ATTEMPTS})",
-        )
-        time.sleep(wait)
-        delay *= 2
-
-    raise NetworkError(f"{context}: retry attempts exhausted")  # pragma: no cover
 
 
 def _poll(
@@ -333,11 +127,11 @@ def _poll(
     """
     deadline = time.monotonic() + POLL_MAX_SECONDS
     while time.monotonic() < deadline:
-        data = _graph_request(
+        data = graph_request(
             "GET",
             poll_url,
             context,
-            headers=_auth_headers(access_token),
+            headers=auth_headers(access_token),
             deadline=deadline,
         )
         state: str = data.get("uploadState", "")
@@ -388,8 +182,8 @@ def resolve_group_id(access_token: str, group: str) -> str:
         f"{GRAPH_BASE}/groups"
         f"?$filter=displayName eq '{escaped}'&$select=id,displayName"
     )
-    body = _graph_request(
-        "GET", url, "resolve_group_id", headers=_auth_headers(access_token)
+    body = graph_request(
+        "GET", url, "resolve_group_id", headers=auth_headers(access_token)
     )
     matches: list[dict] = body.get("value", [])
 
@@ -461,8 +255,8 @@ def get_app_assignments(access_token: str, app_id: str) -> list[dict]:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}/assignments"
-    body = _graph_request(
-        "GET", url, "get_app_assignments", headers=_auth_headers(access_token)
+    body = graph_request(
+        "GET", url, "get_app_assignments", headers=auth_headers(access_token)
     )
     return body.get("value", [])
 
@@ -534,8 +328,8 @@ def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}/assign"
     body = {"mobileAppAssignments": assignments}
-    _graph_request(
-        "POST", url, "assign_app", headers=_json_headers(access_token), json=body
+    graph_request(
+        "POST", url, "assign_app", headers=json_headers(access_token), json=body
     )
 
 
@@ -557,12 +351,12 @@ def list_mobile_apps(access_token: str) -> list[dict]:
 
     """
     url: str | None = (
-        f"{GRAPH_BASE}/deviceAppManagement/mobileApps" "?$select=id,displayName,notes"
+        f"{GRAPH_BASE}/deviceAppManagement/mobileApps?$select=id,displayName,notes"
     )
     apps: list[dict] = []
     while url:
-        body = _graph_request(
-            "GET", url, "list_mobile_apps", headers=_auth_headers(access_token)
+        body = graph_request(
+            "GET", url, "list_mobile_apps", headers=auth_headers(access_token)
         )
         apps.extend(body.get("value", []))
         url = body.get("@odata.nextLink")
@@ -585,11 +379,11 @@ def delete_mobile_app(access_token: str, app_id: str) -> None:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
-    _graph_request(
+    graph_request(
         "DELETE",
         url,
         "delete_mobile_app",
-        headers=_auth_headers(access_token),
+        headers=auth_headers(access_token),
         ok_statuses=(404,),
     )
 
@@ -613,8 +407,8 @@ def get_mobile_app(access_token: str, app_id: str) -> dict:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
-    return _graph_request(
-        "GET", url, "get_mobile_app", headers=_auth_headers(access_token)
+    return graph_request(
+        "GET", url, "get_mobile_app", headers=auth_headers(access_token)
     )
 
 
@@ -636,11 +430,11 @@ def create_win32_app(access_token: str, app_metadata: dict) -> str:
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps"
-    body = _graph_request(
+    body = graph_request(
         "POST",
         url,
         "create_win32_app",
-        headers=_json_headers(access_token),
+        headers=json_headers(access_token),
         json=app_metadata,
         idempotent=False,
     )
@@ -662,11 +456,11 @@ def update_win32_app(access_token: str, app_id: str, app_metadata: dict) -> None
 
     """
     url = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
-    _graph_request(
+    graph_request(
         "PATCH",
         url,
         "update_win32_app",
-        headers=_json_headers(access_token),
+        headers=json_headers(access_token),
         json=app_metadata,
     )
 
@@ -690,11 +484,11 @@ def create_content_version(access_token: str, app_id: str) -> str:
         f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{app_id}"
         f"/microsoft.graph.win32LobApp/contentVersions"
     )
-    body = _graph_request(
+    body = graph_request(
         "POST",
         url,
         "create_content_version",
-        headers=_json_headers(access_token),
+        headers=json_headers(access_token),
         json={},
         idempotent=False,
     )
@@ -739,11 +533,11 @@ def create_content_version_file(
         "manifest": None,
         "isDependency": False,
     }
-    file_body = _graph_request(
+    file_body = graph_request(
         "POST",
         base_url,
         "create_content_version_file",
-        headers=_json_headers(access_token),
+        headers=json_headers(access_token),
         json=body,
         idempotent=False,
     )
@@ -955,11 +749,11 @@ def commit_content_version_file(
             "fileDigestAlgorithm": metadata.file_digest_algorithm,
         }
     }
-    _graph_request(
+    graph_request(
         "POST",
         commit_url,
         "commit_content_version_file",
-        headers=_json_headers(access_token),
+        headers=json_headers(access_token),
         json=body,
     )
 
@@ -996,10 +790,10 @@ def commit_content_version(access_token: str, app_id: str, cv_id: str) -> None:
         "@odata.type": WIN32_LOB_APP_TYPE,
         "committedContentVersion": cv_id,
     }
-    _graph_request(
+    graph_request(
         "PATCH",
         url,
         "commit_content_version",
-        headers=_json_headers(access_token),
+        headers=json_headers(access_token),
         json=body,
     )

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -51,7 +51,16 @@ import json
 from pathlib import Path
 from typing import Any
 
+from napt.auth.credentials import get_access_token
 from napt.exceptions import ConfigError, NetworkError, StateError
+from napt.graph.intune import (
+    assign_app,
+    build_assignment,
+    delete_mobile_app,
+    get_app_assignments,
+    list_mobile_apps,
+    resolve_assignment_target,
+)
 from napt.logging import get_global_logger
 from napt.promote.drift import detect_drift
 from napt.promote.planner import (
@@ -66,15 +75,6 @@ from napt.state import (
     deployment_state_path,
     load_deployment_state,
     save_deployment_state,
-)
-from napt.upload.auth import get_access_token
-from napt.upload.graph import (
-    assign_app,
-    build_assignment,
-    delete_mobile_app,
-    get_app_assignments,
-    list_mobile_apps,
-    resolve_assignment_target,
 )
 from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
 

--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -49,11 +49,11 @@ from pathlib import Path
 from typing import Any
 
 from napt.exceptions import ConfigError
-from napt.state import deployment_state_path, load_deployment_state
-from napt.upload.graph import (
+from napt.graph.intune import (
     get_app_assignments,
     resolve_assignment_target,
 )
+from napt.state import deployment_state_path, load_deployment_state
 from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, parse_stamp
 
 __all__ = ["detect_drift"]

--- a/napt/promote/preflight.py
+++ b/napt/promote/preflight.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from typing import Any
 
 from napt.exceptions import ConfigError
-from napt.upload.graph import resolve_assignment_target
+from napt.graph.intune import resolve_assignment_target
 
 __all__ = ["unresolvable_groups"]
 

--- a/napt/promote/reconcile.py
+++ b/napt/promote/reconcile.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from napt.graph.intune import get_mobile_app
 from napt.logging import get_global_logger
 from napt.state import (
     deployment_state_path,
@@ -54,7 +55,6 @@ from napt.state import (
     record_published,
     save_deployment_state,
 )
-from napt.upload.graph import get_mobile_app
 from napt.upload.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
 
 __all__ = ["reconcile_publications"]

--- a/napt/upload/__init__.py
+++ b/napt/upload/__init__.py
@@ -15,19 +15,13 @@
 """Intune upload operations for NAPT.
 
 This module provides the complete upload pipeline for deploying Win32 LOB apps
-to Microsoft Intune via the Graph API.
-
-Authentication needs no configuration file:
-
-- Developers: run `napt auth login` once (browser or OS broker); later commands use the cached session silently
-- CI/CD: set AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET (EnvironmentCredential), or sign in with an OIDC login step such as GitHub Actions `azure/login` (AzureCliCredential)
+to Microsoft Intune via the Graph API. Authentication comes from
+[napt.auth][] and the Graph calls from [napt.graph][].
 
 Modules:
     manager - Upload orchestration (load config, auth, upload flow).
-    graph - Graph API and Azure Blob Storage HTTP calls.
-    auth - Credential resolution (azure-identity chain, MSAL interactive session).
-    entra - App registration provisioning for `napt auth setup`.
     intunewin - .intunewin ZIP parser (reads Detection.xml encryption metadata).
+    stamp - Provenance stamp written to the Intune app's notes field.
 
 Example:
     Upload a packaged app to Intune:

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -39,19 +39,11 @@ from pathlib import Path
 import tempfile
 from typing import Any
 
+from napt.auth.credentials import get_access_token
 from napt.build.icons import MAX_ICON_BYTES
 from napt.config import load_effective_config
 from napt.exceptions import ConfigError, PackagingError
-from napt.logging import get_global_logger
-from napt.results import UploadResult
-from napt.state import (
-    deployment_state_path,
-    load_deployment_state,
-    record_published,
-    save_deployment_state,
-)
-from napt.upload.auth import get_access_token
-from napt.upload.graph import (
+from napt.graph.intune import (
     commit_content_version,
     commit_content_version_file,
     create_content_version,
@@ -62,6 +54,14 @@ from napt.upload.graph import (
     list_mobile_apps,
     update_win32_app,
     upload_to_azure_blob,
+)
+from napt.logging import get_global_logger
+from napt.results import UploadResult
+from napt.state import (
+    deployment_state_path,
+    load_deployment_state,
+    record_published,
+    save_deployment_state,
 )
 from napt.upload.intunewin import extract_encrypted_payload, parse_intunewin
 from napt.upload.stamp import (

--- a/tests/auth/test_credentials.py
+++ b/tests/auth/test_credentials.py
@@ -1,4 +1,4 @@
-"""Tests for napt.upload.auth."""
+"""Tests for napt.auth.credentials."""
 
 from __future__ import annotations
 
@@ -9,9 +9,8 @@ from unittest.mock import MagicMock, patch
 from azure.core.exceptions import ClientAuthenticationError
 import pytest
 
-from napt.exceptions import AuthError, ConfigError
-from napt.upload import auth
-from napt.upload.auth import (
+from napt.auth import credentials
+from napt.auth.credentials import (
     AuthConfig,
     AuthStore,
     get_access_token,
@@ -21,6 +20,7 @@ from napt.upload.auth import (
     logout,
     resolve_auth_config,
 )
+from napt.exceptions import AuthError, ConfigError
 
 
 def _jwt(claims: dict) -> str:
@@ -50,9 +50,9 @@ def chain_fails():
     cred = MagicMock()
     cred.get_token.side_effect = ClientAuthenticationError("no cred")
     with (
-        patch("napt.upload.auth.get_credential", return_value=cred),
+        patch("napt.auth.credentials.get_credential", return_value=cred),
         # Keep the developer's real `az login` session out of the tests.
-        patch("napt.upload.auth._azure_cli_token", return_value=None),
+        patch("napt.auth.credentials._azure_cli_token", return_value=None),
     ):
         yield cred
 
@@ -63,7 +63,7 @@ def _remember(*configs: AuthConfig, active: str | None = None) -> None:
         active=active or configs[-1].tenant_id,
         tenants={c.tenant_id: c for c in configs},
     )
-    auth._save_auth_store(store)
+    credentials._save_auth_store(store)
 
 
 def _fake_app(
@@ -90,7 +90,7 @@ def test_get_access_token_returns_token_when_chain_succeeds() -> None:
     cred = MagicMock()
     cred.get_token.return_value = mock_token
 
-    with patch("napt.upload.auth.get_credential", return_value=cred):
+    with patch("napt.auth.credentials.get_credential", return_value=cred):
         assert get_access_token() == "test-bearer-token"
 
 
@@ -107,7 +107,7 @@ def test_get_access_token_uses_cached_session(user_dir, chain_fails) -> None:
     _remember(AuthConfig("cid", "tid", "u@x"))
     app = _fake_app(accounts=[{"username": "u@x"}], silent={"access_token": "cached"})
 
-    with patch("napt.upload.auth._build_public_client", return_value=app):
+    with patch("napt.auth.credentials._build_public_client", return_value=app):
         assert get_access_token() == "cached"
 
     app.get_accounts.assert_called_once_with(username="u@x")
@@ -121,7 +121,7 @@ def test_get_access_token_never_opens_browser_without_session(
     _remember(AuthConfig("cid", "tid", "u@x"))
     app = _fake_app(accounts=[])
 
-    with patch("napt.upload.auth._build_public_client", return_value=app):
+    with patch("napt.auth.credentials._build_public_client", return_value=app):
         with pytest.raises(AuthError, match="napt auth login"):
             get_access_token()
 
@@ -136,7 +136,7 @@ def test_get_access_token_reports_expired_session(user_dir, chain_fails) -> None
         silent={"error": "invalid_grant", "error_description": "AADSTS70008 expired"},
     )
 
-    with patch("napt.upload.auth._build_public_client", return_value=app):
+    with patch("napt.auth.credentials._build_public_client", return_value=app):
         with pytest.raises(AuthError, match="invalid_grant") as excinfo:
             get_access_token()
     assert "napt auth login" in str(excinfo.value)
@@ -219,8 +219,8 @@ def test_login_saves_config_and_reports_permissions(user_dir) -> None:
     app = _fake_app(interactive={"access_token": token})
 
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
     ):
         status = login(client_id="cid", tenant_id="tid")
 
@@ -239,14 +239,14 @@ def test_login_reuses_valid_session_without_prompt(user_dir) -> None:
     app = _fake_app(accounts=[{"username": "a@x"}], silent={"access_token": token})
 
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
     ):
         status = login(tenant_id="tid-a")
 
     assert status.account == "a@x"
     app.acquire_token_interactive.assert_not_called()
-    assert auth.load_auth_store().active == "tid-a"
+    assert credentials.load_auth_store().active == "tid-a"
 
 
 def test_login_prompts_when_cached_session_expired(user_dir) -> None:
@@ -260,8 +260,8 @@ def test_login_prompts_when_cached_session_expired(user_dir) -> None:
     )
 
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
     ):
         status = login()
 
@@ -276,12 +276,12 @@ def test_login_keeps_other_tenants(user_dir) -> None:
     app = _fake_app(interactive={"access_token": token})
 
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
     ):
         login(client_id="cid-b", tenant_id="tid-b")
 
-    store = auth.load_auth_store()
+    store = credentials.load_auth_store()
     assert store.active == "tid-b"
     assert store.tenants["tid-a"] == AuthConfig("cid-a", "tid-a", "a@x")
     assert store.tenants["tid-b"] == AuthConfig("cid-b", "tid-b", "b@x")
@@ -293,8 +293,8 @@ def test_login_uses_broker_when_available(user_dir) -> None:
     app = _fake_app(interactive={"access_token": token})
 
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app) as build,
-        patch("napt.upload.auth._broker_available", return_value=True),
+        patch("napt.auth.credentials._build_public_client", return_value=app) as build,
+        patch("napt.auth.credentials._broker_available", return_value=True),
     ):
         status = login(client_id="cid", tenant_id="tid")
 
@@ -310,8 +310,8 @@ def test_login_no_broker_flag_forces_browser(user_dir) -> None:
     app = _fake_app(interactive={"access_token": _jwt({})})
 
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app) as build,
-        patch("napt.upload.auth._broker_available", return_value=True),
+        patch("napt.auth.credentials._build_public_client", return_value=app) as build,
+        patch("napt.auth.credentials._broker_available", return_value=True),
     ):
         login(client_id="cid", tenant_id="tid", use_broker=False)
 
@@ -333,8 +333,8 @@ def test_login_surfaces_msal_error(user_dir) -> None:
         }
     )
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
     ):
         with pytest.raises(AuthError, match="invalid_client: AADSTS50011") as exc:
             login(client_id="cid", tenant_id="tid")
@@ -347,12 +347,12 @@ def test_logout_signs_out_active_tenant_only(user_dir) -> None:
     _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
     app = _fake_app(accounts=[{"username": "b@x"}])
 
-    with patch("napt.upload.auth._build_public_client", return_value=app):
+    with patch("napt.auth.credentials._build_public_client", return_value=app):
         assert logout() == ["tid-b"]
 
     app.get_accounts.assert_called_once_with(username="b@x")
     app.remove_account.assert_called_once()
-    store = auth.load_auth_store()
+    store = credentials.load_auth_store()
     assert store.tenants["tid-b"] == AuthConfig("cid-b", "tid-b", None)
     assert store.tenants["tid-a"] == AuthConfig("cid-a", "tid-a", "a@x")
     assert store.active == "tid-b"
@@ -363,10 +363,10 @@ def test_logout_all_signs_out_every_tenant(user_dir) -> None:
     _remember(AuthConfig("cid-a", "tid-a", "a@x"), AuthConfig("cid-b", "tid-b", "b@x"))
     app = _fake_app(accounts=[{"username": "x"}])
 
-    with patch("napt.upload.auth._build_public_client", return_value=app):
+    with patch("napt.auth.credentials._build_public_client", return_value=app):
         assert sorted(logout(all_tenants=True)) == ["tid-a", "tid-b"]
 
-    store = auth.load_auth_store()
+    store = credentials.load_auth_store()
     assert all(c.username is None for c in store.tenants.values())
 
 
@@ -385,7 +385,7 @@ def test_get_status_reports_service_principal(user_dir, monkeypatch) -> None:
     cred = MagicMock()
     cred.get_token.return_value = token
 
-    with patch("napt.upload.auth.get_credential", return_value=cred):
+    with patch("napt.auth.credentials.get_credential", return_value=cred):
         status = get_status()
 
     assert status is not None
@@ -401,10 +401,10 @@ def test_get_status_returns_none_when_unauthenticated(user_dir, chain_fails) -> 
 
 def test_status_handles_opaque_token() -> None:
     """Tests that an undecodable token still yields a status object."""
-    status = auth._status_from_token("not-a-jwt", "service principal")
+    status = credentials._status_from_token("not-a-jwt", "service principal")
     assert status.account is None
     assert status.permissions == []
-    assert set(status.missing) == set(auth.REQUIRED_PERMISSIONS)
+    assert set(status.missing) == set(credentials.REQUIRED_PERMISSIONS)
 
 
 def test_login_canceled_in_broker_explains_hidden_error(user_dir) -> None:
@@ -423,8 +423,8 @@ def test_login_canceled_in_broker_explains_hidden_error(user_dir) -> None:
         }
     )
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=True),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=True),
     ):
         with pytest.raises(AuthError, match="canceled") as exc:
             login(client_id="cid", tenant_id="tid")
@@ -454,9 +454,9 @@ def test_login_stores_tenant_domain_and_name(user_dir) -> None:
         ]
     )
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
-        patch("napt.upload.auth.requests.get", return_value=org) as get,
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
+        patch("napt.auth.credentials.requests.get", return_value=org) as get,
     ):
         login(client_id="cid", tenant_id="tid")
 
@@ -475,10 +475,10 @@ def test_login_without_user_read_leaves_label_empty(user_dir) -> None:
     token = _jwt({"preferred_username": "a@msp.com"})
     app = _fake_app(interactive={"access_token": token})
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._broker_available", return_value=False),
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch("napt.auth.credentials._broker_available", return_value=False),
         patch(
-            "napt.upload.auth.requests.get",
+            "napt.auth.credentials.requests.get",
             side_effect=_requests.HTTPError("403 Forbidden"),
         ),
     ):
@@ -494,9 +494,9 @@ def test_logout_keeps_tenant_label(user_dir) -> None:
     """Tests that signing out clears the account but keeps the tenant label."""
     _remember(AuthConfig("cid", "tid", "u@x", domain="x.com", display_name="X"))
     app = _fake_app(accounts=[{"username": "u@x"}])
-    with patch("napt.upload.auth._build_public_client", return_value=app):
+    with patch("napt.auth.credentials._build_public_client", return_value=app):
         logout()
-    saved = auth.load_auth_store().tenants["tid"]
+    saved = credentials.load_auth_store().tenants["tid"]
     assert saved.username is None
     assert saved.label == "X (x.com)"
 
@@ -523,7 +523,7 @@ def test_resolve_auth_config_accepts_domain_for_tenant(user_dir) -> None:
 
 def test_get_access_token_falls_back_to_azure_cli(user_dir, chain_fails) -> None:
     """Tests that an az login session is used when nothing else is configured."""
-    with patch("napt.upload.auth._azure_cli_token", return_value="cli-token"):
+    with patch("napt.auth.credentials._azure_cli_token", return_value="cli-token"):
         assert get_access_token() == "cli-token"
 
 
@@ -532,8 +532,10 @@ def test_napt_session_wins_over_azure_cli(user_dir, chain_fails) -> None:
     _remember(AuthConfig("cid", "tid", "u@x"))
     app = _fake_app(accounts=[{"username": "u@x"}], silent={"access_token": "napt"})
     with (
-        patch("napt.upload.auth._build_public_client", return_value=app),
-        patch("napt.upload.auth._azure_cli_token", return_value="cli-token") as cli,
+        patch("napt.auth.credentials._build_public_client", return_value=app),
+        patch(
+            "napt.auth.credentials._azure_cli_token", return_value="cli-token"
+        ) as cli,
     ):
         assert get_access_token() == "napt"
     cli.assert_not_called()
@@ -542,9 +544,9 @@ def test_napt_session_wins_over_azure_cli(user_dir, chain_fails) -> None:
 def test_get_status_reports_azure_cli(user_dir, chain_fails) -> None:
     """Tests that status names the Azure CLI as the source and decodes its token."""
     token = _jwt(
-        {"appid": "cid", "tid": "tid", "roles": list(auth.REQUIRED_PERMISSIONS)}
+        {"appid": "cid", "tid": "tid", "roles": list(credentials.REQUIRED_PERMISSIONS)}
     )
-    with patch("napt.upload.auth._azure_cli_token", return_value=token):
+    with patch("napt.auth.credentials._azure_cli_token", return_value=token):
         status = get_status()
     assert status is not None
     assert status.method == "azure cli"
@@ -555,8 +557,8 @@ def test_azure_cli_token_is_none_when_unavailable() -> None:
     """Tests that a missing or signed-out Azure CLI yields None, not an error."""
     cred = MagicMock()
     cred.get_token.side_effect = ClientAuthenticationError("az not found")
-    with patch("napt.upload.auth.AzureCliCredential", return_value=cred):
-        assert auth._azure_cli_token() is None
+    with patch("napt.auth.credentials.AzureCliCredential", return_value=cred):
+        assert credentials._azure_cli_token() is None
 
 
 def _cli_cred(token: str) -> MagicMock:
@@ -570,8 +572,10 @@ def _cli_cred(token: str) -> MagicMock:
 def test_azure_cli_token_accepts_service_principal_session() -> None:
     """Tests that an app-only az session (azure/login in CI) is used."""
     token = _jwt({"idtyp": "app", "appid": "cid", "roles": ["Group.Read.All"]})
-    with patch("napt.upload.auth.AzureCliCredential", return_value=_cli_cred(token)):
-        assert auth._azure_cli_token() == token
+    with patch(
+        "napt.auth.credentials.AzureCliCredential", return_value=_cli_cred(token)
+    ):
+        assert credentials._azure_cli_token() == token
 
 
 def test_azure_cli_token_refuses_user_session() -> None:
@@ -583,7 +587,9 @@ def test_azure_cli_token_refuses_user_session() -> None:
             "scp": "DeviceManagementApps.ReadWrite.All Group.Read.All",
         }
     )
-    with patch("napt.upload.auth.AzureCliCredential", return_value=_cli_cred(token)):
+    with patch(
+        "napt.auth.credentials.AzureCliCredential", return_value=_cli_cred(token)
+    ):
         with pytest.raises(AuthError, match="signed in as a user") as exc:
-            auth._azure_cli_token()
+            credentials._azure_cli_token()
     assert "napt auth login" in str(exc.value)

--- a/tests/auth/test_registration.py
+++ b/tests/auth/test_registration.py
@@ -1,4 +1,4 @@
-"""Tests for napt.upload.entra."""
+"""Tests for napt.auth.registration."""
 
 from __future__ import annotations
 
@@ -6,10 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
+from napt.auth import credentials, registration
+from napt.auth.credentials import AuthConfig, AuthStore
+from napt.auth.registration import SetupSpec, setup_app_registration
 from napt.exceptions import AuthError, ConfigError, NetworkError
-from napt.upload import auth, entra
-from napt.upload.auth import AuthConfig, AuthStore
-from napt.upload.entra import SetupSpec, setup_app_registration
 
 GRAPH_SP_ID = "graph-sp"
 ROLE_IDS = {"DeviceManagementApps.ReadWrite.All": "role-dm", "Group.Read.All": "role-g"}
@@ -34,8 +34,8 @@ def _graph_sp_response() -> dict:
     }
 
 
-def _stamp(spec: int = entra.SPEC_VERSION, version: str | None = None) -> str:
-    version = version or entra.__version__
+def _stamp(spec: int = registration.SPEC_VERSION, version: str | None = None) -> str:
+    version = version or registration.__version__
     return f"napt/v1 spec={spec} version={version} provisioned=2026-08-18"
 
 
@@ -48,20 +48,20 @@ def _complete_app(app_id: str = "cid", object_id: str = "obj") -> dict:
         "notes": _stamp(),
         "publicClient": {
             "redirectUris": [
-                entra.LOCALHOST_REDIRECT,
-                entra.BROKER_REDIRECT_TEMPLATE.format(client_id=app_id),
+                registration.LOCALHOST_REDIRECT,
+                registration.BROKER_REDIRECT_TEMPLATE.format(client_id=app_id),
             ]
         },
         "requiredResourceAccess": [
             {
-                "resourceAppId": entra._MS_GRAPH_APP_ID,
+                "resourceAppId": registration._MS_GRAPH_APP_ID,
                 "resourceAccess": [
                     {"id": ROLE_IDS[p], "type": "Role"}
-                    for p in entra.APPLICATION_PERMISSIONS
+                    for p in registration.APPLICATION_PERMISSIONS
                 ]
                 + [
                     {"id": SCOPE_IDS[p], "type": "Scope"}
-                    for p in entra.DELEGATED_PERMISSIONS
+                    for p in registration.DELEGATED_PERMISSIONS
                 ],
             }
         ],
@@ -69,7 +69,7 @@ def _complete_app(app_id: str = "cid", object_id: str = "obj") -> dict:
 
 
 class FakeGraph:
-    """Routes _graph_request calls to canned responses and records writes."""
+    """Routes graph_request calls to canned responses and records writes."""
 
     def __init__(self, responses: dict[tuple[str, str], dict | list[dict]]):
         # Keys are (method, path-after-v1.0 up to '?'); values are a dict, or a
@@ -78,7 +78,7 @@ class FakeGraph:
         self.calls: list[tuple[str, str, dict | None]] = []
 
     def __call__(self, method, url, context, headers, json=None, **kwargs):
-        path = url.replace(entra._GRAPH_V1, "").split("?")[0]
+        path = url.replace(registration._GRAPH_V1, "").split("?")[0]
         self.calls.append((method, path, json))
         key = (method, path)
         if key not in self.responses:
@@ -100,14 +100,14 @@ def user_dir(tmp_path, monkeypatch):
 
 @pytest.fixture
 def bootstrap():
-    with patch("napt.upload.entra._bootstrap_token", return_value="tok") as b:
+    with patch("napt.auth.registration._bootstrap_token", return_value="tok") as b:
         yield b
 
 
 def _run(graph: FakeGraph, spec: SetupSpec):
     with (
-        patch("napt.upload.entra._graph_request", graph),
-        patch("napt.upload.entra.time.sleep"),
+        patch("napt.auth.registration.graph_request", graph),
+        patch("napt.auth.registration.time.sleep"),
     ):
         return setup_app_registration(spec)
 
@@ -125,7 +125,7 @@ def test_spec_federated_credential_name_is_derived_or_given() -> None:
         federated_subject="repo:o/r:ref:refs/heads/main",
     )
     assert derived.federated_credential_name == "napt-repo-o-r-ref-refs-heads-main"
-    assert derived.federated_audience == entra.FEDERATED_AUDIENCE_DEFAULT
+    assert derived.federated_audience == registration.FEDERATED_AUDIENCE_DEFAULT
 
     given = SetupSpec(
         tenant_id="t",
@@ -181,9 +181,9 @@ def test_setup_creates_everything_in_a_fresh_tenant(user_dir, bootstrap) -> None
     )
     assert create is not None
     assert create["signInAudience"] == "AzureADMyOrg"
-    assert create["publicClient"]["redirectUris"] == [entra.LOCALHOST_REDIRECT]
+    assert create["publicClient"]["redirectUris"] == [registration.LOCALHOST_REDIRECT]
     access = create["requiredResourceAccess"][0]
-    assert access["resourceAppId"] == entra._MS_GRAPH_APP_ID
+    assert access["resourceAppId"] == registration._MS_GRAPH_APP_ID
     assert {(a["id"], a["type"]) for a in access["resourceAccess"]} == {
         ("role-dm", "Role"),
         ("role-g", "Role"),
@@ -212,12 +212,12 @@ def test_setup_creates_everything_in_a_fresh_tenant(user_dir, bootstrap) -> None
     grant = next(j for m, p, j in graph.writes() if p == "/oauth2PermissionGrants")
     assert grant is not None
     assert grant["consentType"] == "AllPrincipals"
-    assert grant["scope"].split() == list(entra.DELEGATED_PERMISSIONS)
+    assert grant["scope"].split() == list(registration.DELEGATED_PERMISSIONS)
 
     # Nothing touches the service principal's redirect URIs or permissions.
     assert not any(p == "/servicePrincipals/sp" for _, p, _ in graph.writes())
 
-    store = auth.load_auth_store()
+    store = credentials.load_auth_store()
     assert store.active == "tid"
     assert store.tenants["tid"] == AuthConfig("new-cid", "tid")
     assert len(result.changes) >= 5
@@ -269,7 +269,7 @@ def test_setup_adds_only_what_is_missing(user_dir, bootstrap) -> None:
     # Only the application roles were declared; delegated scopes are missing.
     app["requiredResourceAccess"] = [
         {
-            "resourceAppId": entra._MS_GRAPH_APP_ID,
+            "resourceAppId": registration._MS_GRAPH_APP_ID,
             "resourceAccess": [
                 {"id": "role-dm", "type": "Role"},
                 {"id": "role-g", "type": "Role"},
@@ -314,7 +314,7 @@ def test_setup_adds_only_what_is_missing(user_dir, bootstrap) -> None:
     graph_access = next(
         r
         for r in app_patch["requiredResourceAccess"]
-        if r["resourceAppId"] == entra._MS_GRAPH_APP_ID
+        if r["resourceAppId"] == registration._MS_GRAPH_APP_ID
     )
     assert {(a["id"], a["type"]) for a in graph_access["resourceAccess"]} == {
         ("role-dm", "Role"),
@@ -333,14 +333,14 @@ def test_setup_adds_only_what_is_missing(user_dir, bootstrap) -> None:
         j for m, p, j in graph.writes() if p == "/oauth2PermissionGrants/grant"
     )
     assert grant_patch is not None
-    assert grant_patch["scope"].split() == sorted(entra.DELEGATED_PERMISSIONS)
+    assert grant_patch["scope"].split() == sorted(registration.DELEGATED_PERMISSIONS)
     assert any("redirect" in c.lower() for c in result.changes)
     assert any("delegated" in c.lower() for c in result.changes)
 
 
 def test_setup_keeps_existing_session_for_same_client(user_dir, bootstrap) -> None:
     """Tests that re-running setup does not sign out a tenant already logged in."""
-    auth._save_auth_store(
+    credentials._save_auth_store(
         AuthStore(
             active="tid",
             tenants={"tid": AuthConfig("cid", "tid", "me@x", "x.com", "X")},
@@ -360,12 +360,14 @@ def test_setup_keeps_existing_session_for_same_client(user_dir, bootstrap) -> No
                 ]
             },
             ("GET", "/oauth2PermissionGrants"): {
-                "value": [{"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}]
+                "value": [
+                    {"id": "g", "scope": " ".join(registration.DELEGATED_PERMISSIONS)}
+                ]
             },
         }
     )
     _run(graph, SetupSpec(tenant_id="tid"))
-    assert auth.load_auth_store().tenants["tid"] == AuthConfig(
+    assert credentials.load_auth_store().tenants["tid"] == AuthConfig(
         "cid", "tid", "me@x", "x.com", "X"
     )
 
@@ -428,7 +430,9 @@ def test_bootstrap_failure_is_an_auth_error(user_dir) -> None:
             }
         },
     )()
-    with patch("napt.upload.entra.msal.PublicClientApplication", return_value=fake_app):
+    with patch(
+        "napt.auth.registration.msal.PublicClientApplication", return_value=fake_app
+    ):
         with pytest.raises(AuthError, match="access_denied") as exc:
             setup_app_registration(SetupSpec(tenant_id="tid"))
     assert "--print-only" in str(exc.value)
@@ -446,7 +450,7 @@ def test_consent_retries_until_service_principal_replicates(
     attempts = {"n": 0}
 
     def flaky_graph(method, url, context, headers, json=None, **kwargs):
-        path = url.replace(entra._GRAPH_V1, "").split("?")[0]
+        path = url.replace(registration._GRAPH_V1, "").split("?")[0]
         if (method, path) == ("POST", "/servicePrincipals/sp/appRoleAssignments"):
             attempts["n"] += 1
             if attempts["n"] == 1:
@@ -461,7 +465,10 @@ def test_consent_retries_until_service_principal_replicates(
                 },
                 ("GET", "/oauth2PermissionGrants"): {
                     "value": [
-                        {"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}
+                        {
+                            "id": "g",
+                            "scope": " ".join(registration.DELEGATED_PERMISSIONS),
+                        }
                     ]
                 },
             }
@@ -470,14 +477,14 @@ def test_consent_retries_until_service_principal_replicates(
     # Second /servicePrincipals GET must return the NAPT SP; FakeGraph above is
     # rebuilt per call, so answer it explicitly.
     def graph(method, url, context, headers, json=None, **kwargs):
-        path = url.replace(entra._GRAPH_V1, "").split("?")[0]
+        path = url.replace(registration._GRAPH_V1, "").split("?")[0]
         if (method, path) == ("GET", "/servicePrincipals") and "appId eq 'cid'" in url:
             return {"value": [{"id": "sp"}]}
         return flaky_graph(method, url, context, headers, json, **kwargs)
 
     with (
-        patch("napt.upload.entra._graph_request", graph),
-        patch("napt.upload.entra.time.sleep") as sleep,
+        patch("napt.auth.registration.graph_request", graph),
+        patch("napt.auth.registration.time.sleep") as sleep,
     ):
         result = setup_app_registration(SetupSpec(tenant_id="tid"))
 
@@ -506,7 +513,9 @@ def test_setup_adds_federated_credential_once(user_dir, bootstrap) -> None:
                 ]
             },
             ("GET", "/oauth2PermissionGrants"): {
-                "value": [{"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}]
+                "value": [
+                    {"id": "g", "scope": " ".join(registration.DELEGATED_PERMISSIONS)}
+                ]
             },
         }
 
@@ -536,7 +545,7 @@ def test_setup_adds_federated_credential_once(user_dir, bootstrap) -> None:
         "name": "github-prod",
         "issuer": issuer,
         "subject": subject,
-        "audiences": [entra.FEDERATED_AUDIENCE_DEFAULT],
+        "audiences": [registration.FEDERATED_AUDIENCE_DEFAULT],
         "description": "NAPT CI/CD (OIDC)",
     }
     assert any("federated" in c for c in result.changes)
@@ -574,7 +583,9 @@ def _existing_tenant_responses(app: dict) -> dict:
             ]
         },
         ("GET", "/oauth2PermissionGrants"): {
-            "value": [{"id": "g", "scope": " ".join(entra.DELEGATED_PERMISSIONS)}]
+            "value": [
+                {"id": "g", "scope": " ".join(registration.DELEGATED_PERMISSIONS)}
+            ]
         },
     }
 
@@ -584,15 +595,15 @@ def test_stamp_round_trip_preserves_admin_notes() -> None:
     notes = (
         "Owned by Endpoint team\nnapt/v1 spec=0 version=0.9.0 provisioned=2026-01-01\n"
     )
-    parsed = entra._parse_stamp(notes)
+    parsed = registration._parse_stamp(notes)
     assert parsed == {"spec": "0", "version": "0.9.0", "date": "2026-01-01"}
 
-    updated = entra._with_stamp(notes)
+    updated = registration._with_stamp(notes)
     lines = updated.splitlines()
-    assert lines[0].startswith(f"napt/v1 spec={entra.SPEC_VERSION} version=")
+    assert lines[0].startswith(f"napt/v1 spec={registration.SPEC_VERSION} version=")
     assert lines[1:] == ["Owned by Endpoint team"]
-    assert entra._parse_stamp(None) is None
-    assert entra._parse_stamp("napt/v1 spec=x") is None
+    assert registration._parse_stamp(None) is None
+    assert registration._parse_stamp("napt/v1 spec=x") is None
 
 
 def test_setup_create_writes_stamp(user_dir, bootstrap) -> None:
@@ -615,9 +626,9 @@ def test_setup_create_writes_stamp(user_dir, bootstrap) -> None:
         j for m, p, j in graph.writes() if (m, p) == ("POST", "/applications")
     )
     assert create is not None
-    assert entra._parse_stamp(create["notes"]) == {
-        "spec": str(entra.SPEC_VERSION),
-        "version": entra.__version__,
+    assert registration._parse_stamp(create["notes"]) == {
+        "spec": str(registration.SPEC_VERSION),
+        "version": registration.__version__,
         "date": create["notes"].split("provisioned=")[1],
     }
 
@@ -634,7 +645,7 @@ def test_setup_refuses_unstamped_name_match_without_adopt(user_dir, bootstrap) -
     assert result.client_id == "cid"
     assert result.changes == []
     assert graph.writes() == []
-    assert auth.load_auth_store().active is None  # nothing remembered either
+    assert credentials.load_auth_store().active is None  # nothing remembered either
 
 
 def test_setup_adopts_unstamped_registration_with_flag(user_dir, bootstrap) -> None:
@@ -653,12 +664,12 @@ def test_setup_adopts_unstamped_registration_with_flag(user_dir, bootstrap) -> N
     assert patch is not None
     assert list(patch) == ["notes"]  # nothing else needed changing
     assert patch["notes"].splitlines()[1] == "Created by hand"
-    assert entra._parse_stamp(patch["notes"]) is not None
+    assert registration._parse_stamp(patch["notes"]) is not None
     assert result.changes == [
-        f"Stamped internal notes: napt/v1 spec={entra.SPEC_VERSION} "
-        f"version={entra.__version__}"
+        f"Stamped internal notes: napt/v1 spec={registration.SPEC_VERSION} "
+        f"version={registration.__version__}"
     ]
-    assert auth.load_auth_store().active == "tid"
+    assert credentials.load_auth_store().active == "tid"
 
 
 def test_setup_explicit_client_id_implies_adopt(user_dir, bootstrap) -> None:
@@ -687,4 +698,4 @@ def test_setup_restamps_outdated_spec(user_dir, bootstrap) -> None:
         j for m, p, j in graph.writes() if (m, p) == ("PATCH", "/applications/obj")
     )
     assert patch is not None and list(patch) == ["notes"]
-    assert f"spec={entra.SPEC_VERSION}" in patch["notes"]
+    assert f"spec={registration.SPEC_VERSION}" in patch["notes"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import yaml
 
 from napt.config.defaults import DEFAULT_CONFIG
 from napt.config.loader import _deep_merge_dicts
+from napt.upload.intunewin import IntunewinMetadata
 
 
 @pytest.fixture
@@ -174,6 +175,23 @@ def fake_brand_pack(tmp_path: Path) -> tuple[Path, dict[str, Any]]:
     }
 
     return brand_dir, config
+
+
+@pytest.fixture
+def fake_metadata() -> IntunewinMetadata:
+    """Return a sample IntunewinMetadata for use in graph and upload tests."""
+    return IntunewinMetadata(
+        encrypted_file_name="IntunePackage.intunewin",
+        unencrypted_content_size=12345,
+        file_digest="dGVzdGRpZ2VzdA==",
+        file_digest_algorithm="SHA256",
+        encryption_key="dGVzdGVuY3J5cHRpb25rZXk=",
+        mac_key="dGVzdG1hY2tleQ==",
+        init_vector="dGVzdGl2",
+        mac="dGVzdG1hYw==",
+        profile_identifier="ProfileVersion1",
+        encrypted_file_size=22,
+    )
 
 
 # =============================================================================

--- a/tests/graph/test_client.py
+++ b/tests/graph/test_client.py
@@ -1,0 +1,253 @@
+"""Tests for napt.graph.client."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+import requests
+import requests_mock as req_mock
+
+from napt.exceptions import AuthError, ConfigError, NetworkError
+from napt.graph.client import GRAPH_BASE, auth_headers, graph_request, json_headers
+
+TOKEN = "fake-token"
+APP_ID = "app-id-123"
+
+_APPS_URL = f"{GRAPH_BASE}/deviceAppManagement/mobileApps"
+_APP_URL = f"{_APPS_URL}/{APP_ID}"
+
+_SLEEP = "napt.graph.client.time.sleep"
+
+
+def _get() -> dict:
+    return graph_request("GET", _APP_URL, "get app", headers=auth_headers(TOKEN))
+
+
+def _create() -> dict:
+    return graph_request(
+        "POST",
+        _APPS_URL,
+        "create app",
+        headers=json_headers(TOKEN),
+        json={"displayName": "Test App"},
+        idempotent=False,
+    )
+
+
+# --- headers ---
+
+
+def test_auth_headers_carry_bearer_token() -> None:
+    """Tests that auth_headers sets only the Authorization header."""
+    assert auth_headers(TOKEN) == {"Authorization": f"Bearer {TOKEN}"}
+
+
+def test_json_headers_add_content_type() -> None:
+    """Tests that json_headers adds a JSON content type to the bearer token."""
+    assert json_headers(TOKEN) == {
+        "Authorization": f"Bearer {TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+# --- response mapping ---
+
+
+def test_graph_request_returns_parsed_body() -> None:
+    """Tests that a 200 response body is returned as a dict."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, json=body)
+        assert _get() == body
+
+
+def test_graph_request_empty_body_returns_empty_dict() -> None:
+    """Tests that a 204 response yields an empty dict."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, status_code=204)
+        assert _get() == {}
+
+
+def test_graph_request_ok_statuses_short_circuit() -> None:
+    """Tests that a status listed in ok_statuses is treated as success."""
+    with req_mock.Mocker() as m:
+        m.delete(_APP_URL, status_code=404)
+        with patch(_SLEEP) as sleep_mock:
+            result = graph_request(
+                "DELETE",
+                _APP_URL,
+                "delete app",
+                headers=auth_headers(TOKEN),
+                ok_statuses=(404,),
+            )
+
+    assert result == {}
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_graph_request_401_raises_auth_error() -> None:
+    """Tests that a 401 raises AuthError without retrying."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, status_code=401)
+        with patch(_SLEEP) as sleep_mock:
+            with pytest.raises(AuthError):
+                _get()
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_graph_request_non_retryable_fails_fast() -> None:
+    """Tests that a 400 raises ConfigError immediately without retrying."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, json={"error": "bad"}, status_code=400)
+        with patch(_SLEEP) as sleep_mock:
+            with pytest.raises(ConfigError):
+                _create()
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_graph_request_sends_client_request_id() -> None:
+    """Tests that every request carries a client-request-id header."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, json={"id": APP_ID})
+        _get()
+
+    assert m.request_history[0].headers["client-request-id"]
+
+
+# --- retry behavior ---
+
+
+def test_graph_request_retries_429_honoring_retry_after() -> None:
+    """Tests that a throttled call waits per Retry-After and succeeds."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(
+            _APP_URL,
+            [
+                {"status_code": 429, "headers": {"Retry-After": "7"}},
+                {"json": body, "status_code": 200},
+            ],
+        )
+        with patch(_SLEEP) as sleep_mock:
+            result = _get()
+
+    assert result == body
+    assert len(m.request_history) == 2
+    assert sleep_mock.call_args.args[0] == 7.0
+
+
+def test_graph_request_retries_transient_server_error() -> None:
+    """Tests that a transient 503 retries with backoff and succeeds."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, [{"status_code": 503}, {"json": body, "status_code": 200}])
+        with patch(_SLEEP) as sleep_mock:
+            result = _get()
+
+    assert result == body
+    assert sleep_mock.call_args.args[0] == 2.0  # initial backoff, no Retry-After
+
+
+def test_graph_request_exhausts_attempts() -> None:
+    """Tests that persistent throttling raises after bounded attempts."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, status_code=429)
+        with patch(_SLEEP):
+            with pytest.raises(NetworkError):
+                _get()
+
+    assert len(m.request_history) == 5
+
+
+def test_graph_request_retries_connection_error() -> None:
+    """Tests that a connection-level failure retries and succeeds."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(
+            _APP_URL,
+            [
+                {"exc": requests.exceptions.ConnectionError},
+                {"json": body, "status_code": 200},
+            ],
+        )
+        with patch(_SLEEP):
+            result = _get()
+
+    assert result == body
+
+
+def test_graph_request_retries_509_bandwidth_throttle() -> None:
+    """Tests that a 509 bandwidth throttle is retried."""
+    body = {"id": APP_ID}
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, [{"status_code": 509}, {"json": body, "status_code": 200}])
+        with patch(_SLEEP):
+            result = _get()
+
+    assert result == body
+
+
+def test_create_connection_error_fails_fast() -> None:
+    """Tests that a non-idempotent POST never retries a connection failure."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, exc=requests.exceptions.ConnectionError)
+        with patch(_SLEEP) as sleep_mock:
+            with pytest.raises(NetworkError):
+                _create()
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_create_ambiguous_gateway_error_fails_fast() -> None:
+    """Tests that a non-idempotent POST never retries an ambiguous 502."""
+    with req_mock.Mocker() as m:
+        m.post(_APPS_URL, status_code=502)
+        with patch(_SLEEP) as sleep_mock:
+            with pytest.raises(NetworkError):
+                _create()
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
+
+
+def test_create_retries_throttle() -> None:
+    """Tests that a non-idempotent POST retries an unambiguous 429 throttle."""
+    with req_mock.Mocker() as m:
+        m.post(
+            _APPS_URL,
+            [
+                {"status_code": 429, "headers": {"Retry-After": "3"}},
+                {"json": {"id": APP_ID}, "status_code": 201},
+            ],
+        )
+        with patch(_SLEEP) as sleep_mock:
+            result = _create()
+
+    assert result == {"id": APP_ID}
+    assert sleep_mock.call_args.args[0] == 3.0
+
+
+def test_graph_request_deadline_stops_retries() -> None:
+    """Tests that an exhausted deadline surfaces the failure unslept."""
+    with req_mock.Mocker() as m:
+        m.get(_APP_URL, status_code=429, headers={"Retry-After": "60"})
+        with patch(_SLEEP) as sleep_mock:
+            with pytest.raises(NetworkError):
+                graph_request(
+                    "GET",
+                    _APP_URL,
+                    "deadline test",
+                    headers=auth_headers(TOKEN),
+                    deadline=time.monotonic() + 1.0,
+                )
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()

--- a/tests/graph/test_intune.py
+++ b/tests/graph/test_intune.py
@@ -1,20 +1,16 @@
-"""Tests for napt.upload.graph."""
+"""Tests for napt.graph.intune."""
 
 from __future__ import annotations
 
 from pathlib import Path
-import time
 from unittest.mock import patch
 
 import pytest
-import requests
 import requests_mock as req_mock
 
 from napt.exceptions import ConfigError, NetworkError
-from napt.upload.graph import (
-    GRAPH_BASE,
-    _auth_headers,
-    _graph_request,
+from napt.graph.client import GRAPH_BASE
+from napt.graph.intune import (
     assign_app,
     build_group_assignment,
     commit_content_version,
@@ -45,6 +41,11 @@ _FILES_URL = f"{_CV_URL}/{CV_ID}/files"
 _FILE_POLL_URL = f"{_FILES_URL}/{FILE_ID}"
 _COMMIT_FILE_URL = f"{_FILE_POLL_URL}/commit"
 _APP_URL = f"{GRAPH_BASE}/deviceAppManagement/mobileApps/{APP_ID}"
+
+# Graph retry waits happen in the transport; polling and blob retry waits
+# happen in this module.
+_CLIENT_SLEEP = "napt.graph.client.time.sleep"
+_INTUNE_SLEEP = "napt.graph.intune.time.sleep"
 
 
 # --- create_win32_app ---
@@ -80,12 +81,15 @@ def test_create_content_version_returns_cv_id() -> None:
 
 
 def test_create_content_version_500_raises_network_error() -> None:
-    """Tests that a persistent 500 raises NetworkError after retries."""
+    """Tests that a 500 on a create POST raises NetworkError without retrying."""
     with req_mock.Mocker() as m:
         m.post(_CV_URL, json={}, status_code=500)
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_CLIENT_SLEEP) as sleep_mock:
             with pytest.raises(NetworkError):
                 create_content_version(TOKEN, APP_ID)
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
 
 
 # --- create_content_version_file ---
@@ -113,7 +117,7 @@ def test_create_content_version_file_returns_file_id_and_sas_uri(
                 },
             ],
         )
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             file_id, sas_uri = create_content_version_file(
                 TOKEN, APP_ID, CV_ID, fake_metadata
             )
@@ -133,7 +137,7 @@ def test_create_content_version_file_error_state_raises_network_error(
             json={"uploadState": "azureStorageUriRequestError"},
             status_code=200,
         )
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             with pytest.raises(NetworkError, match="error state"):
                 create_content_version_file(TOKEN, APP_ID, CV_ID, fake_metadata)
 
@@ -164,7 +168,7 @@ def test_upload_to_azure_blob_block_failure_raises_network_error(
 
     with req_mock.Mocker() as m:
         m.put(req_mock.ANY, status_code=500)
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             with pytest.raises(NetworkError, match="block upload failed"):
                 upload_to_azure_blob(SAS_URI, payload)
 
@@ -186,7 +190,7 @@ def test_upload_to_azure_blob_retries_transient_403(tmp_path: Path) -> None:
                 {"status_code": 201},
             ],
         )
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             upload_to_azure_blob(SAS_URI, payload)
 
     # One failed block PUT + its retry + the block list commit
@@ -203,7 +207,7 @@ def test_upload_to_azure_blob_non_retryable_status_fails_fast(
 
     with req_mock.Mocker() as m:
         m.put(req_mock.ANY, status_code=400)
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             with pytest.raises(NetworkError, match="block upload failed"):
                 upload_to_azure_blob(SAS_URI, payload)
 
@@ -222,7 +226,7 @@ def test_commit_content_version_file_polls_until_committed(fake_metadata) -> Non
             json={"uploadState": "commitFileSuccess"},
             status_code=200,
         )
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             commit_content_version_file(TOKEN, APP_ID, CV_ID, FILE_ID, fake_metadata)
 
 
@@ -237,7 +241,7 @@ def test_commit_content_version_file_error_state_raises_network_error(
             json={"uploadState": "commitFileFailed"},
             status_code=200,
         )
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_INTUNE_SLEEP):
             with pytest.raises(NetworkError, match="error state"):
                 commit_content_version_file(
                     TOKEN, APP_ID, CV_ID, FILE_ID, fake_metadata
@@ -258,176 +262,14 @@ def test_commit_content_version_500_raises_network_error() -> None:
     """Tests that a persistent 500 raises NetworkError after retries."""
     with req_mock.Mocker() as m:
         m.patch(_APP_URL, json={}, status_code=500)
-        with patch("napt.upload.graph.time.sleep"):
+        with patch(_CLIENT_SLEEP):
             with pytest.raises(NetworkError):
                 commit_content_version(TOKEN, APP_ID, CV_ID)
-
-
-# --- _graph_request retry behavior ---
-
-
-def test_graph_request_retries_429_honoring_retry_after() -> None:
-    """Tests that a throttled call waits per Retry-After and succeeds."""
-    body = {"id": APP_ID}
-    with req_mock.Mocker() as m:
-        m.get(
-            _APP_URL,
-            [
-                {"status_code": 429, "headers": {"Retry-After": "7"}},
-                {"json": body, "status_code": 200},
-            ],
-        )
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            result = get_mobile_app(TOKEN, APP_ID)
-
-    assert result == body
-    assert len(m.request_history) == 2
-    assert sleep_mock.call_args.args[0] == 7.0
-
-
-def test_graph_request_retries_transient_500() -> None:
-    """Tests that a transient 500 retries with backoff and succeeds."""
-    body = {"id": APP_ID}
-    with req_mock.Mocker() as m:
-        m.get(_APP_URL, [{"status_code": 503}, {"json": body, "status_code": 200}])
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            result = get_mobile_app(TOKEN, APP_ID)
-
-    assert result == body
-    assert sleep_mock.call_args.args[0] == 2.0  # initial backoff, no Retry-After
-
-
-def test_graph_request_exhausts_attempts() -> None:
-    """Tests that persistent throttling raises after bounded attempts."""
-    with req_mock.Mocker() as m:
-        m.get(_APP_URL, status_code=429)
-        with patch("napt.upload.graph.time.sleep"):
-            with pytest.raises(NetworkError):
-                get_mobile_app(TOKEN, APP_ID)
 
     assert len(m.request_history) == 5
 
 
-def test_graph_request_non_retryable_fails_fast() -> None:
-    """Tests that a 400 raises immediately without retrying."""
-    with req_mock.Mocker() as m:
-        m.post(_APPS_URL, json={"error": "bad"}, status_code=400)
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            with pytest.raises(ConfigError):
-                create_win32_app(TOKEN, {})
-
-    assert len(m.request_history) == 1
-    sleep_mock.assert_not_called()
-
-
-def test_graph_request_retries_connection_error() -> None:
-    """Tests that a connection-level failure retries and succeeds."""
-    body = {"id": APP_ID}
-    with req_mock.Mocker() as m:
-        m.get(
-            _APP_URL,
-            [
-                {"exc": requests.exceptions.ConnectionError},
-                {"json": body, "status_code": 200},
-            ],
-        )
-        with patch("napt.upload.graph.time.sleep"):
-            result = get_mobile_app(TOKEN, APP_ID)
-
-    assert result == body
-
-
-def test_graph_request_retries_509_bandwidth_throttle() -> None:
-    """Tests that a 509 bandwidth throttle is retried."""
-    body = {"id": APP_ID}
-    with req_mock.Mocker() as m:
-        m.get(_APP_URL, [{"status_code": 509}, {"json": body, "status_code": 200}])
-        with patch("napt.upload.graph.time.sleep"):
-            result = get_mobile_app(TOKEN, APP_ID)
-
-    assert result == body
-
-
-def test_graph_request_sends_client_request_id() -> None:
-    """Tests that every request carries a client-request-id header."""
-    with req_mock.Mocker() as m:
-        m.get(_APP_URL, json={"id": APP_ID})
-        get_mobile_app(TOKEN, APP_ID)
-
-    assert m.request_history[0].headers["client-request-id"]
-
-
-def test_delete_mobile_app_tolerates_404() -> None:
-    """Tests that deleting an already-gone app is a no-op, not a retry."""
-    with req_mock.Mocker() as m:
-        m.delete(_APP_URL, status_code=404)
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            delete_mobile_app(TOKEN, APP_ID)
-
-    assert len(m.request_history) == 1
-    sleep_mock.assert_not_called()
-
-
-def test_create_connection_error_fails_fast() -> None:
-    """Tests that a create POST never retries a connection failure."""
-    with req_mock.Mocker() as m:
-        m.post(_APPS_URL, exc=requests.exceptions.ConnectionError)
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            with pytest.raises(NetworkError):
-                create_win32_app(TOKEN, {"displayName": "Test App"})
-
-    assert len(m.request_history) == 1
-    sleep_mock.assert_not_called()
-
-
-def test_create_ambiguous_gateway_error_fails_fast() -> None:
-    """Tests that a create POST never retries an ambiguous 502."""
-    with req_mock.Mocker() as m:
-        m.post(_APPS_URL, status_code=502)
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            with pytest.raises(NetworkError):
-                create_win32_app(TOKEN, {"displayName": "Test App"})
-
-    assert len(m.request_history) == 1
-    sleep_mock.assert_not_called()
-
-
-def test_create_retries_throttle() -> None:
-    """Tests that a create POST retries an unambiguous 429 throttle."""
-    with req_mock.Mocker() as m:
-        m.post(
-            _APPS_URL,
-            [
-                {"status_code": 429, "headers": {"Retry-After": "3"}},
-                {"json": {"id": APP_ID}, "status_code": 201},
-            ],
-        )
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            result = create_win32_app(TOKEN, {"displayName": "Test App"})
-
-    assert result == APP_ID
-    assert sleep_mock.call_args.args[0] == 3.0
-
-
-def test_graph_request_deadline_stops_retries() -> None:
-    """Tests that an exhausted deadline surfaces the failure unslept."""
-    with req_mock.Mocker() as m:
-        m.get(_APP_URL, status_code=429, headers={"Retry-After": "60"})
-        with patch("napt.upload.graph.time.sleep") as sleep_mock:
-            with pytest.raises(NetworkError):
-                _graph_request(
-                    "GET",
-                    _APP_URL,
-                    "deadline test",
-                    headers=_auth_headers(TOKEN),
-                    deadline=time.monotonic() + 1.0,
-                )
-
-    assert len(m.request_history) == 1
-    sleep_mock.assert_not_called()
-
-
-# --- list_mobile_apps / get_mobile_app ---
+# --- list_mobile_apps / get_mobile_app / delete_mobile_app ---
 
 
 def test_list_mobile_apps_single_page() -> None:
@@ -462,6 +304,17 @@ def test_get_mobile_app_returns_full_object() -> None:
         result = get_mobile_app(TOKEN, APP_ID)
 
     assert result == body
+
+
+def test_delete_mobile_app_tolerates_404() -> None:
+    """Tests that deleting an already-gone app is a no-op, not a retry."""
+    with req_mock.Mocker() as m:
+        m.delete(_APP_URL, status_code=404)
+        with patch(_CLIENT_SLEEP) as sleep_mock:
+            delete_mobile_app(TOKEN, APP_ID)
+
+    assert len(m.request_history) == 1
+    sleep_mock.assert_not_called()
 
 
 # --- resolve_group_id / assignments ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from napt.auth.credentials import AuthStatus
 from napt.cli import (
     _resolve_build_dir_from_recipe,
     cmd_auth_login,
@@ -26,7 +27,6 @@ from napt.cli import (
     cmd_validate,
 )
 from napt.exceptions import AuthError, ConfigError, NetworkError, PackagingError
-from napt.upload.auth import AuthStatus
 
 
 def _args(**kwargs) -> argparse.Namespace:
@@ -637,7 +637,7 @@ class TestCmdAuth:
 
     def test_status_lists_known_tenants(self, capsys, tmp_path, monkeypatch):
         """Tests that interactive status lists remembered tenants, marking the active."""
-        from napt.upload.auth import AuthConfig, AuthStore, _save_auth_store
+        from napt.auth.credentials import AuthConfig, AuthStore, _save_auth_store
 
         monkeypatch.setenv("NAPT_USER_DIR", str(tmp_path))
         _save_auth_store(
@@ -726,7 +726,7 @@ class TestCmdAuth:
 
     def test_setup_warns_and_exits_one_when_adopt_is_needed(self, capsys):
         """Tests that an unstamped name match prints the adopt warning and fails."""
-        from napt.upload.entra import SetupResult
+        from napt.auth.registration import SetupResult
 
         result = SetupResult(
             tenant_id="tid", client_id="cid", display_name="NAPT", needs_adopt=True
@@ -745,7 +745,7 @@ class TestCmdAuth:
 
     def test_setup_reports_adoption(self, capsys):
         """Tests that --adopt is forwarded and an adopted registration is announced."""
-        from napt.upload.entra import SPEC_VERSION, SetupResult
+        from napt.auth.registration import SPEC_VERSION, SetupResult
 
         result = SetupResult(
             tenant_id="tid",
@@ -765,7 +765,7 @@ class TestCmdAuth:
 
     def test_setup_reports_changes_and_next_steps(self, capsys):
         """Tests that a provisioning run lists its changes and the IDs to use."""
-        from napt.upload.entra import SetupResult
+        from napt.auth.registration import SetupResult
 
         result = SetupResult(
             tenant_id="tid",
@@ -803,7 +803,7 @@ class TestCmdAuth:
 
     def test_setup_reports_nothing_to_change(self, capsys):
         """Tests that a complete registration is reported as already done."""
-        from napt.upload.entra import SetupResult
+        from napt.auth.registration import SetupResult
 
         result = SetupResult(tenant_id="tid", client_id="cid", display_name="NAPT")
         with patch("napt.cli.setup_app_registration", return_value=result):

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 
 from napt.exceptions import NetworkError, StateError
+from napt.graph.intune import VIRTUAL_TARGETS
 from napt.promote import apply_plan, load_plan_file, plan_path_for
 from napt.state import (
     create_default_deployment_state,
@@ -20,7 +21,6 @@ from napt.state import (
     load_deployment_state,
     save_deployment_state,
 )
-from napt.upload.graph import VIRTUAL_TARGETS
 
 NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=UTC)
 

--- a/tests/upload/conftest.py
+++ b/tests/upload/conftest.py
@@ -9,11 +9,7 @@ import zipfile
 
 import pytest
 
-from napt.upload.intunewin import (
-    DETECTION_XML_PATH,
-    ENCRYPTED_PAYLOAD_PATH,
-    IntunewinMetadata,
-)
+from napt.upload.intunewin import DETECTION_XML_PATH, ENCRYPTED_PAYLOAD_PATH
 
 _DETECTION_XML = """\
 <?xml version="1.0" encoding="utf-8"?>
@@ -89,20 +85,3 @@ def fake_intunewin(tmp_path: Path) -> Path:
     path = tmp_path / "Invoke-AppDeployToolkit.intunewin"
     path.write_bytes(make_intunewin_bytes())
     return path
-
-
-@pytest.fixture
-def fake_metadata() -> IntunewinMetadata:
-    """Return a sample IntunewinMetadata for use in graph and manager tests."""
-    return IntunewinMetadata(
-        encrypted_file_name="IntunePackage.intunewin",
-        unencrypted_content_size=12345,
-        file_digest="dGVzdGRpZ2VzdA==",
-        file_digest_algorithm="SHA256",
-        encryption_key="dGVzdGVuY3J5cHRpb25rZXk=",
-        mac_key="dGVzdG1hY2tleQ==",
-        init_vector="dGVzdGl2",
-        mac="dGVzdG1hYw==",
-        profile_identifier="ProfileVersion1",
-        encrypted_file_size=22,
-    )


### PR DESCRIPTION
## Description

Moves authentication and the Microsoft Graph client out of `napt/upload/` into their own packages, and splits the Graph transport from the Intune endpoint wrappers.

| Before | After |
|---|---|
| `napt/upload/auth.py` | `napt/auth/credentials.py` |
| `napt/upload/entra.py` | `napt/auth/registration.py` |
| `napt/upload/graph.py` | `napt/graph/client.py` (transport) + `napt/graph/intune.py` (endpoints) |

Tests and API docs mirror the move (`tests/auth/`, `tests/graph/`, `docs/api/auth.md`, `docs/api/graph.md`).

## Motivation

`napt auth` is its own command group consumed by `upload`, `promote`, and `cli`; it lived in `upload/` by history. The Graph client being in `upload/` was the only stage-to-stage dependency in the codebase (`promote` imported `upload` for Graph calls), and `entra.py` reached into private helpers of `graph.py` and `auth.py` -- the cross-module private imports flagged in the #103 review.

## Changes

- `napt/auth/` package: `credentials.py` (token resolution, session store, login/logout/status) and `registration.py` (`napt auth setup`)
- `napt/graph/` package: `client.py` (`graph_request`, header builders, retry and error mapping) and `intune.py` (Win32 app upload, queries, assignments, blob upload)
- Helpers shared across modules are now public with docstrings: `graph_request`, `auth_headers`, `json_headers`, `AUTHORITY_BASE`, `LOGIN_TIMEOUT`, `msal_error`, `remember_tenant`
- `promote/` no longer imports `upload/` for Graph calls
- `fake_metadata` fixture moved to the root `tests/conftest.py` (used by both `graph` and `upload` tests)
- Six new direct `graph_request` tests (headers, 401 mapping, empty body, `ok_statuses`); the transport retry tests now call `graph_request` directly instead of through Intune wrappers
- `docs/api/index.md` code-organization tree and mkdocs nav updated

No behavior change.

## Testing

- `ruff check`, `black --check`, `pyright` clean
- 822 tests pass, including integration
- `mkdocs build --strict` clean
- Reviewer verdict: ship, no findings
- No remaining references to `napt.upload.auth`, `napt.upload.entra`, or `napt.upload.graph`

## Checklist

- [x] Formatting, lint, and type check pass
- [x] Tests pass
- [x] Docs updated
- [x] No changelog entry needed (no user-facing impact)