### PR TITLE
refactor: Empty package inits, import from defining modules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -183,9 +183,20 @@ Domain types and internal types stay co-located with their logic.
 
 ## CLI Structure
 
-**Strict one module per top-level command.** `napt/cli/<command>.py` owns everything about `napt <command>`: its `cmd_*` handler(s), its parser definition in a `register(subparsers)` hook, and any helpers only that command uses. `napt/cli/__init__.py` only assembles the top-level parser, calls each module's `register`, and dispatches — no command logic there.
+**Strict one module per top-level command.** `napt/cli/<command>.py` owns everything about `napt <command>`: its `cmd_*` handler(s), its parser definition in a `register(subparsers)` hook, and any helpers only that command uses. `napt/cli/main.py` only assembles the top-level parser, calls each module's `register`, and dispatches — no command logic there.
 
-**Adding a command:** create `napt/cli/<command>.py` with `cmd_<command>` and `register`, call `register` from `main()` in `__init__.py`, and add `tests/cli/test_<command>.py`. A command with subcommands (`auth`, `promote`) still gets exactly one module. Never combine two commands in one module.
+**Adding a command:** create `napt/cli/<command>.py` with `cmd_<command>` and `register`, call `register` from `main()` in `napt/cli/main.py`, and add `tests/cli/test_<command>.py`. A command with subcommands (`auth`, `promote`) still gets exactly one module. Never combine two commands in one module.
+
+---
+
+## Imports
+
+**Package `__init__.py` files are docstring-only — no re-exports.** Import every name from its defining module: `from napt.state.cache import load_cache`, never `from napt.state import load_cache`. This keeps the import graph equal to the real dependencies, makes circular imports through package inits structurally impossible, and keeps CLI startup from loading subsystems a command doesn't use.
+
+Exceptions:
+
+- `napt/__init__.py` — package metadata dunders (`__version__`, ...) only.
+- `napt/discovery/__init__.py` — imports the strategy modules so they self-register; no name re-exports.
 
 ---
 

--- a/.claude/agents/napt-reviewer.md
+++ b/.claude/agents/napt-reviewer.md
@@ -63,7 +63,8 @@ Review the diff against the rules in these CLAUDE.md sections:
 - **`Exceptions`** — is each `raise` using the right type for the error domain? Is public API using custom types and private helpers using built-ins?
 - **`results.py Scope`** — only public API return types allowed in `napt/results.py`
 - **`Console Output`** — ASCII-only applies to print(), logger, CLI strings (not docstrings / comments / JSON / YAML)
-- **`CLI Structure`** — strict one module per top-level command under `napt/cli/` (`napt/cli/<command>.py` owns its `cmd_*` handlers and `register(subparsers)` hook); `__init__.py` assembles and dispatches only. Flag any new command added outside its own module, two commands sharing a module, or command logic growing in `__init__.py`.
+- **`CLI Structure`** — strict one module per top-level command under `napt/cli/` (`napt/cli/<command>.py` owns its `cmd_*` handlers and `register(subparsers)` hook); `main.py` assembles and dispatches only. Flag any new command added outside its own module, two commands sharing a module, or command logic growing in `main.py` or `__init__.py`.
+- **`Imports`** — package `__init__.py` files are docstring-only; names are imported from their defining module (`from napt.state.cache import load_cache`, never `from napt.state import load_cache`). Flag new re-exports in any `__init__.py` and new imports that name a package instead of the defining module. Consult the section for the three sanctioned exceptions.
 
 ### Project principles
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -2,6 +2,8 @@
 
 ::: napt.cli
 
+::: napt.cli.main
+
 ::: napt.cli.auth
 
 ::: napt.cli.build

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -2,3 +2,6 @@
 
 ::: napt.config
 
+::: napt.config.loader
+
+::: napt.config.defaults

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -27,6 +27,7 @@ napt/
 │   └── template.py             # PSADT template generation
 │
 ├── cli/                     # Command-line interface (one module per command)
+│   ├── main.py                 # Parser assembly and dispatch
 │   ├── auth.py                 # napt auth login/logout/status/setup
 │   ├── build.py                # napt build
 │   ├── discover.py             # napt discover
@@ -120,7 +121,7 @@ Result (dataclass)
 ## Extending NAPT
 
 - **New discovery strategy:** Implement `DiscoveryStrategy`, register with `register_strategy()`, add to `discovery/__init__.py`
-- **New CLI command:** Create `napt/cli/<command>.py` with the `cmd_<name>()` handler and a `register(subparsers)` hook, call `register` from `main()` in `napt/cli/__init__.py`, and add `tests/cli/test_<command>.py` (strict one module per command)
+- **New CLI command:** Create `napt/cli/<command>.py` with the `cmd_<name>()` handler and a `register(subparsers)` hook, call `register` from `main()` in `napt/cli/main.py`, and add `tests/cli/test_<command>.py` (strict one module per command)
 - **New config option:** Update schema in `config/loader.py`, add validation in `validation.py`, document in recipe schema
 
 ## See Also

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -49,42 +49,9 @@ __author__ = "Roger Cibrian"
 __license__ = "Apache-2.0"
 __description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"
 
-# Re-export commonly used functions for convenience
-from napt.config import load_effective_config
-from napt.discovery.manager import discover_recipe
-from napt.download import download_file
-from napt.exceptions import (
-    ConfigError,
-    NAPTError,
-    NetworkError,
-    PackagingError,
-)
-from napt.results import (
-    BuildResult,
-    DiscoverResult,
-    PackageResult,
-    ValidationResult,
-)
-from napt.validation import validate_recipe
-from napt.versioning import compare, is_newer
-
 __all__ = [
-    "__version__",
     "__author__",
-    "__license__",
-    "BuildResult",
-    "DiscoverResult",
-    "PackageResult",
-    "ValidationResult",
     "__description__",
-    "discover_recipe",
-    "validate_recipe",
-    "load_effective_config",
-    "download_file",
-    "compare",
-    "is_newer",
-    "NAPTError",
-    "ConfigError",
-    "NetworkError",
-    "PackagingError",
+    "__license__",
+    "__version__",
 ]

--- a/napt/build/__init__.py
+++ b/napt/build/__init__.py
@@ -12,36 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""PSADT package building for NAPT.
+
+Builds PSAppDeployToolkit packages from recipes and downloaded installers:
+PSADT release management, script generation, file copying, and branding
+application.
+
+Modules:
+    manager - Package building orchestration (build_package).
+    packager - .intunewin package creation (create_intunewin).
+    template - Invoke-AppDeployToolkit.ps1 generation.
+    icons - Icon extraction from installers.
+    registry_scripts - Detection/requirements script generation (registry).
+    msix_scripts - Detection/requirements script generation (MSIX).
 """
-PSADT package building for NAPT.
-
-This module handles building PSAppDeployToolkit packages from recipes and
-downloaded installers. It orchestrates PSADT release management, script
-generation, file copying, and branding application.
-
-Example:
-    from pathlib import Path
-    from napt.build import build_package, create_intunewin
-
-    # Build PSADT package
-    build_result = build_package(
-        recipe_path=Path("recipes/Google/chrome.yaml"),
-        downloads_dir=Path("downloads"),
-        verbose=True
-    )
-
-    print(f"Built: {build_result.build_dir}")
-
-    # Create .intunewin
-    package_result = create_intunewin(
-        build_dir=build_result.build_dir,
-        verbose=True
-    )
-
-    print(f"Package: {package_result.package_path}")
-"""
-
-from .manager import build_package
-from .packager import create_intunewin
-
-__all__ = ["build_package", "create_intunewin"]

--- a/napt/build/manager.py
+++ b/napt/build/manager.py
@@ -28,7 +28,7 @@ Example:
     Basic usage:
         ```python
         from pathlib import Path
-        from napt.build import build_package
+        from napt.build.manager import build_package
 
         result = build_package(
             recipe_path=Path("recipes/Google/chrome.yaml"),
@@ -62,11 +62,11 @@ from napt.build.registry_scripts import (
     generate_detection_script,
     generate_requirements_script,
 )
-from napt.config import load_effective_config
+from napt.config.loader import load_effective_config
 from napt.exceptions import ConfigError, PackagingError
-from napt.psadt import get_psadt_release
+from napt.psadt.release import get_psadt_release
 from napt.results import BuildResult
-from napt.state import deployment_state_path, load_deployment_state
+from napt.state.deployment import deployment_state_path, load_deployment_state
 from napt.versioning.msi import (
     MSIMetadata,
     extract_msi_metadata,
@@ -196,7 +196,7 @@ def _get_installer_version(
 
     # Non-MSI/MSIX: fall back to discovery cache
     if cache_file and cache_file.exists():
-        from napt.state import load_cache
+        from napt.state.cache import load_cache
 
         logger.verbose("BUILD", "Using version from discovery cache")
         cache_data = load_cache(cache_file)
@@ -274,7 +274,7 @@ def _find_installer_file(
     # Strategy 2: Extract filename from discovery cache URL (for web_scrape, etc.)
     if cache_file and cache_file.exists():
         try:
-            from napt.state import load_cache
+            from napt.state.cache import load_cache
 
             cache_data = load_cache(cache_file)
             app_entry = cache_data.get("apps", {}).get(app_id, {})
@@ -1338,7 +1338,7 @@ def build_package(
         "update_only" generates detection and requirements.
     """
     from napt.logging import get_global_logger
-    from napt.state import cache_file_path
+    from napt.state.cache import cache_file_path
 
     logger = get_global_logger()
     # Load configuration

--- a/napt/build/packager.py
+++ b/napt/build/packager.py
@@ -46,7 +46,7 @@ import subprocess
 
 import requests
 
-from napt.download import make_session
+from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError, PackagingError
 from napt.results import PackageResult
 

--- a/napt/cli/__init__.py
+++ b/napt/cli/__init__.py
@@ -14,9 +14,6 @@
 
 """Command-line interface for NAPT.
 
-This package provides the main CLI entry point for the napt tool, offering
-commands for recipe validation, package building, and deployment management.
-
 Commands:
 
     init: Initialize a new NAPT project
@@ -31,25 +28,9 @@ Commands:
 
 Each command lives in its own module named after it -- `napt/cli/validate.py`
 owns `napt validate` -- holding the command's `cmd_*` handlers and a
-`register(subparsers)` hook that adds its parser. This module assembles the
-top-level parser, calls each command's `register`, and dispatches to the
-selected handler.
-
-Example:
-    Validate recipe syntax:
-        ```bash
-        $ napt validate recipes/Google/chrome.yaml
-        ```
-
-    Discover latest version:
-        ```bash
-        $ napt discover recipes/Google/chrome.yaml
-        ```
-
-    Enable verbose output:
-        ```bash
-        $ napt discover recipes/Google/chrome.yaml --verbose
-        ```
+`register(subparsers)` hook that adds its parser. `napt/cli/main.py`
+assembles the top-level parser, calls each command's `register`, and
+dispatches to the selected handler.
 
 Exit Codes:
 
@@ -60,66 +41,4 @@ Note:
     The CLI uses argparse for command parsing (stdlib, zero dependencies).
     Verbose mode shows full tracebacks on errors for debugging.
     Debug mode implies verbose mode and shows detailed configuration dumps.
-
 """
-
-from __future__ import annotations
-
-import argparse
-from importlib.metadata import version
-import sys
-
-from . import (
-    auth,
-    build,
-    discover,
-    init,
-    package,
-    promote,
-    status,
-    upload,
-    validate,
-)
-
-__all__ = ["main"]
-
-
-def main() -> None:
-    """Main entry point for the napt CLI.
-
-    This function is registered as the 'napt' console script in pyproject.toml.
-    """
-    parser = argparse.ArgumentParser(
-        prog="napt",
-        description="NAPT - Not a Pkg Tool for Windows/Intune packaging with PSADT",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"napt {version('napt')}",
-    )
-
-    subparsers = parser.add_subparsers(
-        dest="command",
-        help="Available commands",
-        required=True,
-    )
-
-    validate.register(subparsers)
-    discover.register(subparsers)
-    build.register(subparsers)
-    package.register(subparsers)
-    init.register(subparsers)
-    upload.register(subparsers)
-    auth.register(subparsers)
-    promote.register(subparsers)
-    status.register(subparsers)
-
-    # Parse and dispatch
-    args = parser.parse_args()
-
-    # Call the appropriate command handler
-    exit_code = args.func(args)
-    sys.exit(exit_code)

--- a/napt/cli/__main__.py
+++ b/napt/cli/__main__.py
@@ -14,6 +14,6 @@
 
 """Runs the NAPT CLI when invoked as `python -m napt.cli`."""
 
-from napt.cli import main
+from napt.cli.main import main
 
 main()

--- a/napt/cli/build.py
+++ b/napt/cli/build.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from napt.build import build_package
+from napt.build.manager import build_package
 from napt.exceptions import ConfigError, NAPTError, NetworkError, PackagingError
 from napt.logging import get_logger, set_global_logger
 

--- a/napt/cli/main.py
+++ b/napt/cli/main.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI entry point: parser assembly and dispatch.
+
+Builds the top-level ``napt`` argument parser, calls each command
+module's ``register`` hook to add its subparser, and dispatches to the
+selected command's handler. Registered as the ``napt`` console script in
+pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import version
+import sys
+
+from napt.cli import (
+    auth,
+    build,
+    discover,
+    init,
+    package,
+    promote,
+    status,
+    upload,
+    validate,
+)
+
+
+def main() -> None:
+    """Main entry point for the napt CLI.
+
+    This function is registered as the 'napt' console script in pyproject.toml.
+    """
+    parser = argparse.ArgumentParser(
+        prog="napt",
+        description="NAPT - Not a Pkg Tool for Windows/Intune packaging with PSADT",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"napt {version('napt')}",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="command",
+        help="Available commands",
+        required=True,
+    )
+
+    validate.register(subparsers)
+    discover.register(subparsers)
+    build.register(subparsers)
+    package.register(subparsers)
+    init.register(subparsers)
+    upload.register(subparsers)
+    auth.register(subparsers)
+    promote.register(subparsers)
+    status.register(subparsers)
+
+    # Parse and dispatch
+    args = parser.parse_args()
+
+    # Call the appropriate command handler
+    exit_code = args.func(args)
+    sys.exit(exit_code)

--- a/napt/cli/package.py
+++ b/napt/cli/package.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from napt.build import create_intunewin
-from napt.config import load_effective_config
+from napt.build.packager import create_intunewin
+from napt.config.loader import load_effective_config
 from napt.exceptions import ConfigError, NAPTError, NetworkError, PackagingError
 from napt.logging import get_logger, set_global_logger
 

--- a/napt/cli/promote.py
+++ b/napt/cli/promote.py
@@ -34,17 +34,17 @@ from napt.exceptions import (
 )
 from napt.graph.intune import list_mobile_apps
 from napt.logging import get_logger, set_global_logger
-from napt.promote import (
-    apply_plan,
-    detect_drift,
+from napt.promote.applier import apply_plan
+from napt.promote.drift import detect_drift
+from napt.promote.planner import (
     load_recipe_configs,
     plan_promotions,
     plans_dir_for,
-    reconcile_publications,
     resolve_state_dir,
-    unresolvable_groups,
     write_plan_files,
 )
+from napt.promote.preflight import unresolvable_groups
+from napt.promote.reconcile import reconcile_publications
 
 
 def _describe_action(action: dict[str, Any]) -> str:

--- a/napt/cli/status.py
+++ b/napt/cli/status.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from napt.exceptions import ConfigError, StateError
 from napt.logging import get_logger, set_global_logger
-from napt.state import summarize_deployment_states
+from napt.state.deployment import summarize_deployment_states
 
 
 def cmd_status(args: argparse.Namespace) -> int:

--- a/napt/cli/upload.py
+++ b/napt/cli/upload.py
@@ -31,7 +31,7 @@ from napt.exceptions import (
     PackagingError,
 )
 from napt.logging import get_logger, set_global_logger
-from napt.upload import upload_package
+from napt.upload.manager import upload_package
 
 
 def cmd_upload(args: argparse.Namespace) -> int:

--- a/napt/cli/validate.py
+++ b/napt/cli/validate.py
@@ -24,7 +24,7 @@ import argparse
 from pathlib import Path
 from typing import Any
 
-from napt.config import load_effective_config
+from napt.config.loader import load_effective_config
 from napt.logging import get_logger, set_global_logger
 from napt.validation import validate_recipe
 

--- a/napt/config/__init__.py
+++ b/napt/config/__init__.py
@@ -14,28 +14,18 @@
 
 """Configuration loading and management for NAPT.
 
-This module provides tools for loading, merging, and validating YAML-based
-configuration files with a layered approach:
+Loads, merges, and validates YAML-based configuration files with a layered
+approach:
 
-  - Organization-wide defaults (defaults/org.yaml)
-  - Vendor-specific defaults (defaults/vendors/{Vendor}.yaml)
-  - Recipe-specific configuration (recipes/{Vendor}/{app}.yaml)
+- Organization-wide defaults (defaults/org.yaml)
+- Vendor-specific defaults (defaults/vendors/{Vendor}.yaml)
+- Recipe-specific configuration (recipes/{Vendor}/{app}.yaml)
 
 The loader performs deep merging where dicts are merged recursively and
 lists/scalars are replaced (last wins). Relative paths are resolved against
 the recipe file location for relocatability.
 
-Example:
-    Basic usage:
-        ```python
-        from pathlib import Path
-        from napt.config import load_effective_config
-
-        config = load_effective_config(Path("recipes/Google/chrome.yaml"))
-        print(config["name"])  # "Google Chrome"
-        ```
+Modules:
+    loader: The 3-layer configuration loader (load_effective_config).
+    defaults: Built-in default configuration and the org.yaml template.
 """
-
-from .loader import load_effective_config
-
-__all__ = ["load_effective_config"]

--- a/napt/config/loader.py
+++ b/napt/config/loader.py
@@ -66,7 +66,7 @@ Example:
     Basic usage:
         ```python
         from pathlib import Path
-        from napt.config import load_effective_config
+        from napt.config.loader import load_effective_config
 
         cfg = load_effective_config(Path("recipes/Google/chrome.yaml"))
         print(cfg["name"])  # Output: Google Chrome

--- a/napt/discovery/__init__.py
+++ b/napt/discovery/__init__.py
@@ -42,12 +42,12 @@ Built-in strategies:
 
 """
 
+# Importing a strategy module runs its register_strategy() call. This is
+# the one side effect a NAPT package __init__ carries: importing anything
+# under napt.discovery guarantees the built-in strategies are registered
+# before get_strategy() runs. No names are re-exported.
 from . import (
     api_github,  # noqa: F401
     api_json,  # noqa: F401
     web_scrape,  # noqa: F401
 )
-from .base import DiscoveryStrategy, get_strategy
-from .manager import discover_recipe
-
-__all__ = ["DiscoveryStrategy", "discover_recipe", "get_strategy"]

--- a/napt/discovery/api_github.py
+++ b/napt/discovery/api_github.py
@@ -61,7 +61,7 @@ from typing import Any
 import requests
 
 from napt.discovery.base import RemoteVersion
-from napt.download import make_session
+from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy

--- a/napt/discovery/api_json.py
+++ b/napt/discovery/api_json.py
@@ -76,7 +76,7 @@ from jsonpath_ng import parse as jsonpath_parse
 import requests
 
 from napt.discovery.base import RemoteVersion
-from napt.download import make_session
+from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy

--- a/napt/discovery/base.py
+++ b/napt/discovery/base.py
@@ -76,10 +76,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-from napt.download import download_file
+from napt.download.download import download_file
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
-from napt.versioning import is_newer
+from napt.versioning.compare import is_newer
 
 
 @dataclass(frozen=True)

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -60,13 +60,11 @@ from napt.discovery.url_download import run_url_download
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import DiscoverResult
-from napt.state import (
-    cache_file_path,
+from napt.state.cache import cache_file_path, load_cache, save_cache
+from napt.state.deployment import (
     deployment_state_path,
-    load_cache,
     load_deployment_state,
     record_pending,
-    save_cache,
     save_deployment_state,
 )
 

--- a/napt/discovery/url_download.py
+++ b/napt/discovery/url_download.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from napt.download import download_file
+from napt.download.download import download_file
 from napt.exceptions import ConfigError, NetworkError, NotModifiedError
 from napt.versioning.msi import extract_msi_metadata
 

--- a/napt/discovery/web_scrape.py
+++ b/napt/discovery/web_scrape.py
@@ -79,7 +79,7 @@ from bs4 import BeautifulSoup
 import requests
 
 from napt.discovery.base import RemoteVersion
-from napt.download import make_session
+from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
 from .base import register_strategy

--- a/napt/download/__init__.py
+++ b/napt/download/__init__.py
@@ -17,23 +17,6 @@
 Provides robust HTTP(S) file download with conditional requests, retry logic,
 atomic writes, and integrity verification.
 
-Example:
-    Basic usage:
-        ```python
-        from pathlib import Path
-        from napt.download import download_file
-
-        result = download_file(
-            url="https://example.com/installer.msi",
-            destination_folder=Path("./downloads/my-app"),
-        )
-        print(f"Downloaded to {result.file_path} with hash {result.sha256}")
-        ```
-
+Modules:
+    download - HTTP downloads with ETag support (download_file, make_session).
 """
-
-from napt.exceptions import NotModifiedError
-
-from .download import download_file, make_session
-
-__all__ = ["download_file", "make_session", "NotModifiedError"]

--- a/napt/download/download.py
+++ b/napt/download/download.py
@@ -34,7 +34,7 @@ Example:
     Basic download:
         ```python
         from pathlib import Path
-        from napt.download import download_file
+        from napt.download.download import download_file
 
         result = download_file(
             url="https://example.com/installer.msi",

--- a/napt/exceptions.py
+++ b/napt/exceptions.py
@@ -21,7 +21,7 @@ callers to catch all NAPT errors with a single except clause if needed.
 Example:
     Catching specific error types:
         ```python
-        from napt.discovery import discover_recipe
+        from napt.discovery.manager import discover_recipe
         from napt.exceptions import ConfigError, NetworkError
 
         try:

--- a/napt/promote/__init__.py
+++ b/napt/promote/__init__.py
@@ -32,31 +32,11 @@ on ``plan --check-drift``, and is always reported, never corrected.
 Publications whose deployment state writeback was lost (e.g. a failed CI
 push after a successful upload) are recovered from tenant evidence on
 every apply and on ``plan --reconcile``.
+
+Modules:
+    planner - Plan computation and plan file writing.
+    applier - Plan execution against Intune.
+    preflight - Group resolution validation before assignment.
+    drift - Assignment drift detection.
+    reconcile - Lost publication writeback recovery.
 """
-
-from .applier import apply_plan, load_plan_file
-from .drift import detect_drift
-from .planner import (
-    load_recipe_configs,
-    plan_path_for,
-    plan_promotions,
-    plans_dir_for,
-    resolve_state_dir,
-    write_plan_files,
-)
-from .preflight import unresolvable_groups
-from .reconcile import reconcile_publications
-
-__all__ = [
-    "apply_plan",
-    "detect_drift",
-    "load_plan_file",
-    "load_recipe_configs",
-    "plan_path_for",
-    "plan_promotions",
-    "plans_dir_for",
-    "reconcile_publications",
-    "resolve_state_dir",
-    "unresolvable_groups",
-    "write_plan_files",
-]

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -71,7 +71,7 @@ from napt.promote.planner import (
 )
 from napt.promote.preflight import unresolvable_groups
 from napt.promote.reconcile import reconcile_publications
-from napt.state import (
+from napt.state.deployment import (
     deployment_state_path,
     load_deployment_state,
     save_deployment_state,

--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -53,7 +53,7 @@ from napt.graph.intune import (
     get_app_assignments,
     resolve_assignment_target,
 )
-from napt.state import deployment_state_path, load_deployment_state
+from napt.state.deployment import deployment_state_path, load_deployment_state
 from napt.state.stamp import ENTRY_INSTALL, ENTRY_UPDATE, parse_stamp
 
 __all__ = ["detect_drift"]

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -55,10 +55,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt.config import load_effective_config
+from napt.config.loader import load_effective_config
 from napt.exceptions import ConfigError, StateError
 from napt.logging import get_global_logger
-from napt.state import deployment_state_path, load_deployment_state
+from napt.state.deployment import deployment_state_path, load_deployment_state
 
 __all__ = [
     "load_recipe_configs",

--- a/napt/promote/reconcile.py
+++ b/napt/promote/reconcile.py
@@ -49,7 +49,7 @@ from typing import Any
 
 from napt.graph.intune import get_mobile_app
 from napt.logging import get_global_logger
-from napt.state import (
+from napt.state.deployment import (
     deployment_state_path,
     load_deployment_state,
     record_published,

--- a/napt/psadt/__init__.py
+++ b/napt/psadt/__init__.py
@@ -14,30 +14,9 @@
 
 """PSAppDeployToolkit integration for NAPT.
 
-This module handles PSAppDeployToolkit (PSADT) release management, caching,
-and integration with NAPT's build system.
+Handles PSAppDeployToolkit (PSADT) release management, caching, and
+integration with NAPT's build system.
 
-Example:
-    Basic usage:
-        ```python
-        from pathlib import Path
-        from napt.psadt import get_psadt_release, fetch_latest_psadt_version
-
-        # Get latest version
-        latest = fetch_latest_psadt_version()
-        print(f"Latest PSADT: {latest}")
-
-        # Download and cache
-        psadt_path = get_psadt_release("latest", Path("cache/psadt"))
-        print(f"PSADT cached at: {psadt_path}")
-        ```
-
+Modules:
+    release - PSADT release download, caching, and version resolution.
 """
-
-from .release import (
-    fetch_latest_psadt_version,
-    get_psadt_release,
-    is_psadt_cached,
-)
-
-__all__ = ["fetch_latest_psadt_version", "get_psadt_release", "is_psadt_cached"]

--- a/napt/psadt/release.py
+++ b/napt/psadt/release.py
@@ -29,7 +29,7 @@ Example:
     Get and cache PSADT releases:
         ```python
         from pathlib import Path
-        from napt.psadt import get_psadt_release, is_psadt_cached
+        from napt.psadt.release import get_psadt_release, is_psadt_cached
 
         # Get latest PSADT
         psadt_dir = get_psadt_release("latest", Path("cache/psadt"))
@@ -58,7 +58,7 @@ import zipfile
 
 import requests
 
-from napt.download import make_session
+from napt.download.download import make_session
 from napt.exceptions import NetworkError, PackagingError
 
 PSADT_REPO = "PSAppDeployToolkit/PSAppDeployToolkit"

--- a/napt/results.py
+++ b/napt/results.py
@@ -25,7 +25,7 @@ Example:
     Using result types:
         ```python
         from pathlib import Path
-        from napt.discovery import discover_recipe
+        from napt.discovery.manager import discover_recipe
         from napt.results import DiscoverResult
 
         result: DiscoverResult = discover_recipe(

--- a/napt/state/__init__.py
+++ b/napt/state/__init__.py
@@ -39,7 +39,7 @@ Example:
     Reading the discovery cache:
         ```python
         from pathlib import Path
-        from napt.state import load_cache
+        from napt.state.cache import load_cache
 
         data = load_cache(Path("cache/discovery.json"))
         entry = data.get("apps", {}).get("napt-chrome")
@@ -48,7 +48,10 @@ Example:
     Reading deployment state:
         ```python
         from pathlib import Path
-        from napt.state import deployment_state_path, load_deployment_state
+        from napt.state.deployment import (
+            deployment_state_path,
+            load_deployment_state,
+        )
 
         path = deployment_state_path(Path("state/deployment"), "napt-chrome")
         state = load_deployment_state(path)
@@ -56,35 +59,3 @@ Example:
         ```
 
 """
-
-from .cache import (
-    DiscoveryCache,
-    cache_file_path,
-    create_default_cache,
-    load_cache,
-    save_cache,
-)
-from .deployment import (
-    create_default_deployment_state,
-    deployment_state_path,
-    load_deployment_state,
-    record_pending,
-    record_published,
-    save_deployment_state,
-    summarize_deployment_states,
-)
-
-__all__ = [
-    "DiscoveryCache",
-    "cache_file_path",
-    "create_default_cache",
-    "create_default_deployment_state",
-    "deployment_state_path",
-    "load_cache",
-    "load_deployment_state",
-    "record_pending",
-    "record_published",
-    "save_cache",
-    "save_deployment_state",
-    "summarize_deployment_states",
-]

--- a/napt/state/cache.py
+++ b/napt/state/cache.py
@@ -37,7 +37,7 @@ Example:
     High-level API with DiscoveryCache:
         ```python
         from pathlib import Path
-        from napt.state import DiscoveryCache
+        from napt.state.cache import DiscoveryCache
 
         cache = DiscoveryCache(Path("cache/discovery.json"))
         cache.load()
@@ -53,7 +53,7 @@ Example:
     Low-level API with functions:
         ```python
         from pathlib import Path
-        from napt.state import load_cache, save_cache
+        from napt.state.cache import load_cache, save_cache
 
         data = load_cache(Path("cache/discovery.json"))
         # ... modify cache dict ...

--- a/napt/state/deployment.py
+++ b/napt/state/deployment.py
@@ -49,7 +49,7 @@ Example:
     Recording a discovered release:
         ```python
         from pathlib import Path
-        from napt.state import (
+        from napt.state.deployment import (
             deployment_state_path,
             load_deployment_state,
             record_pending,

--- a/napt/upload/__init__.py
+++ b/napt/upload/__init__.py
@@ -26,7 +26,7 @@ Example:
     Upload a packaged app to Intune:
         ```python
         from pathlib import Path
-        from napt.upload import upload_package
+        from napt.upload.manager import upload_package
 
         result = upload_package(Path("recipes/Google/chrome.yaml"))
         print(f"Intune app ID: {result.intune_app_id}")
@@ -34,7 +34,3 @@ Example:
         ```
 
 """
-
-from .manager import upload_package
-
-__all__ = ["upload_package"]

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -22,7 +22,7 @@ Example:
     Upload a packaged app to Intune:
         ```python
         from pathlib import Path
-        from napt.upload import upload_package
+        from napt.upload.manager import upload_package
 
         result = upload_package(Path("recipes/Google/chrome.yaml"))
         print(f"Created Intune app: {result.intune_app_id}")
@@ -41,7 +41,7 @@ from typing import Any
 
 from napt.auth.credentials import get_access_token
 from napt.build.icons import MAX_ICON_BYTES
-from napt.config import load_effective_config
+from napt.config.loader import load_effective_config
 from napt.exceptions import ConfigError, PackagingError
 from napt.graph.intune import (
     commit_content_version,
@@ -57,7 +57,7 @@ from napt.graph.intune import (
 )
 from napt.logging import get_global_logger
 from napt.results import UploadResult
-from napt.state import (
+from napt.state.deployment import (
     deployment_state_path,
     load_deployment_state,
     record_published,
@@ -729,7 +729,7 @@ def upload_package(recipe_path: Path, force: bool = False) -> UploadResult:
         Upload and print the resulting Intune app IDs:
             ```python
             from pathlib import Path
-            from napt.upload import upload_package
+            from napt.upload.manager import upload_package
 
             result = upload_package(Path("recipes/Google/chrome.yaml"))
             print(f"Install app ID: {result.intune_app_id}")

--- a/napt/validation.py
+++ b/napt/validation.py
@@ -52,7 +52,7 @@ from typing import Any
 
 import yaml
 
-from napt.discovery import get_strategy
+from napt.discovery.base import get_strategy
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import ValidationResult

--- a/napt/versioning/__init__.py
+++ b/napt/versioning/__init__.py
@@ -14,85 +14,21 @@
 
 """Version comparison and extraction utilities for NAPT.
 
-This package provides tools for comparing version strings and extracting
-version information from MSI and MSIX files. It supports multiple
-comparison strategies and handles various versioning schemes including
-semantic versioning, numeric versions, and prerelease tags.
-
-Modules:
-    compare
-        Core version comparison logic with semver-like parsing and robust fallbacks.
-    msi
-        MSI metadata extraction using PowerShell COM (Windows) or msitools (Linux/macOS).
-    msix
-        MSIX metadata extraction using zipfile and XML parsing (cross-platform).
-
-Version Comparison Strategy:
+Compares version strings and extracts version information from MSI and
+MSIX files. Supports multiple comparison strategies and handles various
+versioning schemes including semantic versioning, numeric versions, and
+prerelease tags.
 
 Versions are compared using semver-like parsing: X.Y.Z tuples with optional
 prerelease and build metadata. Handles prerelease tags (alpha, beta, rc, dev)
 and correctly orders 1.0.0-alpha < 1.0.0-beta < 1.0.0-rc < 1.0.0. Falls back
-to lexicographic comparison for non-version-like strings (build IDs, timestamps).
+to lexicographic comparison for non-version-like strings (build IDs,
+timestamps).
 
-Example:
-    Basic version comparison:
-        ```python
-        from napt.versioning import compare, is_newer
-
-        # Compare versions (returns 1 for newer, 0 for equal, -1 for older)
-        result = compare("1.2.0", "1.1.9")  # Returns: 1
-
-        # Check if version is newer
-        is_newer_version = is_newer("1.2.0", "1.1.9")  # Returns: True
-        ```
-
-    Prerelease handling:
-        ```python
-        # rc is newer than beta
-        compare("1.0.0-rc.1", "1.0.0-beta.5")  # Returns: 1
-
-        # Release is newer than prerelease
-        compare("1.0.0", "1.0.0-rc.1")  # Returns: 1
-        ```
-
-    MSI metadata extraction:
-        ```python
-        from pathlib import Path
-        from napt.versioning import extract_msi_metadata
-
-        metadata = extract_msi_metadata(Path("installer.msi"))
-        print(f"{metadata.product_name} {metadata.product_version} ({metadata.architecture})")
-        # e.g., "Google Chrome 131.0.6778.86 (x64)"
-        ```
-
-    MSIX metadata extraction:
-        ```python
-        from pathlib import Path
-        from napt.versioning import extract_msix_metadata
-
-        metadata = extract_msix_metadata(Path("Slack.msix"))
-        print(f"{metadata.display_name} {metadata.version} ({metadata.architecture})")
-        # e.g., "Slack 4.49.81.0 (x64)"
-        ```
-
-Note:
-    - Version comparison is format-agnostic: no network or file I/O
-    - MSI extraction works cross-platform with appropriate backends
-    - MSIX extraction works cross-platform with no external dependencies
-    - Prerelease ordering follows common conventions but allows custom tags
-
+Modules:
+    compare - Version comparison with semver-like parsing (compare, is_newer).
+    msi - MSI metadata extraction using PowerShell COM (Windows) or
+        msitools (Linux/macOS).
+    msix - MSIX metadata extraction using zipfile and XML parsing
+        (cross-platform).
 """
-
-from .compare import (
-    compare,
-    is_newer,
-    version_key,
-)
-from .msi import (
-    MSIMetadata,
-    extract_msi_metadata,
-)
-from .msix import (
-    MSIXMetadata,
-    extract_msix_metadata,
-)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.scripts]
-napt = "napt.cli:main"
+napt = "napt.cli.main:main"
 
 [project.urls]
 Documentation = "https://rogercibrian.github.io/notapkgtool"

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -11,7 +11,7 @@ class TestCmdStatus:
 
     def test_table_lists_apps(self, tmp_path, capsys):
         """Tests that the text table lists each app with its versions."""
-        from napt.state import (
+        from napt.state.deployment import (
             create_default_deployment_state,
             deployment_state_path,
             save_deployment_state,
@@ -39,7 +39,7 @@ class TestCmdStatus:
         """Tests that JSON output parses and carries the summary."""
         import json as json_module
 
-        from napt.state import (
+        from napt.state.deployment import (
             create_default_deployment_state,
             deployment_state_path,
             save_deployment_state,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,7 @@ def real_psadt_template(real_psadt_cache_dir: Path) -> Path:
 
     # Only download if not already cached
     if not version_dir.exists():
-        from napt.psadt import get_psadt_release
+        from napt.psadt.release import get_psadt_release
 
         # Download real PSADT (this is expensive, runs once per session)
         get_psadt_release(version, real_psadt_cache_dir)

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -11,13 +11,13 @@ import pytest
 import yaml
 
 from napt.exceptions import ConfigError, StateError
-from napt.promote import (
+from napt.promote.planner import (
     plan_path_for,
     plan_promotions,
     resolve_state_dir,
     write_plan_files,
 )
-from napt.state import (
+from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
     save_deployment_state,

--- a/tests/test_promote_apply.py
+++ b/tests/test_promote_apply.py
@@ -14,8 +14,9 @@ import yaml
 
 from napt.exceptions import NetworkError, StateError
 from napt.graph.intune import VIRTUAL_TARGETS
-from napt.promote import apply_plan, load_plan_file, plan_path_for
-from napt.state import (
+from napt.promote.applier import apply_plan, load_plan_file
+from napt.promote.planner import plan_path_for
+from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
     load_deployment_state,

--- a/tests/test_promote_drift.py
+++ b/tests/test_promote_drift.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from napt.promote import detect_drift
-from napt.state import (
+from napt.promote.drift import detect_drift
+from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
     save_deployment_state,
@@ -40,7 +40,7 @@ def _config(
     install_groups: list[str] | None = None,
 ) -> dict[str, Any]:
     """Builds an effective config via the real loader for realism."""
-    from napt.config import load_effective_config
+    from napt.config.loader import load_effective_config
 
     deployment: dict[str, Any] = {}
     if rings is not None:

--- a/tests/test_promote_reconcile.py
+++ b/tests/test_promote_reconcile.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import patch
 
 from napt.promote.reconcile import reconcile_publications
-from napt.state import (
+from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
     load_deployment_state,

--- a/tests/test_psadt_release.py
+++ b/tests/test_psadt_release.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
-from napt.psadt import (
+from napt.psadt.release import (
     fetch_latest_psadt_version,
     get_psadt_release,
     is_psadt_cached,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -16,19 +16,21 @@ import json
 import pytest
 
 from napt.exceptions import StateError
-from napt.state import (
+from napt.state.cache import (
     DiscoveryCache,
+    create_default_cache,
+    load_cache,
+    save_cache,
+)
+from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
-    load_cache,
     load_deployment_state,
     record_pending,
     record_published,
-    save_cache,
     save_deployment_state,
     summarize_deployment_states,
 )
-from napt.state.cache import create_default_cache
 
 
 class TestCacheFileOperations:

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import pytest
 
 from napt.exceptions import ConfigError
-from napt.versioning import compare, is_newer, version_key
+from napt.versioning.compare import compare, is_newer, version_key
 from napt.versioning.msi import _architecture_from_template
 
 

--- a/tests/upload/test_manager.py
+++ b/tests/upload/test_manager.py
@@ -14,7 +14,7 @@ import pytest
 from napt.config.defaults import DEFAULT_CONFIG
 from napt.config.loader import _deep_merge_dicts
 from napt.exceptions import NetworkError, PackagingError
-from napt.state import (
+from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
     load_deployment_state,


### PR DESCRIPTION
## Description

Makes every package `__init__.py` docstring-only and rewrites all internal imports to name the defining module (`from napt.state.cache import load_cache`, never `from napt.state import load_cache`). Also moves CLI parser assembly from `napt/cli/__init__.py` to `napt/cli/main.py`, so the CLI package follows the same rule.

## Motivation

The package-level re-exports date from an era when NAPT was being considered as a shippable Python library. That direction is settled: NAPT is a CLI, nothing external depends on package import paths, and the re-exports bought convenience nobody uses while costing real things -- every `napt` invocation imported the full dependency tree (msal, azure-identity, requests) regardless of command, and package inits acted as cycle hubs (the #106 circular import existed only through `upload/__init__`'s re-export). With empty inits the import graph equals the real module dependencies: `napt validate` now loads yaml and stdlib only, and init-mediated cycles are structurally impossible.

## Changes

- Ten package inits reduced to docstrings (`build`, `config`, `discovery`, `download`, `promote`, `psadt`, `state`, `upload`, `versioning`; `napt/__init__.py` keeps only metadata dunders)
- ~45 import sites across `napt/` and `tests/` rewritten to defining modules, including docstring examples so rendered docs show the importable form
- `napt/cli/main.py` now owns parser assembly and dispatch; the console script entry point is `napt.cli.main:main`; `napt/cli/__init__.py` is docstring-only
- Two sanctioned exceptions, documented in CLAUDE.md (`Imports` section) and enforced by the reviewer agent:
    - `napt/__init__.py` -- metadata dunders (slated for removal via `importlib.metadata` in a follow-up)
    - `napt/discovery/__init__.py` -- imports strategy modules for their self-registration side effect (slated for replacement with an explicit registry in a follow-up)
- `docs/api/config.md` renders `loader` and `defaults`; `docs/api/cli.md` renders `main`; developer-reference tree and instructions updated

No user-facing behavior change.

## Testing

- `ruff check`, `black --check`, `pyright` clean
- 823 tests pass, including integration and the fresh-interpreter import guard
- `mkdocs build --strict` clean
- Repo-wide grep: no remaining package-level imports outside the two sanctioned exceptions
- Console script reinstalled and smoke-tested: `napt --version`, `python -m napt.cli --version`, `napt validate --help`
- Reviewer verdict: ship, no findings

## Checklist

- [x] Formatting, lint, and type check pass
- [x] Tests pass
- [x] Docs updated
- [x] No changelog entry needed (no user-facing impact)