### PR TITLE
refactor: Switch to explicit strategy registry

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -193,10 +193,9 @@ Domain types and internal types stay co-located with their logic.
 
 **Package `__init__.py` files are docstring-only — no re-exports.** Import every name from its defining module: `from napt.state.cache import load_cache`, never `from napt.state import load_cache`. This keeps the import graph equal to the real dependencies, makes circular imports through package inits structurally impossible, and keeps CLI startup from loading subsystems a command doesn't use.
 
-Exceptions:
+Exception:
 
 - `napt/__init__.py` — package metadata dunders (`__version__`, ...) only.
-- `napt/discovery/__init__.py` — imports the strategy modules so they self-register; no name re-exports.
 
 ---
 

--- a/.claude/agents/napt-reviewer.md
+++ b/.claude/agents/napt-reviewer.md
@@ -64,7 +64,7 @@ Review the diff against the rules in these CLAUDE.md sections:
 - **`results.py Scope`** — only public API return types allowed in `napt/results.py`
 - **`Console Output`** — ASCII-only applies to print(), logger, CLI strings (not docstrings / comments / JSON / YAML)
 - **`CLI Structure`** — strict one module per top-level command under `napt/cli/` (`napt/cli/<command>.py` owns its `cmd_*` handlers and `register(subparsers)` hook); `main.py` assembles and dispatches only. Flag any new command added outside its own module, two commands sharing a module, or command logic growing in `main.py` or `__init__.py`.
-- **`Imports`** — package `__init__.py` files are docstring-only; names are imported from their defining module (`from napt.state.cache import load_cache`, never `from napt.state import load_cache`). Flag new re-exports in any `__init__.py` and new imports that name a package instead of the defining module. Consult the section for the three sanctioned exceptions.
+- **`Imports`** — package `__init__.py` files are docstring-only; names are imported from their defining module (`from napt.state.cache import load_cache`, never `from napt.state import load_cache`). Flag new re-exports in any `__init__.py` and new imports that name a package instead of the defining module. Consult the section for the sanctioned exception (`napt/__init__.py` metadata dunders).
 
 ### Project principles
 

--- a/docs/api/discovery.md
+++ b/docs/api/discovery.md
@@ -2,6 +2,8 @@
 
 ::: napt.discovery.base
 
+::: napt.discovery.registry
+
 ::: napt.discovery.url_download
 
 ::: napt.discovery.web_scrape

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,7 +44,8 @@ napt/
 ├── discovery/               # Discovery strategies
 │   ├── api_github.py           # GitHub Releases API strategy
 │   ├── api_json.py             # Generic JSON API strategy
-│   ├── base.py                 # Strategy protocol and registry
+│   ├── base.py                 # Strategy protocol and shared helpers
+│   ├── registry.py             # Strategy name-to-class table
 │   ├── url_download.py         # Direct URL download strategy
 │   └── web_scrape.py           # Web scraping strategy
 │
@@ -103,7 +104,7 @@ Result (dataclass)
 
 ## Key Concepts
 
-- **Discovery Strategies:** Protocol-based, stateless, registered in global registry (api_github, api_json, web_scrape). All return a `RemoteVersion` from configuration alone. The orchestrator runs the result through `resolve_with_cache` to skip the download when the version is unchanged. `url_download` is a separate flow (not a registered strategy) because it must download the file to determine the version.
+- **Discovery Strategies:** Protocol-based, stateless, listed in an explicit registry table (api_github, api_json, web_scrape). All return a `RemoteVersion` from configuration alone. The orchestrator runs the result through `resolve_with_cache` to skip the download when the version is unchanged. `url_download` is a separate flow (not a registered strategy) because it must download the file to determine the version.
 - **Configuration:** 3-layer system (org → vendor → recipe) with deep merging
 - **State Management:** Two kinds with opposite philosophies — the disposable discovery cache (`cache/discovery.json`) for download optimization, and authoritative per-app deployment state (`state/deployment/<id>.json`) recording what is published and pending
 - **Exceptions:** All NAPT domain errors use custom exceptions inheriting from `NAPTError` (ConfigError, NetworkError, PackagingError) - allows catching all NAPT errors or specific types
@@ -120,7 +121,7 @@ Result (dataclass)
 
 ## Extending NAPT
 
-- **New discovery strategy:** Implement `DiscoveryStrategy`, register with `register_strategy()`, add to `discovery/__init__.py`
+- **New discovery strategy:** Implement `DiscoveryStrategy` in a new module under `discovery/`, then add it to the table in `discovery/registry.py`
 - **New CLI command:** Create `napt/cli/<command>.py` with the `cmd_<name>()` handler and a `register(subparsers)` hook, call `register` from `main()` in `napt/cli/main.py`, and add `tests/cli/test_<command>.py` (strict one module per command)
 - **New config option:** Update schema in `config/loader.py`, add validation in `validation.py`, document in recipe schema
 

--- a/napt/discovery/__init__.py
+++ b/napt/discovery/__init__.py
@@ -12,22 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Discovery package: registry, strategies, and orchestration.
+"""Discovery package: strategies, registry, and orchestration.
 
 Two flows feed into
 [discover_recipe][napt.discovery.manager.discover_recipe]:
 
-- **Registered strategies** (api_github, api_json, web_scrape) implement
-    [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy] — they
-    discover a version and its download URL without touching the file.
-    The orchestrator runs the result through
+- **Version-first strategies** (api_github, api_json, web_scrape)
+    implement [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy]
+    — they discover a version and its download URL without touching the
+    file. The orchestrator looks them up in the explicit table in
+    [napt.discovery.registry][] and runs the result through
     [resolve_with_cache][napt.discovery.base.resolve_with_cache] to
     decide whether to skip the download.
 - **url_download** is a separate flow at
     [run_url_download][napt.discovery.url_download.run_url_download]. It
     downloads the file with HTTP conditional requests and extracts the
-    version from the file's metadata. It is not a registered strategy
-    because it cannot determine the version without the file.
+    version from the file's metadata. It is not in the registry because
+    it cannot determine the version without the file.
 
 The discovery orchestrator dispatches to one of the two flows based
 on the recipe's ``discovery.strategy`` value.
@@ -41,13 +42,3 @@ Built-in strategies:
         parses a vendor download page for both fields.
 
 """
-
-# Importing a strategy module runs its register_strategy() call. This is
-# the one side effect a NAPT package __init__ carries: importing anything
-# under napt.discovery guarantees the built-in strategies are registered
-# before get_strategy() runs. No names are re-exported.
-from . import (
-    api_github,  # noqa: F401
-    api_json,  # noqa: F401
-    web_scrape,  # noqa: F401
-)

--- a/napt/discovery/api_github.py
+++ b/napt/discovery/api_github.py
@@ -64,8 +64,6 @@ from napt.discovery.base import RemoteVersion
 from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
-from .base import register_strategy
-
 # Strategy-specific defaults for optional recipe fields.
 _DEFAULT_VERSION_PATTERN = r"v?([0-9.]+)"
 _DEFAULT_PRERELEASE = False
@@ -329,7 +327,3 @@ class ApiGithubStrategy:
                     errors.append(f"Invalid version_pattern regex: {err}")
 
         return errors
-
-
-# Register this strategy when the module is imported
-register_strategy("api_github", ApiGithubStrategy)

--- a/napt/discovery/api_json.py
+++ b/napt/discovery/api_json.py
@@ -79,8 +79,6 @@ from napt.discovery.base import RemoteVersion
 from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
-from .base import register_strategy
-
 # Strategy-specific defaults for optional recipe fields.
 _DEFAULT_METHOD = "GET"
 _DEFAULT_TIMEOUT = 30
@@ -325,7 +323,3 @@ class ApiJsonStrategy:
             errors.append("discovery.body must be a dictionary")
 
         return errors
-
-
-# Register this strategy when the module is imported
-register_strategy("api_json", ApiJsonStrategy)

--- a/napt/discovery/base.py
+++ b/napt/discovery/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Discovery strategy protocol, registry, and shared helpers.
+"""Discovery strategy protocol and shared helpers.
 
 A *discovery strategy* answers a single question: "what is the latest
 version of this app, and where can it be downloaded from?" Strategies
@@ -36,37 +36,13 @@ Design Philosophy:
         matched structurally; no inheritance is required.
     - Strategies are pure functions of configuration. They have no state,
         no I/O of files, and no awareness of the cache.
-    - Registration is a side effect of importing each strategy module.
+    - Dispatch is an explicit name-to-class table in
+        [napt.discovery.registry][].
     - The [resolve_with_cache][napt.discovery.base.resolve_with_cache]
         helper turns a [RemoteVersion][napt.discovery.base.RemoteVersion]
         into a [StrategyResult][napt.discovery.base.StrategyResult] by
         checking the cache and downloading if needed. Strategies don't
         call it themselves; the orchestrator does.
-
-Example:
-    Adding a new strategy to the codebase:
-        ```python
-        from napt.discovery.base import (
-            RemoteVersion, register_strategy,
-        )
-
-        class GitlabReleasesStrategy:
-            def discover(self, app_config):
-                # Query GitLab API and parse the response...
-                return RemoteVersion(
-                    version="1.2.3",
-                    download_url="https://gitlab.example.com/.../installer.msi",
-                    source="gitlab_releases",
-                )
-
-            def validate_config(self, app_config):
-                errors = []
-                if "project" not in app_config.get("discovery", {}):
-                    errors.append("Missing required field: discovery.project")
-                return errors
-
-        register_strategy("gitlab_releases", GitlabReleasesStrategy)
-        ```
 
 """
 
@@ -77,7 +53,6 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from napt.download.download import download_file
-from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.versioning.compare import is_newer
 
@@ -182,60 +157,6 @@ class DiscoveryStrategy(Protocol):
 
         """
         ...
-
-
-_STRATEGY_REGISTRY: dict[str, type[DiscoveryStrategy]] = {}
-
-
-def register_strategy(name: str, strategy_class: type[DiscoveryStrategy]) -> None:
-    """Registers a discovery strategy by name in the global registry.
-
-    Strategies call this at module import time so they're available when
-    the orchestrator looks them up. Registering the same name twice
-    overwrites the previous entry (intentional, to allow test
-    monkey-patching).
-
-    Args:
-        name: Strategy name. This is the value used in recipe YAML files
-            under ``discovery.strategy``. Use lowercase with underscores.
-        strategy_class: Class implementing
-            [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy].
-            Type checkers verify protocol compliance statically.
-
-    Note:
-        ``url_download`` is intentionally not registered here. It runs
-        through a separate code path in the orchestrator because it
-        downloads the file before it can determine the version, which
-        does not fit the version-first contract.
-
-    """
-    _STRATEGY_REGISTRY[name] = strategy_class
-
-
-def get_strategy(name: str) -> DiscoveryStrategy:
-    """Returns a discovery strategy instance by name from the registry.
-
-    Strategies are instantiated on-demand because they are stateless. The
-    strategy's module must already be imported for registration to have
-    happened.
-
-    Args:
-        name: Registered strategy name. Case-sensitive.
-
-    Returns:
-        New instance of the requested strategy.
-
-    Raises:
-        ConfigError: If the name is not registered. The message lists
-            the available strategies for troubleshooting.
-
-    """
-    if name not in _STRATEGY_REGISTRY:
-        available = ", ".join(_STRATEGY_REGISTRY.keys())
-        raise ConfigError(
-            f"Unknown discovery strategy: {name!r}. Available: {available or '(none)'}"
-        )
-    return _STRATEGY_REGISTRY[name]()
 
 
 def resolve_with_cache(

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -51,11 +51,8 @@ from typing import Any
 
 from napt import __version__
 from napt.config.loader import load_effective_config
-from napt.discovery.base import (
-    StrategyResult,
-    get_strategy,
-    resolve_with_cache,
-)
+from napt.discovery.base import StrategyResult, resolve_with_cache
+from napt.discovery.registry import get_strategy
 from napt.discovery.url_download import run_url_download
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger

--- a/napt/discovery/registry.py
+++ b/napt/discovery/registry.py
@@ -1,0 +1,76 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Explicit registry of discovery strategies.
+
+Maps each ``discovery.strategy`` recipe value to the class implementing
+it. Dispatch is a plain table lookup: nothing registers itself at import
+time, and this module's imports are what pull in the strategy
+implementations.
+
+Adding a strategy:
+    1. Implement [DiscoveryStrategy][napt.discovery.base.DiscoveryStrategy]
+        in a new module under ``napt/discovery/``.
+    2. Import the class here and add it to the table.
+
+Note:
+    ``url_download`` is intentionally absent from the table. It
+    downloads the file before it can determine the version, which does
+    not fit the version-first contract, so the discovery orchestrator
+    dispatches to
+    [run_url_download][napt.discovery.url_download.run_url_download]
+    directly.
+
+"""
+
+from __future__ import annotations
+
+from napt.discovery.api_github import ApiGithubStrategy
+from napt.discovery.api_json import ApiJsonStrategy
+from napt.discovery.base import DiscoveryStrategy
+from napt.discovery.web_scrape import WebScrapeStrategy
+from napt.exceptions import ConfigError
+
+_STRATEGIES: dict[str, type[DiscoveryStrategy]] = {
+    "api_github": ApiGithubStrategy,
+    "api_json": ApiJsonStrategy,
+    "web_scrape": WebScrapeStrategy,
+}
+
+
+def get_strategy(name: str) -> DiscoveryStrategy:
+    """Returns a discovery strategy instance by name.
+
+    Strategies are stateless, so a fresh instance is created on every
+    call.
+
+    Args:
+        name: Strategy name as written in recipe YAML under
+            ``discovery.strategy``. Case-sensitive.
+
+    Returns:
+        New instance of the requested strategy.
+
+    Raises:
+        ConfigError: If the name is not in the registry. The message
+            lists the available strategies for troubleshooting.
+
+    """
+    strategy_class = _STRATEGIES.get(name)
+    if strategy_class is None:
+        available = ", ".join(sorted(_STRATEGIES))
+        raise ConfigError(
+            f"Unknown discovery strategy: {name!r}. Available: {available}"
+        )
+    return strategy_class()

--- a/napt/discovery/web_scrape.py
+++ b/napt/discovery/web_scrape.py
@@ -82,8 +82,6 @@ from napt.discovery.base import RemoteVersion
 from napt.download.download import make_session
 from napt.exceptions import ConfigError, NetworkError
 
-from .base import register_strategy
-
 # Strategy-specific defaults for optional recipe fields.
 _DEFAULT_VERSION_FORMAT = "{0}"
 
@@ -350,7 +348,3 @@ class WebScrapeStrategy:
                 errors.append("discovery.version_format cannot be empty")
 
         return errors
-
-
-# Register this strategy when the module is imported
-register_strategy("web_scrape", WebScrapeStrategy)

--- a/napt/validation.py
+++ b/napt/validation.py
@@ -52,7 +52,7 @@ from typing import Any
 
 import yaml
 
-from napt.discovery.base import get_strategy
+from napt.discovery.registry import get_strategy
 from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import ValidationResult

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -9,7 +9,8 @@ import requests_mock
 
 from napt.discovery.api_github import ApiGithubStrategy
 from napt.discovery.api_json import ApiJsonStrategy
-from napt.discovery.base import RemoteVersion, get_strategy, register_strategy
+from napt.discovery.base import RemoteVersion
+from napt.discovery.registry import get_strategy
 from napt.discovery.url_download import run_url_download
 from napt.discovery.web_scrape import WebScrapeStrategy
 from napt.exceptions import ConfigError, NetworkError
@@ -17,7 +18,7 @@ from napt.versioning.msi import MSIMetadata
 
 
 class TestStrategyRegistry:
-    """Tests for discovery strategy registration and lookup."""
+    """Tests for discovery strategy registry lookup."""
 
     def test_get_api_github_strategy(self):
         """Tests that api_github strategy can be retrieved from the registry."""
@@ -34,23 +35,15 @@ class TestStrategyRegistry:
         with pytest.raises(ConfigError, match="Unknown discovery strategy"):
             get_strategy("url_download")
 
-    def test_register_custom_strategy(self):
-        """Tests that a custom strategy can be registered and retrieved."""
+    def test_get_api_json_strategy(self):
+        """Tests that api_json strategy can be retrieved from the registry."""
+        strategy = get_strategy("api_json")
+        assert isinstance(strategy, ApiJsonStrategy)
 
-        class CustomStrategy:
-            def discover(self, app_config):
-                return RemoteVersion(
-                    version="1.0.0",
-                    download_url="https://example.com/installer.msi",
-                    source="custom",
-                )
-
-            def validate_config(self, app_config):
-                return []
-
-        register_strategy("custom_test", CustomStrategy)
-        strategy = get_strategy("custom_test")
-        assert isinstance(strategy, CustomStrategy)
+    def test_get_web_scrape_strategy(self):
+        """Tests that web_scrape strategy can be retrieved from the registry."""
+        strategy = get_strategy("web_scrape")
+        assert isinstance(strategy, WebScrapeStrategy)
 
 
 class TestUrlDownloadFlow:


### PR DESCRIPTION
## Description

Replaces the import-side-effect strategy registration pattern with an explicit name-to-class table in the new `napt/discovery/registry.py`. Strategy modules no longer call `register_strategy()` at import time, and `napt/discovery/__init__.py` no longer needs to import them for their side effects — it is now docstring-only like every other package init.

## Motivation

The self-registration pattern made dispatch depend on hidden import order: `get_strategy()` only worked if something had already imported `napt.discovery` (or the strategy modules) to trigger registration. An explicit table makes the strategy set visible in one place, makes lookup independent of import order, and removes the last side-effecting package `__init__` — the `Imports` rule in CLAUDE.md now has a single exception (`napt/__init__.py` metadata dunders).

## Changes

- New `napt/discovery/registry.py`: explicit `_STRATEGIES` table (`api_github`, `api_json`, `web_scrape`) and `get_strategy()`, which instantiates per call and raises `ConfigError` listing available strategies for unknown names
- `napt/discovery/base.py`: removed `_STRATEGY_REGISTRY`, `register_strategy()`, and `get_strategy()`; docstring updated to describe table dispatch; dropped the library-era "adding a strategy" example
- Strategy modules (`api_github`, `api_json`, `web_scrape`): removed `register_strategy` imports and tail registration calls
- `napt/discovery/__init__.py`: docstring-only, no imports
- `napt/discovery/manager.py`, `napt/validation.py`: import `get_strategy` from `napt.discovery.registry`
- `tests/test_discovery.py`: dynamic-registration test replaced with lookup tests covering all three built-in strategies
- Docs: `registry.py` added to `docs/api/discovery.md` and the `docs/api/index.md` tree; "new discovery strategy" instructions now point at the table
- `.claude/CLAUDE.md` + reviewer agent: Imports exceptions list shrunk to `napt/__init__.py` only

## Testing

- Full test suite (including integration): 824 passed
- `ruff check`, `black`, `pyright`: clean
- `mkdocs build --strict`: clean
- Smoke: `napt --version`, `import napt.cli`, and a direct `get_strategy("web_scrape")` lookup

## Checklist

- [x] Tests pass
- [x] Lint/format/type-check clean
- [x] Docs updated (`docs/api/`)
- [x] Changelog: not needed (internal refactor, no user-facing change)