### PR TITLE
refactor: Single-source version from pyproject.toml

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -191,11 +191,9 @@ Domain types and internal types stay co-located with their logic.
 
 ## Imports
 
-**Package `__init__.py` files are docstring-only — no re-exports.** Import every name from its defining module: `from napt.state.cache import load_cache`, never `from napt.state import load_cache`. This keeps the import graph equal to the real dependencies, makes circular imports through package inits structurally impossible, and keeps CLI startup from loading subsystems a command doesn't use.
+**Package `__init__.py` files are docstring-only — no re-exports, no exceptions.** Import every name from its defining module: `from napt.state.cache import load_cache`, never `from napt.state import load_cache`. This keeps the import graph equal to the real dependencies, makes circular imports through package inits structurally impossible, and keeps CLI startup from loading subsystems a command doesn't use.
 
-Exception:
-
-- `napt/__init__.py` — package metadata dunders (`__version__`, ...) only.
+The package version is not defined in code — `pyproject.toml` is the single source. Read it at runtime with `get_version()` from `napt/version.py` (a cached `importlib.metadata` lookup); never add a `__version__` dunder.
 
 ---
 
@@ -237,7 +235,7 @@ See `docs/branching.md` for full workflow. PR template at `.github/PULL_REQUEST_
 
 **PRs:** Title in conventional commit format. Use `gh pr create` to create PRs from CLI. PR descriptions should describe what changed and why, not include setup instructions or how-to guides.
 
-**Releases:** Run `/release X.Y.Z`. Phase 1 opens the release PR (version bumps in `pyproject.toml` + `napt/__init__.py`, changelog promotion). Phase 2 (after the PR is squash-merged) tags and publishes the GitHub release. The skill includes the release notes template ([Semver 2.0.0](https://semver.org/spec/v2.0.0.html), no `v` prefix).
+**Releases:** Run `/release X.Y.Z`. Phase 1 opens the release PR (version bump in `pyproject.toml`, changelog promotion). Phase 2 (after the PR is squash-merged) tags and publishes the GitHub release. The skill includes the release notes template ([Semver 2.0.0](https://semver.org/spec/v2.0.0.html), no `v` prefix).
 
 ---
 

--- a/.claude/agents/napt-reviewer.md
+++ b/.claude/agents/napt-reviewer.md
@@ -64,7 +64,7 @@ Review the diff against the rules in these CLAUDE.md sections:
 - **`results.py Scope`** — only public API return types allowed in `napt/results.py`
 - **`Console Output`** — ASCII-only applies to print(), logger, CLI strings (not docstrings / comments / JSON / YAML)
 - **`CLI Structure`** — strict one module per top-level command under `napt/cli/` (`napt/cli/<command>.py` owns its `cmd_*` handlers and `register(subparsers)` hook); `main.py` assembles and dispatches only. Flag any new command added outside its own module, two commands sharing a module, or command logic growing in `main.py` or `__init__.py`.
-- **`Imports`** — package `__init__.py` files are docstring-only; names are imported from their defining module (`from napt.state.cache import load_cache`, never `from napt.state import load_cache`). Flag new re-exports in any `__init__.py` and new imports that name a package instead of the defining module. Consult the section for the sanctioned exception (`napt/__init__.py` metadata dunders).
+- **`Imports`** — package `__init__.py` files are docstring-only; names are imported from their defining module (`from napt.state.cache import load_cache`, never `from napt.state import load_cache`). Flag new re-exports in any `__init__.py` and new imports that name a package instead of the defining module. There are no sanctioned exceptions — `napt/__init__.py` is docstring-only too, and the version comes from `napt.version.get_version()` (a cached `importlib.metadata` lookup), never a `__version__` dunder.
 
 ### Project principles
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Prepare and ship a NAPT release. Phase 1 opens the release PR (version bumps + changelog promotion). Phase 2 (after merge) tags and publishes the GitHub release. Detects phase automatically.
+description: Prepare and ship a NAPT release. Phase 1 opens the release PR (version bump + changelog promotion). Phase 2 (after merge) tags and publishes the GitHub release. Detects phase automatically.
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash(git *) Bash(*python* -m *) Bash(gh *) Read Edit Write Glob Grep
@@ -60,9 +60,10 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
    ```
    If anything fails, stop and report. Do not continue.
 
-5. **Bump version in two places** — both must match exactly:
-   - `pyproject.toml` → `version = "X.Y.Z"` under `[project]`
-   - `napt/__init__.py` → `__version__ = "X.Y.Z"`
+5. **Bump the version** in `pyproject.toml` → `version = "X.Y.Z"` under `[project]`.
+   This is the single source of truth — runtime code reads it via
+   `napt.version.get_version()` (a cached `importlib.metadata` lookup), so no
+   other file changes.
 
 6. **Promote changelog** in `docs/changelog.md`:
    - Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (today's date in absolute form, not "today")
@@ -71,7 +72,7 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
 
 7. **Stage and commit** specific files only:
    ```
-   git add pyproject.toml napt/__init__.py docs/changelog.md
+   git add pyproject.toml docs/changelog.md
    git commit -m "chore: Prepare release X.Y.Z"
    ```
 
@@ -81,14 +82,13 @@ bump and changelog promotion — nothing from an unrelated feature branch can le
    git push -u origin chore/prepare-release-X.Y.Z
    gh pr create --title "chore: Prepare release X.Y.Z" --body "$(cat <<'EOF'
    ## Description
-   Release PR for NAPT X.Y.Z. Bumps version in `pyproject.toml` and `napt/__init__.py`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[X.Y.Z]`, and adds a fresh empty `[Unreleased]` section.
+   Release PR for NAPT X.Y.Z. Bumps the version in `pyproject.toml`, promotes the `[Unreleased]` section of `docs/changelog.md` to `[X.Y.Z]`, and adds a fresh empty `[Unreleased]` section.
 
    ## Motivation
    Cuts the X.Y.Z release.
 
    ## Changes
    - Bump `pyproject.toml` version to X.Y.Z
-   - Bump `napt/__init__.py` `__version__` to X.Y.Z
    - Promote `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` in `docs/changelog.md`
    - Add comparison link `[X.Y.Z]: ...compare/PREV...X.Y.Z`
 
@@ -121,8 +121,8 @@ the release commit, so it works from whatever branch you happen to be standing o
    subject starts with `chore: Prepare release X.Y.Z`. If none is found, stop and report —
    the merge subject may have been edited at merge time; ask the user which commit to tag.
 
-2. **Verify version files at that commit.** `git show <sha>:pyproject.toml` and
-   `git show <sha>:napt/__init__.py` must both show X.Y.Z. If not, stop and report.
+2. **Verify the version at that commit.** `git show <sha>:pyproject.toml` must show
+   X.Y.Z under `[project]`. If not, stop and report.
 
 3. **Tag the release commit and push the tag:**
    ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,7 +8,7 @@ NAPT's codebase structure matches the module organization. Here's the file struc
 
 ```
 napt/
-├── __init__.py              # Package initialization and public API exports
+├── __init__.py              # Package overview docstring
 ├── core.py                  # Main public API functions (orchestration)
 ├── detection.py             # Detection script generation for Intune Win32 apps
 ├── requirements.py          # Requirements script generation for Intune Update entries
@@ -16,6 +16,7 @@ napt/
 ├── logging.py               # Logging configuration
 ├── results.py               # Public API return types (dataclasses)
 ├── validation.py            # Recipe validation logic
+├── version.py               # NAPT's own version, read from package metadata
 │
 ├── auth/                    # Microsoft Entra ID authentication
 │   ├── credentials.py          # Token resolution and the napt auth login session

--- a/docs/api/version.md
+++ b/docs/api/version.md
@@ -1,0 +1,3 @@
+# version
+
+::: napt.version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
     - logging: api/logging.md
     - results: api/results.md
     - validation: api/validation.md
+    - version: api/version.md
     - auth: api/auth.md
     - build:
       - manager: api/build.md

--- a/napt/__init__.py
+++ b/napt/__init__.py
@@ -43,15 +43,3 @@ For full CLI documentation:
 
 For more details, see the individual module docstrings.
 """
-
-__version__ = "0.9.0"
-__author__ = "Roger Cibrian"
-__license__ = "Apache-2.0"
-__description__ = "Not a Pkg Tool - Windows/Intune packaging with PSADT"
-
-__all__ = [
-    "__author__",
-    "__description__",
-    "__license__",
-    "__version__",
-]

--- a/napt/auth/registration.py
+++ b/napt/auth/registration.py
@@ -52,7 +52,6 @@ import time
 
 import msal
 
-from napt import __version__
 from napt.auth.credentials import (
     AUTHORITY_BASE,
     LOGIN_TIMEOUT,
@@ -63,6 +62,7 @@ from napt.auth.credentials import (
 )
 from napt.exceptions import AuthError, ConfigError, NetworkError
 from napt.graph.client import graph_request, json_headers
+from napt.version import get_version
 
 __all__ = [
     "BROKER_REDIRECT_TEMPLATE",
@@ -222,7 +222,8 @@ class SetupResult:
 def _render_stamp() -> str:
     today = datetime.now(UTC).date().isoformat()
     return (
-        f"{_STAMP_PREFIX} spec={SPEC_VERSION} version={__version__} provisioned={today}"
+        f"{_STAMP_PREFIX} spec={SPEC_VERSION} "
+        f"version={get_version()} provisioned={today}"
     )
 
 
@@ -477,7 +478,7 @@ def _ensure_application(
             logger.info(
                 "AUTH",
                 f"Registration is at spec {result.previous_spec}; NAPT "
-                f"{__version__} expects spec {SPEC_VERSION}. Updating.",
+                f"{get_version()} expects spec {SPEC_VERSION}. Updating.",
             )
 
     patch: dict = {}
@@ -500,12 +501,12 @@ def _ensure_application(
     if (
         stamp is None
         or stamp["spec"] != str(SPEC_VERSION)
-        or stamp["version"] != __version__
+        or stamp["version"] != get_version()
     ):
         patch["notes"] = _with_stamp(app.get("notes"))
         result.changes.append(
             f"Stamped internal notes: {_STAMP_PREFIX} spec={SPEC_VERSION} "
-            f"version={__version__}"
+            f"version={get_version()}"
         )
 
     if patch:

--- a/napt/cli/main.py
+++ b/napt/cli/main.py
@@ -23,7 +23,6 @@ pyproject.toml.
 from __future__ import annotations
 
 import argparse
-from importlib.metadata import version
 import sys
 
 from napt.cli import (
@@ -37,6 +36,7 @@ from napt.cli import (
     upload,
     validate,
 )
+from napt.version import get_version
 
 
 def main() -> None:
@@ -53,7 +53,7 @@ def main() -> None:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"napt {version('napt')}",
+        version=f"napt {get_version()}",
     )
 
     subparsers = parser.add_subparsers(

--- a/napt/discovery/manager.py
+++ b/napt/discovery/manager.py
@@ -49,7 +49,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from napt import __version__
 from napt.config.loader import load_effective_config
 from napt.discovery.base import StrategyResult, resolve_with_cache
 from napt.discovery.registry import get_strategy
@@ -64,6 +63,7 @@ from napt.state.deployment import (
     record_pending,
     save_deployment_state,
 )
+from napt.version import get_version
 
 
 def discover_recipe(
@@ -176,7 +176,7 @@ def _load_cache(
     except FileNotFoundError:
         logger.verbose("STATE", f"Cache file not found, will create: {cache_file}")
         return {
-            "metadata": {"napt_version": __version__, "schema_version": "2"},
+            "metadata": {"napt_version": get_version(), "schema_version": "2"},
             "apps": {},
         }
     except Exception as err:
@@ -230,7 +230,7 @@ def _save_app_cache(
 
     cache_data.setdefault("apps", {})[app_id] = cache_entry
     cache_data["metadata"] = {
-        "napt_version": __version__,
+        "napt_version": get_version(),
         "last_updated": datetime.now(UTC).isoformat(),
         "schema_version": "2",
     }

--- a/napt/download/download.py
+++ b/napt/download/download.py
@@ -90,9 +90,9 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from napt import __version__
 from napt.exceptions import ConfigError, NetworkError, NotModifiedError
 from napt.results import DownloadResult
+from napt.version import get_version
 
 # Stream size per chunk (1 MiB). Tune up/down if needed.
 DEFAULT_CHUNK = 1024 * 1024
@@ -177,7 +177,8 @@ def make_session() -> requests.Session:
     s.headers.update(
         {
             "User-Agent": (
-                f"napt/{__version__} (+https://github.com/RogerCibrian/notapkgtool)"
+                f"napt/{get_version()} "
+                f"(+https://github.com/RogerCibrian/notapkgtool)"
             ),
             # Request the raw, uncompressed representation to keep ETags stable
             # across runs and avoid spurious 200s when a CDN flips to gzip.

--- a/napt/state/cache.py
+++ b/napt/state/cache.py
@@ -69,8 +69,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-from napt import __version__
 from napt.exceptions import StateError
+from napt.version import get_version
 
 
 def cache_file_path(config: dict[str, Any]) -> Path:
@@ -317,7 +317,7 @@ def create_default_cache() -> dict[str, Any]:
     """
     return {
         "metadata": {
-            "napt_version": __version__,
+            "napt_version": get_version(),
             "schema_version": "2",
             "last_updated": datetime.now(UTC).isoformat(),
         },

--- a/napt/version.py
+++ b/napt/version.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Roger Cibrian
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NAPT's own package version.
+
+``pyproject.toml`` is the single source of the version; nothing in the
+codebase hard-codes it. [get_version][napt.version.get_version] reads it
+from the installed distribution metadata and caches the result, so the
+metadata scan happens at most once per process.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from importlib.metadata import version
+
+
+@cache
+def get_version() -> str:
+    """Returns the installed NAPT package version.
+
+    Reads the version from the installed distribution metadata (sourced
+    from ``pyproject.toml`` at install time). The lookup scans installed
+    package metadata, so the result is cached for the life of the
+    process.
+
+    Returns:
+        Version string, for example ``"0.9.0"``.
+
+    """
+    return version("napt")

--- a/tests/auth/test_registration.py
+++ b/tests/auth/test_registration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 from unittest.mock import patch
 
 import pytest
@@ -35,7 +36,7 @@ def _graph_sp_response() -> dict:
 
 
 def _stamp(spec: int = registration.SPEC_VERSION, version: str | None = None) -> str:
-    version = version or registration.__version__
+    version = version or importlib.metadata.version("napt")
     return f"napt/v1 spec={spec} version={version} provisioned=2026-08-18"
 
 
@@ -628,7 +629,7 @@ def test_setup_create_writes_stamp(user_dir, bootstrap) -> None:
     assert create is not None
     assert registration._parse_stamp(create["notes"]) == {
         "spec": str(registration.SPEC_VERSION),
-        "version": registration.__version__,
+        "version": importlib.metadata.version("napt"),
         "date": create["notes"].split("provisioned=")[1],
     }
 
@@ -667,7 +668,7 @@ def test_setup_adopts_unstamped_registration_with_flag(user_dir, bootstrap) -> N
     assert registration._parse_stamp(patch["notes"]) is not None
     assert result.changes == [
         f"Stamped internal notes: napt/v1 spec={registration.SPEC_VERSION} "
-        f"version={registration.__version__}"
+        f"version={importlib.metadata.version('napt')}"
     ]
     assert credentials.load_auth_store().active == "tid"
 


### PR DESCRIPTION
## Description

Makes `pyproject.toml` the single source of NAPT's version. The hand-maintained `__version__` dunder (and the other metadata dunders) are gone from `napt/__init__.py`, which is now docstring-only like every other package init. Runtime code reads the version through a new cached helper, `get_version()` in `napt/version.py`, which wraps `importlib.metadata.version("napt")` with `functools.cache` so the metadata scan happens at most once per process.

## Motivation

The version previously lived in two places (`pyproject.toml` and `napt/__init__.py`) that had to be bumped in lockstep at release time — a drift risk with no benefit. Reading the installed distribution metadata is the PyPA-recommended pattern for applications. This also removes the last sanctioned exception to the Imports rule: every package `__init__.py` is now docstring-only, no exceptions. The cached helper (rather than inline `importlib.metadata` calls at each site) came out of the pre-commit review, since `make_session()` builds a User-Agent per HTTP session across discovery, PSADT downloads, and packaging.

## Changes

- New `napt/version.py`: `get_version()`, a `functools.cache`-wrapped `importlib.metadata.version("napt")` lookup
- `napt/__init__.py`: dropped `__version__`, `__author__`, `__license__`, `__description__`, and `__all__` (author/license/description already live in `pyproject.toml`) — now docstring-only
- Call sites switched to `get_version()`: `auth/registration.py` (provenance stamp + spec-drift check), `discovery/manager.py` and `state/cache.py` (`napt_version` cache metadata), `download/download.py` (User-Agent), `cli/main.py` (`--version`)
- `tests/auth/test_registration.py`: expected values computed via `importlib.metadata.version("napt")` directly, keeping the assertion independent of the helper
- `/release` skill: Phase 1 bumps only `pyproject.toml`; Phase 2 verifies only `pyproject.toml` at the tagged commit
- CLAUDE.md Imports rule: "docstring-only — no re-exports, no exceptions", with the version-sourcing rule stated; Releases section and reviewer agent updated to match
- Docs: `docs/api/version.md` added (plus mkdocs nav entry), `docs/api/index.md` tree updated

## Testing

- Full test suite (including integration): 824 passed
- `ruff check`, `black`, `pyright`: clean
- `mkdocs build --strict`: clean
- Smoke: `napt --version` -> `napt 0.9.0`, `get_version()` -> `0.9.0`, `import napt.cli` OK

## Checklist

- [x] Tests pass
- [x] Lint/format/type-check clean
- [x] Docs updated (`docs/api/`)
- [x] Changelog: not needed (internal refactor, `--version` output identical)