### PR TITLE
refactor: Drop __all__ and dead code, add vulture

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,6 +49,12 @@ Use **ruff** + **black**. Fix all errors before committing. Never ignore errors.
 
 **Line length:** 88 chars max. Break with parentheses or multiple lines.
 
+**Dead code:** **vulture** detects unreferenced code. It scans `napt/` only — never `tests/`, so test references can't keep a corpse alive. Configuration is in `[tool.vulture]`. A finding means either delete the code or add a commented entry to `vulture_whitelist.py`; never raise the confidence threshold (unused functions score 60, so a higher floor blinds the check).
+
+```powershell
+.venv\Scripts\python.exe -m vulture
+```
+
 ---
 
 ## Type Checking

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -32,11 +32,15 @@ Run these sequentially:
 .venv/Scripts/python.exe -m black napt/ tests/
 .venv/Scripts/python.exe -m ruff check napt/ tests/
 .venv/Scripts/python.exe -m pyright
+.venv/Scripts/python.exe -m vulture
 ```
 
 If ruff or black made changes, tell the user what was fixed.
 If any lint errors remain that --fix couldn't resolve, stop and report them.
 If pyright reports new errors compared to `main` (use `git diff main` context to judge whether they're pre-existing or introduced by this branch), stop and report them. Pre-existing errors should not block the ship.
+If vulture reports dead code, stop and report it — the fix is either deleting
+the code or a commented entry in `vulture_whitelist.py`, and that's the user's
+call. Never raise the confidence threshold to silence it.
 
 ## Step 3: Run tests
 

--- a/napt/auth/credentials.py
+++ b/napt/auth/credentials.py
@@ -76,26 +76,6 @@ import requests
 
 from napt.exceptions import AuthError, ConfigError
 
-__all__ = [
-    "AUTHORITY_BASE",
-    "AuthConfig",
-    "AuthStatus",
-    "AuthStore",
-    "GRAPH_SCOPES",
-    "LOGIN_TIMEOUT",
-    "REQUIRED_PERMISSIONS",
-    "get_access_token",
-    "get_credential",
-    "get_status",
-    "load_auth_config",
-    "load_auth_store",
-    "login",
-    "logout",
-    "msal_error",
-    "remember_tenant",
-    "resolve_auth_config",
-]
-
 GRAPH_SCOPES = ["https://graph.microsoft.com/.default"]
 
 # azure-identity logs a WARNING every time the non-interactive chain comes up
@@ -326,18 +306,6 @@ def _save_auth_store(store: AuthStore) -> Path:
     }
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
-
-
-def load_auth_config() -> AuthConfig | None:
-    """Returns the active tenant's sign-in settings, or ``None``.
-
-    Raises:
-        ConfigError: If the saved auth config is malformed.
-    """
-    store = load_auth_store()
-    if store.active is None:
-        return None
-    return store.tenants.get(store.active)
 
 
 def resolve_auth_config(

--- a/napt/auth/registration.py
+++ b/napt/auth/registration.py
@@ -64,16 +64,6 @@ from napt.exceptions import AuthError, ConfigError, NetworkError
 from napt.graph.client import graph_request, json_headers
 from napt.version import get_version
 
-__all__ = [
-    "BROKER_REDIRECT_TEMPLATE",
-    "FEDERATED_AUDIENCE_DEFAULT",
-    "LOCALHOST_REDIRECT",
-    "SPEC_VERSION",
-    "SetupResult",
-    "SetupSpec",
-    "setup_app_registration",
-]
-
 _GRAPH_V1 = "https://graph.microsoft.com/v1.0"
 
 # Microsoft Graph Command Line Tools: first-party public client with the

--- a/napt/config/loader.py
+++ b/napt/config/loader.py
@@ -75,7 +75,6 @@ Note:
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -84,20 +83,6 @@ import yaml
 
 from napt.config.defaults import DEFAULT_CONFIG
 from napt.exceptions import ConfigError
-
-
-@dataclass(frozen=True)
-class LoadContext:
-    """Metadata describing how the config was resolved.
-
-    Useful for debugging and logging.
-    """
-
-    recipe_path: Path
-    defaults_root: Path | None
-    vendor_name: str | None
-    org_defaults_path: Path | None
-    vendor_defaults_path: Path | None
 
 
 def _load_yaml_file(p: Path) -> Any:

--- a/napt/exceptions.py
+++ b/napt/exceptions.py
@@ -21,16 +21,6 @@ callers to catch all NAPT errors with a single except clause if needed.
 
 from __future__ import annotations
 
-__all__ = [
-    "NAPTError",
-    "ConfigError",
-    "NetworkError",
-    "PackagingError",
-    "StateError",
-    "AuthError",
-    "NotModifiedError",
-]
-
 
 class NAPTError(Exception):
     """Base exception for all NAPT errors.

--- a/napt/graph/client.py
+++ b/napt/graph/client.py
@@ -36,13 +36,6 @@ import requests
 
 from napt.exceptions import AuthError, ConfigError, NetworkError
 
-__all__ = [
-    "GRAPH_BASE",
-    "auth_headers",
-    "graph_request",
-    "json_headers",
-]
-
 # The Intune app management API (mobileApps, Win32LobApp) has never fully
 # graduated to v1.0. Fields critical to Win32 app uploads — allowedArchitectures,
 # maxRunTimeInMinutes, displayVersion, allowAvailableUninstall — are beta-only.

--- a/napt/graph/intune.py
+++ b/napt/graph/intune.py
@@ -25,8 +25,8 @@ Implements the full upload flow for a Win32 LOB app:
 
 Also provides app queries used for reconciliation (list_mobile_apps,
 get_mobile_app, update_win32_app) and group-based assignment plumbing
-(resolve_group_id, get_app_assignments, build_group_assignment,
-assign_app) used by deployment promotion.
+(resolve_group_id, resolve_assignment_target, get_app_assignments,
+build_assignment, assign_app) used by deployment promotion.
 
 All functions take an access_token as the first argument. Obtain one via
 [get_access_token][napt.auth.credentials.get_access_token]. Graph calls go
@@ -50,26 +50,6 @@ from napt.graph.client import GRAPH_BASE, auth_headers, graph_request, json_head
 
 if TYPE_CHECKING:
     from napt.upload.intunewin import IntunewinMetadata
-
-__all__ = [
-    "VIRTUAL_TARGETS",
-    "assign_app",
-    "build_assignment",
-    "build_group_assignment",
-    "create_win32_app",
-    "create_content_version",
-    "create_content_version_file",
-    "delete_mobile_app",
-    "get_app_assignments",
-    "get_mobile_app",
-    "list_mobile_apps",
-    "resolve_assignment_target",
-    "resolve_group_id",
-    "update_win32_app",
-    "upload_to_azure_blob",
-    "commit_content_version_file",
-    "commit_content_version",
-]
 
 WIN32_LOB_APP_TYPE = "#microsoft.graph.win32LobApp"
 
@@ -266,26 +246,6 @@ def build_assignment(target: dict, intent: str) -> dict:
         "intent": intent,
         "target": target,
     }
-
-
-def build_group_assignment(group_id: str, intent: str) -> dict:
-    """Builds a mobileAppAssignment payload targeting one Entra ID group.
-
-    Args:
-        group_id: Object ID of the target group.
-        intent: Assignment intent, "available" or "required".
-
-    Returns:
-        A mobileAppAssignment dict for use with assign_app.
-
-    """
-    return build_assignment(
-        {
-            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
-            "groupId": group_id,
-        },
-        intent,
-    )
 
 
 def assign_app(access_token: str, app_id: str, assignments: list[dict]) -> None:

--- a/napt/promote/applier.py
+++ b/napt/promote/applier.py
@@ -78,8 +78,6 @@ from napt.state.deployment import (
 )
 from napt.state.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
 
-__all__ = ["apply_plan", "load_plan_file"]
-
 # Ring assignments target the Update entry, which is gated to devices
 # with an older release installed — always a required install.
 _RING_INTENT = "required"

--- a/napt/promote/drift.py
+++ b/napt/promote/drift.py
@@ -56,8 +56,6 @@ from napt.graph.intune import (
 from napt.state.deployment import deployment_state_path, load_deployment_state
 from napt.state.stamp import ENTRY_INSTALL, ENTRY_UPDATE, parse_stamp
 
-__all__ = ["detect_drift"]
-
 
 def _target_key(target: dict[str, Any] | None) -> tuple[str, str]:
     """Returns a comparable identity for an assignment target."""

--- a/napt/promote/planner.py
+++ b/napt/promote/planner.py
@@ -60,15 +60,6 @@ from napt.exceptions import ConfigError, StateError
 from napt.logging import get_global_logger
 from napt.state.deployment import deployment_state_path, load_deployment_state
 
-__all__ = [
-    "load_recipe_configs",
-    "plan_path_for",
-    "plan_promotions",
-    "plans_dir_for",
-    "resolve_state_dir",
-    "write_plan_files",
-]
-
 # Deterministic ordering of action types within one app's actions.
 _ACTION_ORDER = {"assign": 0, "promote": 1}
 

--- a/napt/promote/preflight.py
+++ b/napt/promote/preflight.py
@@ -35,8 +35,6 @@ from typing import Any
 from napt.exceptions import ConfigError
 from napt.graph.intune import resolve_assignment_target
 
-__all__ = ["unresolvable_groups"]
-
 
 def unresolvable_groups(
     access_token: str,

--- a/napt/promote/reconcile.py
+++ b/napt/promote/reconcile.py
@@ -57,8 +57,6 @@ from napt.state.deployment import (
 )
 from napt.state.stamp import ENTRY_INSTALL, ENTRY_UPDATE, find_stamped_app
 
-__all__ = ["reconcile_publications"]
-
 _REQUIRED_ENTRIES = {
     "both": (ENTRY_INSTALL, ENTRY_UPDATE),
     "app_only": (ENTRY_INSTALL,),

--- a/napt/results.py
+++ b/napt/results.py
@@ -28,7 +28,7 @@ return values.
 
 Note:
     Only results that napt commands surface belong in this module. Domain types
-    (like DiscoveredVersion) and internal types (like LoadContext) should
+    (like MSIMetadata) and internal types (like StrategyResult) should
     remain co-located with their related logic.
 """
 

--- a/napt/state/cache.py
+++ b/napt/state/cache.py
@@ -14,35 +14,24 @@
 
 """Discovery cache persistence for NAPT.
 
-This module implements the discovery cache: a disposable optimization file
-(default ``cache/discovery.json``) that tracks discovered versions, ETags,
-and download metadata between runs. Deleting it costs one full re-download
-per app and nothing else — the filesystem and deployment state remain the
-source of truth.
+This module provides the JSON load/save helpers for the discovery cache: a
+disposable optimization file (default ``cache/discovery.json``) that tracks
+discovered versions, ETags, and download metadata between runs. Deleting it
+costs one full re-download per app and nothing else — the filesystem and
+deployment state remain the source of truth.
 
-The cache supports two optimization approaches:
+The cached fields serve two optimization approaches, both implemented by
+the discovery flows that consume this file:
 
-- VERSION-FIRST (url_pattern, api_github, api_json): Uses known_version for comparison
-- FILE-FIRST (url_download): Uses etag/last_modified for HTTP conditional requests
-
-Key Features:
-
-- JSON-based cache storage (fast parsing, standard library)
-- Automatic ETag/Last-Modified tracking for conditional requests
-- Version change detection for version-first strategies
-- Robust error handling (corrupted files, missing data)
-- Auto-creation of cache files and directories
+- VERSION-FIRST (api_github, api_json, web_scrape): known_version comparison
+- FILE-FIRST (url_download): etag/last_modified HTTP conditional requests
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 import json
 from pathlib import Path
 from typing import Any
-
-from napt.exceptions import StateError
-from napt.version import get_version
 
 
 def cache_file_path(config: dict[str, Any]) -> Path:
@@ -56,245 +45,6 @@ def cache_file_path(config: dict[str, Any]) -> Path:
 
     """
     return Path(config["directories"]["cache"]) / "discovery.json"
-
-
-class DiscoveryCache:
-    """Manages the discovery cache with automatic persistence.
-
-    This class provides a high-level interface for loading, querying, and
-    updating the cache file. It handles file I/O, error recovery, and
-    provides convenience methods for common operations.
-
-    Attributes:
-        cache_file: Path to the JSON cache file.
-        data: In-memory cache dictionary.
-
-    Example:
-        Basic usage:
-            ```python
-            from pathlib import Path
-
-            cache = DiscoveryCache(Path("cache/discovery.json"))
-            cache.load()
-            entry = cache.get_cache("napt-chrome")
-            cache.update_cache(
-                "napt-chrome",
-                url="https://...",
-                sha256="...",
-                known_version="130.0.0"
-            )
-            cache.save()
-            ```
-
-    """
-
-    def __init__(self, cache_file: Path):
-        """Initialize discovery cache.
-
-        Args:
-            cache_file: Path to JSON cache file. Created if doesn't exist.
-
-        """
-        self.cache_file = cache_file
-        self.data: dict[str, Any] = {}
-
-    def load(self) -> dict[str, Any]:
-        """Load cache from file.
-
-        Creates default cache structure if file doesn't exist.
-        Handles corrupted files by creating backup and starting fresh.
-
-        Returns:
-            Loaded cache dictionary.
-
-        Raises:
-            OSError: If file permissions prevent reading.
-
-        """
-        try:
-            self.data = load_cache(self.cache_file)
-        except FileNotFoundError:
-            # First run, create default cache
-            self.data = create_default_cache()
-            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
-            self.save()
-        except json.JSONDecodeError as err:
-            # Corrupted file, backup and create new
-            backup = self.cache_file.with_suffix(".json.backup")
-            self.cache_file.rename(backup)
-            self.data = create_default_cache()
-            self.save()
-            raise StateError(
-                f"Corrupted cache file backed up to {backup}. "
-                f"Created fresh cache file."
-            ) from err
-
-        return self.data
-
-    def save(self) -> None:
-        """Save current cache to file.
-
-        Updates metadata.last_updated timestamp automatically.
-        Creates parent directories if needed.
-
-        Raises:
-            OSError: If file permissions prevent writing.
-
-        """
-        # Update metadata
-        self.data.setdefault("metadata", {})
-        self.data["metadata"]["last_updated"] = datetime.now(UTC).isoformat()
-
-        # Ensure parent directory exists
-        self.cache_file.parent.mkdir(parents=True, exist_ok=True)
-
-        save_cache(self.data, self.cache_file)
-
-    def get_cache(self, recipe_id: str) -> dict[str, Any] | None:
-        """Get cached information for a recipe.
-
-        Args:
-            recipe_id: Recipe identifier (from recipe's 'id' field).
-
-        Returns:
-            Cached data if available, None otherwise.
-
-        Example:
-            Retrieve cached information:
-                ```python
-                entry = cache.get_cache("napt-chrome")
-                if entry:
-                    etag = entry.get('etag')
-                    known_version = entry.get('known_version')
-                ```
-
-        """
-        return self.data.get("apps", {}).get(recipe_id)
-
-    def update_cache(
-        self,
-        recipe_id: str,
-        url: str,
-        sha256: str,
-        etag: str | None = None,
-        last_modified: str | None = None,
-        known_version: str | None = None,
-        strategy: str | None = None,
-    ) -> None:
-        """Update cached information for a recipe.
-
-        Args:
-            recipe_id: Recipe identifier.
-            url: Download URL for provenance tracking. For version-first strategies
-                (url_pattern, api_github, api_json), this is the actual download URL
-                from version_info. For file-first (url_download), this is discovery.url.
-            sha256: SHA-256 hash of file (for integrity checks).
-            etag: ETag header from download response. Used by url_download for HTTP 304
-                conditional requests. Saved but unused by version-first strategies.
-            last_modified: Last-Modified header from download response.
-                Used by url_download as fallback for conditional requests.
-                Saved but unused by version-first.
-            known_version: Version string. PRIMARY cache key for
-                version-first strategies (compared to skip downloads).
-                Informational only for url_download.
-            strategy: Discovery strategy used (for debugging).
-
-        Example:
-            Update cache entry:
-                ```python
-                cache.update_cache(
-                    "napt-chrome",
-                    url="https://dl.google.com/chrome.msi",
-                    sha256="abc123...",
-                    etag='W/"def456"',
-                    known_version="130.0.0"
-                )
-                ```
-
-        Note:
-            Schema v2: Removed file_path, last_checked, and renamed
-            version -> known_version.
-
-            Field usage differs by strategy type:
-
-            - Version-first: known_version is PRIMARY cache key,
-                etag/last_modified unused
-            - File-first: etag/last_modified are PRIMARY cache keys,
-                known_version informational
-
-            The cache is for optimization only; the filesystem and
-            deployment state are the source of truth.
-
-        """
-        if "apps" not in self.data:
-            self.data["apps"] = {}
-
-        cache_entry = {
-            "url": url,
-            "etag": etag,
-            "last_modified": last_modified,
-            "sha256": sha256,
-        }
-
-        # Optional fields (only add if provided)
-        if known_version is not None:
-            cache_entry["known_version"] = known_version
-        if strategy is not None:
-            cache_entry["strategy"] = strategy
-
-        self.data["apps"][recipe_id] = cache_entry
-
-    def has_version_changed(self, recipe_id: str, new_version: str) -> bool:
-        """Check if discovered version differs from cached known_version.
-
-        Args:
-            recipe_id: Recipe identifier.
-            new_version: Newly discovered version.
-
-        Returns:
-            True if version changed or no cached version exists.
-
-        Example:
-            Check if version has changed:
-                ```python
-                if cache.has_version_changed("napt-chrome", "130.0.0"):
-                    print("New version available!")
-                ```
-
-        Note:
-            Uses 'known_version' field which is informational only.
-            Real version should be extracted from filesystem during build.
-
-        """
-        entry = self.get_cache(recipe_id)
-        if not entry:
-            return True  # No cache, treat as changed
-
-        return entry.get("known_version") != new_version
-
-
-def create_default_cache() -> dict[str, Any]:
-    """Create a default empty cache structure.
-
-    Returns:
-        Empty cache with metadata section.
-
-    Example:
-        Create default cache structure:
-            ```python
-            data = create_default_cache()
-            data["apps"] = {}
-            ```
-
-    """
-    return {
-        "metadata": {
-            "napt_version": get_version(),
-            "schema_version": "2",
-            "last_updated": datetime.now(UTC).isoformat(),
-        },
-        "apps": {},
-    }
 
 
 def load_cache(cache_file: Path) -> dict[str, Any]:

--- a/napt/upload/intunewin.py
+++ b/napt/upload/intunewin.py
@@ -36,8 +36,6 @@ import zipfile
 
 from napt.exceptions import PackagingError
 
-__all__ = ["IntunewinMetadata", "parse_intunewin", "extract_encrypted_payload"]
-
 DETECTION_XML_PATH = "IntuneWinPackage/Metadata/Detection.xml"
 ENCRYPTED_PAYLOAD_PATH = "IntuneWinPackage/Contents/IntunePackage.intunewin"
 

--- a/napt/upload/manager.py
+++ b/napt/upload/manager.py
@@ -59,8 +59,6 @@ from napt.state.stamp import (
 )
 from napt.upload.intunewin import extract_encrypted_payload, parse_intunewin
 
-__all__ = ["upload_package"]
-
 # Intune return codes for PSADT deployments.
 # 0    - success: clean install/uninstall
 # 1707 - success: removal succeeded (used by some uninstallers)

--- a/napt/validation.py
+++ b/napt/validation.py
@@ -42,9 +42,6 @@ from napt.exceptions import ConfigError
 from napt.logging import get_global_logger
 from napt.results import ValidationResult
 
-__all__ = ["validate_config", "validate_recipe"]
-
-
 # Schema for the intune.detection subsection
 _INTUNE_DETECTION_FIELDS: dict[str, tuple[type, list[str] | None, str]] = {
     "display_name": (str, None, "display name for registry lookup"),

--- a/poetry.lock
+++ b/poetry.lock
@@ -1493,6 +1493,18 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "vulture"
+version = "2.16"
+description = "Find dead code"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee"},
+    {file = "vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717"},
+]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 description = "Filesystem events monitoring"
@@ -1538,4 +1550,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "491da7ea777e08a50369b16f4c4bb4b3a5f39c81f893d4db704897f63b348719"
+content-hash = "c7acccc4a6f62d4ce2f1d4037b9527698141ffa7b0020520575d51dd07a89746"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ mkdocs-material = "^9.6.23"
 mkdocstrings = "^0.30.1"
 mkdocstrings-python = "^1.18.2"
 griffe = "^1.14.0"  # pin to 1.x: mkdocstrings-python 1.x doesn't declare upper bound on griffe (https://github.com/mkdocstrings/python/issues), and griffe 2.x renamed/removed exports it relies on
+vulture = "^2.16"
 
 # -----------------------------
 # Formatting (Black)
@@ -112,6 +113,17 @@ venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
 typeCheckingMode = "standard"
+
+# -----------------------------
+# Dead Code (Vulture)
+# -----------------------------
+[tool.vulture]
+# Scan production code only — tests referencing a symbol must never count as
+# keeping it alive. Default confidence is intentional: unused functions and
+# classes score 60, so any min_confidence above that would miss exactly the
+# dead code this check exists to catch. False positives go in
+# vulture_whitelist.py, not a higher threshold.
+paths = ["napt", "vulture_whitelist.py"]
 
 # -----------------------------
 # Pytest

--- a/tests/auth/test_credentials.py
+++ b/tests/auth/test_credentials.py
@@ -15,7 +15,6 @@ from napt.auth.credentials import (
     AuthStore,
     get_access_token,
     get_status,
-    load_auth_config,
     login,
     logout,
     resolve_auth_config,
@@ -27,6 +26,14 @@ def _jwt(claims: dict) -> str:
     """Builds an unsigned JWT-shaped string carrying the given claims."""
     payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=")
     return f"eyJhbGciOiJub25lIn0.{payload.decode()}.sig"
+
+
+def _active_config() -> AuthConfig | None:
+    """Returns the active tenant's saved config, or None."""
+    store = credentials.load_auth_store()
+    if store.active is None:
+        return None
+    return store.tenants.get(store.active)
 
 
 @pytest.fixture
@@ -193,11 +200,11 @@ def test_resolve_auth_config_returns_none_when_incomplete(user_dir) -> None:
     assert resolve_auth_config(client_id="cid") is None
 
 
-def test_load_auth_config_rejects_malformed_file(user_dir) -> None:
+def test_load_auth_store_rejects_malformed_file(user_dir) -> None:
     """Tests that a corrupt auth.json raises ConfigError with a remedy."""
     (user_dir / "auth.json").write_text("{not json", encoding="utf-8")
     with pytest.raises(ConfigError, match="napt auth login"):
-        load_auth_config()
+        credentials.load_auth_store()
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +234,7 @@ def test_login_saves_config_and_reports_permissions(user_dir) -> None:
     assert status.method == "interactive (browser)"
     assert status.account == "admin@contoso.com"
     assert status.missing == []
-    assert load_auth_config() == AuthConfig("cid", "tid", "admin@contoso.com")
+    assert _active_config() == AuthConfig("cid", "tid", "admin@contoso.com")
     kwargs = app.acquire_token_interactive.call_args.kwargs
     assert kwargs["parent_window_handle"] is None
 
@@ -339,7 +346,7 @@ def test_login_surfaces_msal_error(user_dir) -> None:
         with pytest.raises(AuthError, match="invalid_client: AADSTS50011") as exc:
             login(client_id="cid", tenant_id="tid")
     assert "redirect URI" in str(exc.value)
-    assert load_auth_config() is None
+    assert _active_config() is None
 
 
 def test_logout_signs_out_active_tenant_only(user_dir) -> None:
@@ -460,7 +467,7 @@ def test_login_stores_tenant_domain_and_name(user_dir) -> None:
     ):
         login(client_id="cid", tenant_id="tid")
 
-    saved = load_auth_config()
+    saved = _active_config()
     assert saved is not None
     assert saved.domain == "contoso.com"
     assert saved.display_name == "Contoso"
@@ -485,7 +492,7 @@ def test_login_without_user_read_leaves_label_empty(user_dir) -> None:
         status = login(client_id="cid", tenant_id="tid")
 
     assert status.account == "a@msp.com"
-    saved = load_auth_config()
+    saved = _active_config()
     assert saved is not None
     assert saved.label is None  # no UPN-domain guess
 

--- a/tests/graph/test_intune.py
+++ b/tests/graph/test_intune.py
@@ -12,7 +12,7 @@ from napt.exceptions import ConfigError, NetworkError
 from napt.graph.client import GRAPH_BASE
 from napt.graph.intune import (
     assign_app,
-    build_group_assignment,
+    build_assignment,
     commit_content_version,
     commit_content_version_file,
     create_content_version,
@@ -375,7 +375,15 @@ def test_get_app_assignments_returns_value() -> None:
 
 def test_assign_app_posts_full_set() -> None:
     """Tests that assign_app posts the complete assignment list."""
-    assignments = [build_group_assignment(GROUP_ID, "required")]
+    assignments = [
+        build_assignment(
+            {
+                "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+                "groupId": GROUP_ID,
+            },
+            "required",
+        )
+    ]
     with req_mock.Mocker() as m:
         m.post(_ASSIGN_URL, status_code=200)
         assign_app(TOKEN, APP_ID, assignments)
@@ -383,9 +391,15 @@ def test_assign_app_posts_full_set() -> None:
     assert body == {"mobileAppAssignments": assignments}
 
 
-def test_build_group_assignment_shape() -> None:
+def test_build_assignment_shape() -> None:
     """Tests the mobileAppAssignment payload structure."""
-    result = build_group_assignment(GROUP_ID, "available")
+    result = build_assignment(
+        {
+            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+            "groupId": GROUP_ID,
+        },
+        "available",
+    )
 
     assert result == {
         "@odata.type": "#microsoft.graph.mobileAppAssignment",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -16,12 +16,7 @@ import json
 import pytest
 
 from napt.exceptions import StateError
-from napt.state.cache import (
-    DiscoveryCache,
-    create_default_cache,
-    load_cache,
-    save_cache,
-)
+from napt.state.cache import load_cache, save_cache
 from napt.state.deployment import (
     create_default_deployment_state,
     deployment_state_path,
@@ -35,16 +30,6 @@ from napt.state.deployment import (
 
 class TestCacheFileOperations:
     """Tests for loading and saving discovery cache files."""
-
-    def test_create_default_cache(self):
-        """Tests that the default cache structure is empty with metadata."""
-        data = create_default_cache()
-
-        assert "metadata" in data
-        assert "apps" in data
-        assert data["metadata"]["schema_version"] == "2"
-        assert isinstance(data["apps"], dict)
-        assert len(data["apps"]) == 0
 
     def test_save_and_load_cache(self, tmp_path):
         """Tests round-trip save and load."""
@@ -89,7 +74,7 @@ class TestCacheFileOperations:
     def test_save_creates_parent_directory(self, tmp_path):
         """Tests that save creates parent directories if needed."""
         cache_file = tmp_path / "nested" / "dir" / "discovery.json"
-        data = create_default_cache()
+        data = {"metadata": {"schema_version": "2"}, "apps": {}}
 
         save_cache(data, cache_file)
 
@@ -108,168 +93,6 @@ class TestCacheFileOperations:
         assert "  " in content
         # Should have trailing newline
         assert content.endswith("\n")
-
-
-class TestDiscoveryCache:
-    """Tests for DiscoveryCache class."""
-
-    def test_init(self, tmp_path):
-        """Tests DiscoveryCache initialization."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-
-        assert cache.cache_file == cache_file
-        assert isinstance(cache.data, dict)
-
-    def test_load_creates_default_if_missing(self, tmp_path):
-        """Tests that load creates default cache if file doesn't exist."""
-        cache_file = tmp_path / "new_discovery.json"
-        cache = DiscoveryCache(cache_file)
-
-        data = cache.load()
-
-        assert cache_file.exists()
-        assert "metadata" in data
-        assert "apps" in data
-
-    def test_load_existing_file(self, tmp_path):
-        """Tests loading existing cache file."""
-        cache_file = tmp_path / "discovery.json"
-        initial_data = {
-            "metadata": {"napt_version": "0.1.0"},
-            "apps": {
-                "test-app": {
-                    "url": "https://vendor.com/app.msi",
-                    "sha256": "abc123",
-                    "known_version": "1.2.3",
-                }
-            },
-        }
-        save_cache(initial_data, cache_file)
-
-        cache = DiscoveryCache(cache_file)
-        data = cache.load()
-
-        assert data["apps"]["test-app"]["known_version"] == "1.2.3"
-
-    def test_load_corrupted_file_creates_backup(self, tmp_path):
-        """Tests that corrupted file is backed up and replaced."""
-        cache_file = tmp_path / "discovery.json"
-        cache_file.write_text("corrupted JSON{{{", encoding="utf-8")
-
-        cache = DiscoveryCache(cache_file)
-
-        with pytest.raises(StateError, match="Corrupted cache file"):
-            cache.load()
-
-        # Should create backup
-        backup_file = tmp_path / "discovery.json.backup"
-        assert backup_file.exists()
-        assert backup_file.read_text(encoding="utf-8") == "corrupted JSON{{{"
-
-        # Should create new clean cache file
-        assert cache_file.exists()
-        new_data = load_cache(cache_file)
-        assert "apps" in new_data
-
-    def test_save_updates_timestamp(self, tmp_path):
-        """Tests that save updates last_updated timestamp."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = create_default_cache()
-
-        cache.save()
-
-        loaded = load_cache(cache_file)
-        assert "last_updated" in loaded["metadata"]
-
-    def test_get_cache_existing(self, tmp_path):
-        """Tests getting cache entry for existing recipe."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = {
-            "metadata": {},
-            "apps": {
-                "test-app": {
-                    "url": "https://vendor.com/app.msi",
-                    "etag": 'W/"abc123"',
-                    "sha256": "def456",
-                    "known_version": "1.2.3",
-                }
-            },
-        }
-
-        entry = cache.get_cache("test-app")
-
-        assert entry is not None
-        assert entry["known_version"] == "1.2.3"
-        assert entry["etag"] == 'W/"abc123"'
-        assert entry["url"] == "https://vendor.com/app.msi"
-
-    def test_get_cache_missing(self, tmp_path):
-        """Tests getting cache entry for non-existent recipe returns None."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = {"metadata": {}, "apps": {}}
-
-        entry = cache.get_cache("nonexistent-app")
-
-        assert entry is None
-
-    def test_update_cache(self, tmp_path):
-        """Tests updating cache entry for a recipe."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = create_default_cache()
-
-        cache.update_cache(
-            recipe_id="test-app",
-            url="https://vendor.com/file.msi",
-            sha256="abc123",
-            etag='W/"xyz789"',
-            last_modified="Mon, 28 Oct 2024 10:00:00 GMT",
-            known_version="2.0.0",
-            strategy="url_download",
-        )
-
-        entry = cache.get_cache("test-app")
-        assert entry["known_version"] == "2.0.0"
-        assert entry["url"] == "https://vendor.com/file.msi"
-        assert entry["etag"] == 'W/"xyz789"'
-        assert entry["last_modified"] == "Mon, 28 Oct 2024 10:00:00 GMT"
-        assert entry["sha256"] == "abc123"
-        assert entry["strategy"] == "url_download"
-
-    def test_has_version_changed_true(self, tmp_path):
-        """Tests version change detection when version differs."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = {
-            "metadata": {},
-            "apps": {"test-app": {"known_version": "1.0.0"}},
-        }
-
-        assert cache.has_version_changed("test-app", "2.0.0") is True
-
-    def test_has_version_changed_false(self, tmp_path):
-        """Tests version change detection when version same."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = {
-            "metadata": {},
-            "apps": {"test-app": {"known_version": "1.0.0"}},
-        }
-
-        assert cache.has_version_changed("test-app", "1.0.0") is False
-
-    def test_has_version_changed_no_cache(self, tmp_path):
-        """Tests version change detection with no cached version."""
-        cache_file = tmp_path / "discovery.json"
-        cache = DiscoveryCache(cache_file)
-        cache.data = {"metadata": {}, "apps": {}}
-
-        # No cache means version changed
-        assert cache.has_version_changed("test-app", "1.0.0") is True
 
 
 class TestDeploymentStateFiles:

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,17 @@
+"""Vulture whitelist: names flagged as unused that are actually alive.
+
+Each statement below "uses" a name so vulture stops reporting it. Add an
+entry only after confirming the symbol is genuinely reachable (dynamic
+dispatch, template substitution, dataclass fields read by consumers) —
+or, as below, when the finding is real but tracked for a separate fix.
+Regenerate candidates with: python -m vulture --make-whitelist
+"""
+
+# Recipe schema fields `logging.log_format` / `logging.log_level` flow from
+# build/manager.py into the DetectionConfig / RequirementsConfig dataclasses
+# (registry_scripts.py, msix_scripts.py) but the script generators do not
+# read them yet — a known gap: either wire them into script generation or
+# deprecate the recipe fields. Whitelisted so the open question is recorded
+# here instead of re-reported on every run.
+_.log_format
+_.log_level


### PR DESCRIPTION
## Description

Removes all 13 `__all__` export lists, deletes five dead symbols (plus the tests that were keeping them green), and adds vulture as the project's dead-code check so this class of rot gets caught mechanically from now on.

## Motivation

For a while NAPT was headed toward being a Python library, and the `__all__` lists are left over from that. As a CLI we don't support `import *` and have no public Python API to declare, so the lists only added drift risk. They were also hiding dead code. An audit found three public functions with zero production callers, kept green by nothing but their own tests, all stranded by mid-development design changes. Vulture couldn't flag two of them until the lists came out, since an `__all__` entry counts as usage, and once they were gone it found two more the audit missed. Vulture is now a standing check so this doesn't happen again.

## Changes

- Removed all 13 `__all__` lists (`auth/credentials`, `auth/registration`, `exceptions`, `graph/client`, `graph/intune`, the five `promote/` modules, `upload/intunewin`, `upload/manager`, `validation`)
- Deleted five dead symbols:
    - `DiscoveryCache` class and `create_default_cache()` (`state/cache.py`): the library-era "high-level API" wrapper and its only caller. The module is now the three functions production uses (`cache_file_path`, `load_cache`, `save_cache`), with its docstring tightened to match (including a stale `url_pattern` strategy name -> `web_scrape`)
    - `load_auth_config()` (`auth/credentials.py`): superseded by `resolve_auth_config()`. The four tests using it as an assertion oracle now check the store via a local `_active_config()` helper, and the malformed-file test exercises `load_auth_store()` directly
    - `build_group_assignment()` (`graph/intune.py`): superseded by `build_assignment()` + `resolve_assignment_target()`. Module docstring updated, shape test converted to cover `build_assignment`
    - `LoadContext` (`config/loader.py`): never instantiated anywhere. `results.py`'s Note now cites real types (`MSIMetadata`, `StrategyResult`) instead of two ghosts
- Added vulture (dev dependency) with `[tool.vulture]` scanning `napt/` only, never `tests/`, so test references can't keep a corpse alive. Runs at default confidence (unused functions score 60; a higher floor would blind the check)
- Added `vulture_whitelist.py` documenting the one confirmed-real finding left in place: recipe fields `logging.log_format`/`log_level` flow from `build/manager.py` into the script-gen dataclasses but are never read by the generators. Tracked for a separate fix (wire in or deprecate)
- Wired vulture into CLAUDE.md's Code Quality commands and the ship skill's lint step

## Testing

- Vulture: clean (baseline-validated: it flagged every removed symbol before deletion)
- Full test suite (including integration): 812 passed (824 minus the 12 dead-code tests)
- `ruff check`, `black`, `pyright`: clean
- `mkdocs build --strict`: clean; before/after rendered-anchor diff shows exactly the 11 anchors of deleted symbols, so removing `__all__` changed nothing else in the rendered API docs
- CLI smoke: `napt --version`, `import napt.cli`
- Reviewed twice pre-commit: napt-reviewer (ship, no findings) and a cloud ultra review (one docstring finding, fixed here; its other findings were artifacts of the review bundle missing the then-untracked whitelist file)

## Checklist

- [x] Tests pass
- [x] Lint/format/type-check/dead-code clean
- [x] Docs render validated (`mkdocs build --strict` + anchor diff)
- [x] Changelog: not needed (internal cleanup + contributor tooling)