### PR TITLE
docs: Fix stale references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 NAPT is a Python-based CLI tool that automates the entire workflow for packaging Windows applications and deploying them to Microsoft Intune. It runs on Windows, Linux, and macOS, though packaging (.intunewin creation) requires Windows.
 
-📚 **[Full Documentation](https://rogercibrian.github.io/notapkgtool/)** | [Quick Start](https://rogercibrian.github.io/notapkgtool/quick-start/) | [User Guide](https://rogercibrian.github.io/notapkgtool/user-guide/) | [Developer Reference](https://rogercibrian.github.io/notapkgtool/api/core/)
+📚 **[Full Documentation](https://rogercibrian.github.io/notapkgtool/)** | [Quick Start](https://rogercibrian.github.io/notapkgtool/quick-start/) | [User Guide](https://rogercibrian.github.io/notapkgtool/user-guide/) | [Developer Reference](https://rogercibrian.github.io/notapkgtool/api/)
 
 ### Why NAPT?
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -21,7 +21,7 @@ git checkout main
 git pull origin main
 
 # Create your feature branch
-git checkout -b feature/your-feature-name
+git checkout -b feat/your-feature-name
 ```
 
 ### 2. During Development
@@ -32,7 +32,7 @@ git add .
 git commit -m "feat: add your feature"
 
 # Push your branch
-git push origin feature/your-feature-name
+git push origin feat/your-feature-name
 ```
 
 ### 3. Create Pull Request
@@ -51,7 +51,7 @@ git checkout main
 git pull origin main
 
 # Delete your local feature branch
-git branch -d feature/your-feature-name
+git branch -d feat/your-feature-name
 
 # Remote branch is usually auto-deleted by GitHub
 ```
@@ -62,8 +62,8 @@ git branch -d feature/your-feature-name
 
 ```
 main (always deployable)
-├── feature/add-rpm-support
-├── bugfix/fix-version-parsing
+├── feat/add-rpm-support
+├── fix/version-parsing
 ├── docs/update-installation-guide
 └── refactor/simplify-config-loader
 ```
@@ -72,15 +72,20 @@ main (always deployable)
 
 Use descriptive names with type prefixes:
 
+The prefix is the conventional commit type the PR will squash to:
+
 | Prefix | Purpose | Example |
 |--------|---------|---------|
-| `feature/` | New features or enhancements | `feature/add-rpm-support` |
-| `bugfix/` | Bug fixes | `bugfix/fix-version-parsing` |
+| `feat/` | New features or enhancements | `feat/add-rpm-support` |
+| `fix/` | Bug fixes | `fix/version-parsing` |
 | `docs/` | Documentation updates | `docs/update-installation-guide` |
 | `refactor/` | Code improvements (no behavior change) | `refactor/simplify-config-loader` |
 | `test/` | Test additions/improvements | `test/add-integration-tests` |
 | `chore/` | Maintenance tasks | `chore/update-dependencies` |
-| `hotfix/` | Urgent production fixes | `hotfix/security-patch` |
+| `perf/` | Performance improvements | `perf/parallel-downloads` |
+
+`feature/` and `bugfix/` also appear in the history and are accepted, but
+prefer the short forms so the branch name and the squash commit type match.
 
 ### Naming Rules
 
@@ -91,8 +96,8 @@ Use descriptive names with type prefixes:
 
 **Good Examples:**
 ```
-feature/add-exe-version-extraction
-bugfix/fix-download-resume-logic
+feat/add-exe-version-extraction
+fix/download-resume-logic
 docs/add-cross-platform-examples
 refactor/simplify-config-loader
 ```
@@ -100,8 +105,8 @@ refactor/simplify-config-loader
 **Bad Examples:**
 ```
 my-branch              # No type prefix
-feature/stuff          # Not descriptive
-Feature/My_Branch      # Wrong case
+feat/stuff             # Not descriptive
+Feat/My_Branch         # Wrong case
 fix-bug                # Too generic
 ```
 
@@ -157,9 +162,10 @@ When creating a PR, the [PR template](https://github.com/RogerCibrian/notapkgtoo
 
 ## Merge Strategy
 
-**Default: Squash and Merge**
+**Squash and Merge, always**
 
-NAPT uses **squash and merge** for most Pull Requests to maintain a clean, readable history in `main`.
+NAPT uses **squash and merge** for every Pull Request, including release
+PRs, to maintain a clean, readable history in `main`.
 
 ### Why Squash and Merge?
 
@@ -169,16 +175,7 @@ NAPT uses **squash and merge** for most Pull Requests to maintain a clean, reada
 - ✅ **Better changelogs**: No noise from "WIP" or "fix typo" commits
 - ✅ **Simple bisecting**: Each commit represents a complete, working change
 
-### When to Use Each Strategy
-
-**Squash and Merge (Default - 95% of PRs)**
-
-Use for:
-- Feature additions
-- Bug fixes
-- Documentation updates
-- Refactoring
-- Chores and maintenance
+### Merging
 
 When merging on GitHub:
 1. Click "Squash and merge"
@@ -198,17 +195,9 @@ feat: add RPM version extraction support
 Closes #42
 ```
 
-**Regular Merge (Exceptional Cases)**
-
-Use only when:
-- Multiple authors need attribution for distinct contributions
-- Release PRs where version bump history should be preserved
-- Large features with logically separate commits worth keeping
-
-**Example scenarios:**
-- Version bump PRs (preserve "bump version" + "update changelog" as separate commits)
-- Community contributions with multiple meaningful commits
-- Complex refactors where commit-by-commit history aids debugging
+Release PRs are no exception: `/release` makes a single
+`chore: Prepare release X.Y.Z` commit (version bump plus changelog
+promotion), and that squashes like any other PR.
 
 ### Workflow
 
@@ -231,7 +220,7 @@ Use only when:
 
 If changes are closely related, keep in one branch:
 ```bash
-feature/add-exe-support
+feat/add-exe-support
   ├── Add EXE parsing module
   ├── Add tests
   └── Update documentation
@@ -239,8 +228,8 @@ feature/add-exe-support
 
 If changes are independent, use separate branches:
 ```bash
-feature/add-exe-support
-feature/add-rpm-support
+feat/add-exe-support
+feat/add-rpm-support
 ```
 
 ### Long-Running Features
@@ -258,11 +247,11 @@ For critical production issues:
 # Branch from main
 git checkout main
 git pull origin main
-git checkout -b hotfix/fix-security-vulnerability
+git checkout -b fix/security-vulnerability
 
 # Fix, test, and push
-git commit -am "fix: patch security vulnerability"
-git push origin hotfix/fix-security-vulnerability
+git commit -am "fix: Patch security vulnerability"
+git push origin fix/security-vulnerability
 
 # Create PR with high priority
 # Fast-track review and merge
@@ -275,8 +264,9 @@ git push origin hotfix/fix-security-vulnerability
 - Create small, focused branches with single purpose
 - Commit early and often with clear messages
 - Keep branches short-lived (merge within 1 week)
-- Run tests before pushing (`pytest tests/`)
-- Format code before committing (`black napt/`)
+- Run the full check sequence before committing: `ruff check --fix`,
+  `black`, `pyright`, `vulture`, then `pytest tests/` (the `/ship` skill
+  runs all of these in order)
 - Update branch with `main` if it's behind
 - Delete branches after merging
 
@@ -290,7 +280,5 @@ git push origin hotfix/fix-security-vulnerability
 - Don't include unrelated changes in one PR
 
 ---
-
-**Last Updated**: 2025-11-18
 
 **Strategy**: GitHub Flow with Squash and Merge

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -26,13 +26,22 @@ $ napt init
 Initializing NAPT project in: /path/to/my-intune-packages
 
 [1/2] Creating directory structure...
-      Created: recipes/
-      Created: defaults/vendors/
-
 [2/2] Creating configuration files...
-      Created: defaults/org.yaml
 
-Done! Project initialized.
+======================================================================
+INITIALIZATION RESULTS
+======================================================================
+Project Root:    /path/to/my-intune-packages
+
+Created (4):
+  [OK] recipes/
+  [OK] defaults/vendors/
+  [OK] state/deployment/
+  [OK] defaults/org.yaml
+
+======================================================================
+
+[SUCCESS] Project initialized!
 ```
 
 ### What Gets Created
@@ -42,7 +51,9 @@ my-intune-packages/
 ├── defaults/
 │   ├── org.yaml              # Organization-wide defaults (commented template)
 │   └── vendors/              # Vendor-specific overrides (empty)
-└── recipes/                  # Your recipe files go here
+├── recipes/                  # Your recipe files go here
+└── state/
+    └── deployment/           # Per-app deployment state (written by discover, upload, promote)
 ```
 
 ### Handling Existing Files
@@ -54,13 +65,24 @@ $ napt init
 Initializing NAPT project in: /path/to/existing-project
 
 [1/2] Creating directory structure...
-      Skipped: recipes/ (already exists)
-      Skipped: defaults/vendors/ (already exists)
-
 [2/2] Creating configuration files...
-      Skipped: defaults/org.yaml (already exists)
 
-Done! Project initialized.
+======================================================================
+INITIALIZATION RESULTS
+======================================================================
+Project Root:    /path/to/existing-project
+
+Skipped (4):
+  [SKIP] recipes/
+  [SKIP] defaults/vendors/
+  [SKIP] state/deployment/
+  [SKIP] defaults/org.yaml
+
+======================================================================
+
+Note: Existing files were preserved. Use --force to overwrite.
+
+[SUCCESS] Project initialized!
 ```
 
 To overwrite existing files (with automatic backup):
@@ -69,13 +91,35 @@ To overwrite existing files (with automatic backup):
 napt init --force
 ```
 
-This backs up existing files before replacing them:
+This backs up `defaults/org.yaml` before replacing it (directories are never
+touched):
 
 ```console
 $ napt init --force
+Initializing NAPT project in: /path/to/existing-project
+
+[1/2] Creating directory structure...
 [2/2] Creating configuration files...
-      Backed up: defaults/org.yaml -> defaults/org.yaml.backup
-      Created: defaults/org.yaml
+
+======================================================================
+INITIALIZATION RESULTS
+======================================================================
+Project Root:    /path/to/existing-project
+
+Created (1):
+  [OK] defaults/org.yaml
+
+Backed Up (1):
+  [OK] defaults/org.yaml -> org.yaml.backup
+
+Skipped (3):
+  [SKIP] recipes/
+  [SKIP] defaults/vendors/
+  [SKIP] state/deployment/
+
+======================================================================
+
+[SUCCESS] Project initialized!
 ```
 
 ### Next Steps After Init
@@ -200,8 +244,8 @@ psadt:
 2. Validate and test:
 
 ```bash
-napt validate recipes/7-Zip/7zip.yaml
-napt discover recipes/7-Zip/7zip.yaml --verbose
+napt validate recipes/7-Zip/7zip-x64-msi.yaml
+napt discover recipes/7-Zip/7zip-x64-msi.yaml --verbose
 ```
 
 **What to customize:**
@@ -465,7 +509,7 @@ Validate and test recipes thoroughly before using in production.
 5. **Verify build structure:**
    ```bash
    # Check PSADT files are present
-   ls builds/napt-app/*/Invoke-AppDeployToolkit.ps1
+   ls builds/napt-app/*/packagefiles/Invoke-AppDeployToolkit.ps1
    ```
 
 6. **Test packaging:**
@@ -545,29 +589,37 @@ napt upload recipes/Google/chrome.yaml
 
 ```console
 $ napt upload recipes/Google/chrome.yaml
-Uploading 'Google Chrome' (napt-chrome) to Intune...
+Uploading package for recipe: /path/to/recipes/Google/chrome.yaml
 
-[1/6] Locating .intunewin package...
-[2/6] Authenticating with Azure...
-[3/6] Parsing package metadata...
-[4/6] Creating Intune app record for 'Google Chrome' 144.0.7559.110...
-[5/6] Uploading to Azure Blob Storage...
-upload progress: 100%
-[6/6] Committing content version...
-
+[1/9] Locating .intunewin package...
+[2/9] Authenticating with Azure...
+[3/9] Parsing package metadata...
+[4/9] Creating app record for 'Google Chrome'...
+[UPLOAD] Created Intune app: <app id>
+[5/9] Uploading to Azure Blob Storage...
+[6/9] Committing content version...
+[7/9] Creating app record for '[Update] Google Chrome'...
+[UPLOAD] Created Intune app: <update id>
+[8/9] Uploading to Azure Blob Storage...
+[9/9] Committing content version...
 ======================================================================
 UPLOAD RESULTS
 ======================================================================
-App ID:        napt-chrome
-App Name:      Google Chrome
-Version:       144.0.7559.110
-Intune App ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-Package:       packages/napt-chrome/144.0.7559.110/Invoke-AppDeployToolkit.intunewin
-Status:        success
+App ID:          napt-chrome
+App Name:        Google Chrome
+Version:         <version>
+Intune Win32 App ID:    <app id>
+Intune Win32 Update ID: <update id>
+Package:         /path/to/packages/napt-chrome/<version>/Invoke-AppDeployToolkit.intunewin
+Status:          success
 ======================================================================
 
-[SUCCESS] App uploaded to Intune successfully!
+[SUCCESS] Package uploaded to Intune successfully!
 ```
+
+With the default `intune.build_types: "both"`, the install entry and the
+`[Update]` entry are each created, uploaded, and committed (nine steps).
+`app_only` or `update_only` runs six.
 
 ### Full Pipeline Example
 
@@ -1131,14 +1183,16 @@ binary the runner provides, so a cache can never ship the wrong bytes.
 
 The restore step in the discover workflow serves a second purpose:
 bandwidth.
-`napt discover` records each vendor's `ETag`/`Last-Modified` headers in
-`cache/discovery.json` and sends them as conditional request headers on
-the next run; when the vendor answers HTTP 304, the previously
-downloaded installer is reused without transferring a byte.
-A fresh runner starts with neither the header cache nor the files, so
-restoring `cache/` and `downloads/` from the last run is what lets the
-scheduled discover skip re-downloading installers that have not changed
-— which adds up quickly for recipe sets full of large installers.
+`napt discover` skips the download when the installer has not changed:
+`url_download` recipes record the vendor's `ETag`/`Last-Modified` headers
+in `cache/discovery.json` and send them as conditional request headers
+on the next run, reusing the file when the vendor answers HTTP 304;
+`api_github`, `api_json`, and `web_scrape` recipes compare the discovered
+version against the cached one and skip the download on a match.
+Either way, a fresh runner starts with neither the cache nor the files,
+so restoring `cache/` and `downloads/` from the last run is what lets
+the scheduled discover skip re-downloading installers that have not
+changed, which adds up quickly for recipe sets full of large installers.
 Keep the `path` lists of the save and restore steps identical:
 `actions/cache` makes the path list part of the cache version, so a
 mismatched list reads as a silent cache miss.
@@ -1410,7 +1464,7 @@ When a recipe needs changes (new version format, different download URL, etc.).
 
 Common issues and solutions when `napt discover` fails.
 
-### Issue: "Strategy not found"
+### Issue: "Unknown discovery strategy"
 
 **Problem:** Recipe uses a strategy that doesn't exist or isn't registered.
 
@@ -1484,15 +1538,17 @@ Common issues and solutions when `napt discover` fails.
 
 **Solution:**
 
-NAPT automatically handles cache corruption:
+NAPT logs `Failed to load discovery cache` as a warning and continues without
+cache tracking for that run. The corrupted file is left in place, so the warning
+repeats until you fix it. The cache is disposable: delete it and rediscover.
 
-1. Creates backup of corrupted file: `cache/discovery.json.backup`
+```bash
+rm cache/discovery.json
+napt discover recipes/app.yaml
+```
 
-2. Creates a fresh cache file automatically
-
-3. Reports the issue with an error message
-
-The cache is already fixed - just run your command again. Alternatively, use `--stateless` to bypass state tracking temporarily:
+To bypass cache and state tracking for a single run without touching the file,
+use `--stateless`:
 
 ```bash
 napt discover recipes/app.yaml --stateless

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,7 +32,7 @@ Have questions about using NAPT? Open a GitHub Discussion - we're happy to help!
 
 ## Code Contributions
 
-We're currently not accepting code contributions. NAPT is still in active development and has not been officially released yet. The project is evolving rapidly with frequent changes to APIs, schemas, configuration formats, and internal structure.
+We're currently not accepting code contributions. NAPT is still in active development and has not reached 1.0 yet. The project is evolving rapidly with frequent changes to APIs, schemas, configuration formats, and internal structure.
 
 This means:
 
@@ -41,7 +41,7 @@ This means:
 - Breaking changes are common and backward compatibility is not maintained
 - Code contributions would likely require significant maintenance as the codebase evolves
 
-**Once NAPT is officially released**, we'll be open to code contributions and will establish contribution guidelines. Until then, your ideas and feedback are incredibly valuable and help shape the direction of the project.
+**Once NAPT reaches 1.0**, we'll be open to code contributions and will establish contribution guidelines. Until then, your ideas and feedback are incredibly valuable and help shape the direction of the project.
 
 If you're interested in contributing code in the future, please reach out via GitHub Discussion first to discuss the current state and future plans.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -194,26 +194,22 @@ App Count:   1
 ```console
 $ napt discover recipes/Google/chrome.yaml
 Discovering version for recipe: /path/to/recipes/Google/chrome.yaml
-Output directory: /path/to/downloads
 
 [1/4] Loading configuration...
 [2/4] Discovering version...
-[3/4] Discovering version...
-[4/4] Downloading installer...
-download progress: 0%
-...
-download progress: 100%
-[1/1] Download complete: /path/to/downloads/googlechromestandaloneenterprise64.msi (abc123...) in 25.5s
+[3/4] Fetching installer...
+[DOWNLOAD] 100%
+[4/4] Updating state...
 ======================================================================
 DISCOVERY RESULTS
 ======================================================================
 App Name:        Google Chrome
 App ID:          napt-chrome
 Strategy:        url_download
-Version:         144.0.7559.110
+Version:         <version>
 Version Source:  msi
-File Path:       /path/to/downloads/googlechromestandaloneenterprise64.msi
-SHA-256:         abc123...
+File Path:       /path/to/downloads/napt-chrome/googlechromestandaloneenterprise64.msi
+SHA-256:         <sha256>
 Status:          success
 ======================================================================
 
@@ -225,7 +221,6 @@ Status:          success
 ```console
 $ napt build recipes/Google/chrome.yaml
 Building PSADT package for recipe: /path/to/recipes/Google/chrome.yaml
-Downloads directory: /path/to/downloads
 
 [1/8] Loading configuration...
 [2/8] Finding installer...
@@ -240,9 +235,9 @@ BUILD RESULTS
 ======================================================================
 App Name:        Google Chrome
 App ID:          napt-chrome
-Version:         144.0.7559.110
-PSADT Version:   4.1.8
-Build Directory: builds/napt-chrome/144.0.7559.110/packagefiles
+Version:         <version>
+PSADT Version:   <psadt version>
+Build Directory: /path/to/builds/napt-chrome/<version>/packagefiles
 Status:          success
 ======================================================================
 
@@ -253,7 +248,8 @@ Status:          success
 
 ```console
 $ napt package recipes/Google/chrome.yaml
-Creating .intunewin package from: /path/to/builds/napt-chrome/144.0.7559.110
+Creating .intunewin package from: /path/to/builds/napt-chrome/<version>
+Output directory: /path/to/packages
 
 [1/5] Verifying build structure...
 [2/5] Getting IntuneWinAppUtil tool...
@@ -264,35 +260,38 @@ Creating .intunewin package from: /path/to/builds/napt-chrome/144.0.7559.110
 PACKAGE RESULTS
 ======================================================================
 App ID:          napt-chrome
-Version:         144.0.7559.110
-Package Path:    /path/to/packages/napt-chrome/144.0.7559.110/Invoke-AppDeployToolkit.intunewin
-Build Directory: /path/to/builds/napt-chrome/144.0.7559.110
+Version:         <version>
+Package Path:    /path/to/packages/napt-chrome/<version>/Invoke-AppDeployToolkit.intunewin
+Build Directory: /path/to/builds/napt-chrome/<version>
 Status:          success
 ======================================================================
 
 [SUCCESS] .intunewin package created successfully!
 ```
 
-**Result:** Ready-to-upload .intunewin file in `packages/napt-chrome/144.0.7559.110/`
+**Result:** Ready-to-upload .intunewin file in `packages/napt-chrome/<version>/`
 
 ### Quick Check Workflow
 
 Check if a new version is available (skips re-downloading if unchanged):
 
 ```bash
-# Discover with verbose output to see what happens
-napt discover recipes/Google/chrome.yaml --verbose
+napt discover recipes/Google/chrome.yaml
 ```
 
-If the version hasn't changed since the last run and the file exists, you'll see:
+If the installer hasn't changed since the last run, the fetch step reports a
+cache hit instead of downloading:
+
 ```
-[1/4] Checking cached version...
-[2/4] Version unchanged (144.0.7559.110)
-[3/4] File exists, skipping download
-[4/4] Using cached file: downloads/googlechromestandaloneenterprise64.msi
+[3/4] Fetching installer...
+[CACHE] File not modified (HTTP 304), using cached version
 ```
 
-**Note:** This requires having run `napt discover` at least once before to create the cached version.
+For `url_download` recipes the vendor's `ETag`/`Last-Modified` headers decide
+this; the other strategies compare the discovered version to the cached one.
+
+**Note:** This requires having run `napt discover` at least once before to
+populate `cache/discovery.json`.
 
 ### Clean Build Workflow
 
@@ -322,6 +321,7 @@ For step-by-step guides on common workflows, see [Common Tasks](common-tasks.md)
 
 Now that you have NAPT installed and understand the basic commands, explore:
 
+- **[Deploy to Intune](common-tasks.md#deploy-to-intune)** - Set up authentication with `napt auth`, upload the package with `napt upload`, and roll it out with `napt promote`
 - **[Common Tasks](common-tasks.md)** - Step-by-step guides for common workflows
 - **[User Guide](user-guide.md)** - Learn about discovery strategies, configuration, and advanced features
 - **[Creating Recipes](user-guide.md#discovery-strategies)** - Write your own application recipes

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -13,7 +13,7 @@ id: "napt-app-id"          # Required: Unique identifier
 discovery:                  # Required: How to find and download the installer
   strategy: api_github
   # ... strategy-specific fields
-psadt:                      # Required: PowerShell deployment configuration
+psadt:                      # Optional for MSI/MSIX; EXE needs install and uninstall
   install: |
     # ...
   uninstall: |
@@ -43,9 +43,11 @@ Display name for the application. Used in PSADT dialogs and package metadata.
 
 **Type:** `string`
 **Required:** Yes
-**Format:** Lowercase, alphanumeric, hyphens only (e.g., `napt-chrome`, `napt-git`)
+**Convention:** Lowercase, alphanumeric, hyphens (e.g., `napt-chrome`, `napt-git`)
 
-Unique identifier for the application. Used to generate:
+Unique identifier for the application. `napt validate` only checks that it is a
+non-empty string, but keep it filesystem-safe because it becomes a directory
+name. Used to generate:
 
 - Build directory names: `builds/{id}/{version}/`
 - Package names: `packages/{id}/Invoke-AppDeployToolkit.intunewin`
@@ -72,7 +74,7 @@ discovery:
   strategy: api_github
   repo: "owner/repository"          # Required: GitHub repository in owner/repo format
   asset_pattern: ".*\\.exe$"        # Required: Regex pattern to match installer filename
-  version_pattern: "v?([0-9.]+)"    # Required: Regex pattern to extract version from Git tag
+  version_pattern: "v?([0-9.]+)"    # Optional: Regex pattern to extract version from Git tag
   token: "${GITHUB_TOKEN}"          # Optional: GitHub personal access token
 ```
 
@@ -102,7 +104,8 @@ matched against asset filenames from the GitHub Releases API.
 #### version_pattern
 
 **Type:** `string` (regex)
-**Required:** Yes
+**Required:** No
+**Default:** `"v?([0-9.]+)"`
 
 Regular expression pattern to extract version from the Git tag. Should include capture groups
 for version components.
@@ -126,6 +129,18 @@ substitution (e.g., `"${GITHUB_TOKEN}"`) for security.
 
 - Avoid GitHub API rate limits (60 requests/hour unauthenticated, 5000/hour authenticated)
 - Access private repositories
+
+#### prerelease
+
+**Type:** `boolean`
+**Required:** No
+**Default:** `false`
+
+Whether a release marked as a pre-release on GitHub may be selected. NAPT always
+looks at the most recent release only; when it is a pre-release and this field
+is `false`, discovery fails with an error rather than walking back to an older
+stable release. Set to `true` for projects whose latest release is routinely a
+pre-release.
 
 **How it works:** Queries GitHub Releases API, finds the latest release, matches assets using
 `asset_pattern`, extracts version from tag using `version_pattern`.
@@ -236,7 +251,7 @@ is available.
 discovery:
   strategy: web_scrape
   page_url: "https://vendor.com/download"           # Required: URL of vendor download page
-  link_selector: 'a[href$=".msi"]'                  # Required: CSS selector to find download link
+  link_selector: 'a[href$=".msi"]'                  # One of link_selector or link_pattern
   version_pattern: "app-(\\d+\\.\\d+)\\.msi"        # Required: Regex to extract version from URL
   version_format: "{0}"                              # Optional: Format string for captured groups
 ```
@@ -251,9 +266,10 @@ URL of the vendor download page that contains links to installer files.
 #### link_selector
 
 **Type:** `string` (CSS selector)
-**Required:** Yes
+**Required:** One of `link_selector` or `link_pattern`
 
 CSS selector to find the download link on the page. Uses standard CSS selector syntax.
+Preferred over `link_pattern` when the page structure allows it.
 
 **Examples:**
 - `'a[href$=".msi"]'` - Matches links ending in `.msi`
@@ -263,6 +279,26 @@ CSS selector to find the download link on the page. Uses standard CSS selector s
 
 **Note:** The selector should match exactly one link. If multiple links match, the first match
 is used.
+
+#### link_pattern
+
+**Type:** `string` (regex)
+**Required:** One of `link_selector` or `link_pattern`
+
+Regular expression applied to the raw page HTML to find the download link when
+a CSS selector cannot pin it down (for example, a URL embedded in a script
+block). Must contain exactly one capture group around the link URL; the first
+match is used.
+
+**Example:**
+
+```yaml
+discovery:
+  strategy: web_scrape
+  page_url: "https://vendor.example.com/downloads"
+  link_pattern: 'href="(/files/app-v[0-9.]+-x64\.msi)"'
+  version_pattern: "app-v([0-9.]+)-x64"
+```
 
 #### version_pattern
 
@@ -294,8 +330,9 @@ string syntax with `{0}`, `{1}`, etc. for capture groups.
 - `"{1}.{0}"` - Reverses order: `"01"` + `"25"` → `"01.25"`
 - `"v{0}"` - Prefixes version: `"2.51.2"` → `"v2.51.2"`
 
-**How it works:** Downloads HTML from `page_url`, finds link using CSS selector, extracts
-version from URL using regex pattern, formats version using `version_format` if provided.
+**How it works:** Downloads HTML from `page_url`, finds the link using `link_selector` (CSS)
+or `link_pattern` (regex), extracts the version from the URL using `version_pattern`, and
+formats it using `version_format` if provided.
 
 ## PSADT Configuration
 
@@ -317,7 +354,7 @@ psadt:
 
 **Type:** `string`
 **Required:** No
-**Default:** `"latest"` (from organization defaults)
+**Default:** `"latest"`
 
 PSADT release version to use. Can be:
 
@@ -325,6 +362,32 @@ PSADT release version to use. Can be:
 - Specific version: `"4.1.7"` - Use a specific PSADT version
 
 **Note:** Typically set in organization defaults (`defaults/org.yaml`) rather than per-recipe.
+
+### brand_pack
+
+**Type:** `object`
+**Required:** No
+**Default:** None (PSADT's default assets are used)
+
+Replaces PSADT's default dialog assets (logo, banner) with your organization's
+files in every build. Set in `defaults/org.yaml` rather than per-recipe.
+
+```yaml
+psadt:
+  brand_pack:
+    path: brand-packs/my-company        # Folder holding your assets
+    mappings:
+      - source: "AppIcon.*"             # Glob, relative to path
+        target: "Assets/AppIcon"        # Destination in the build, without extension
+      - source: "Banner.Classic.*"
+        target: "Assets/Banner.Classic"
+```
+
+- `path` is resolved relative to the directory containing `defaults/` (or the
+  recipe's directory when there is none). A path that does not exist is
+  skipped with a verbose log line rather than an error.
+- Each mapping copies the first file matching `source` to `target`, appending
+  the source file's extension. Mappings whose glob matches nothing are skipped.
 
 ### app_vars
 
@@ -339,8 +402,10 @@ PSADT application variables set in the generated `Invoke-AppDeployToolkit.ps1` f
 - `AppName`: Display name shown in PSADT dialogs
 - `AppVersion`: Application version (use `{{discovered_version}}` for auto-substitution)
 - `AppVendor`: Vendor name (typically set in vendor defaults)
-- `AppArch`: Architecture (`x64`, `x86`, or `All`)
 - `AppLang`: Application language
+
+NAPT sets `AppArch` itself from the installer architecture; `napt validate`
+rejects it as an `app_vars` key.
 
 **Build-time variables:** NAPT substitutes `{{discovered_version}}` (the version
 discovered by NAPT) and `{{installer_filename}}` (the exact filename of the downloaded
@@ -577,6 +642,7 @@ intune:
 Minimum Windows 10/11 feature update required to install the app, enforced during Intune
 assignment. Format: `"Windows10_<release>"` or `"Windows11_<release>"` where release is
 the feature update name (e.g., `"Windows10_21H2"`, `"Windows10_22H2"`, `"Windows11_23H2"`).
+Older four-digit release names are also accepted (e.g., `"Windows10_1809"`).
 
 ### install_command
 
@@ -703,14 +769,6 @@ App description displayed in the Intune portal and Company Portal app.
 
 Publisher name shown in Intune and the Company Portal. Override when the directory name doesn't
 match the official publisher name.
-
-### category
-
-**Type:** `string`
-**Required:** No
-**Default:** None
-
-Intune app category. Must match an existing category name in your Intune tenant.
 
 ### privacy_url
 
@@ -952,6 +1010,30 @@ output and embeds them as inline PowerShell rules in the Intune app record.
 
 See [Detection and Requirements Scripts](user-guide.md#detection-and-requirements-scripts) in
 the User Guide for how scripts work and how to configure them in Intune.
+
+## IntuneWinAppUtil Configuration
+
+The `intunewin` section controls the Microsoft packaging tool `napt package`
+uses. Set in `defaults/org.yaml`; it is not a per-recipe setting.
+
+```yaml
+intunewin:
+  release: "latest"   # Optional: IntuneWinAppUtil.exe release
+```
+
+### release
+
+**Type:** `string`
+**Required:** No
+**Default:** `"latest"`
+
+Which `IntuneWinAppUtil.exe` release to download and run. Can be:
+
+- `"latest"` - Use the latest release from Microsoft's GitHub repository
+- Specific version: `"1.8.6"` - Pin to a known-good release for reproducible packaging
+
+Each release is cached independently under `cache/tools/{version}/`, so changing
+the pin never overwrites a previously downloaded tool.
 
 ## Logging Configuration
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,8 +25,9 @@ This roadmap is a living document showing potential future directions for NAPT. 
 |---------|--------|----------|------------|-------|
 | Recipe Schema Redesign | ✅ Completed | User-Facing | High | High |
 | Microsoft Intune Upload | ✅ Completed | User-Facing | High | Very High |
-| `napt auth setup` Command | 💡 Idea | User-Facing | Low | High |
+| `napt auth setup` Command | ✅ Completed | User-Facing | Medium | High |
 | Deployment Wave Management | ✅ Completed | User-Facing | Very High | High |
+| Detection Script Generation | ✅ Completed | User-Facing | High | High |
 | Pre/Post Install/Uninstall Script Support | 💡 Idea | User-Facing | Low | Medium |
 | Enhanced CLI Help Menu | 💡 Idea | User-Facing | Low | Medium |
 | Intune App Categorization & Scope Tags | 💡 Idea | User-Facing | Medium | Medium |
@@ -38,13 +39,13 @@ This roadmap is a living document showing potential future directions for NAPT. 
 | Typed Config with Dataclasses | 💡 Idea | Code Quality | Medium | Medium |
 | EXE Version Extraction | 💡 Idea | Technical | High | Medium |
 | Parallel Package Building | 💡 Idea | Technical | Medium | Medium |
-| IntuneWinAppUtil Version Tracking | 💡 Idea | Technical | Low | Low |
+| IntuneWinAppUtil Version Pinning | ✅ Completed | Technical | Low | Low |
 | Minify Scripts at Intune Upload | 💡 Idea | Technical | Medium | Medium |
 
 **Summary:**
 
-- ✅ **Completed**: 4
-- 💡 **Ideas**: 14
+- ✅ **Completed**: 7
+- 💡 **Ideas**: 11
 - **Total**: 18 features
 
 ---
@@ -65,41 +66,15 @@ _Nothing currently in progress._
 
 ### User-Facing Features
 
-#### `napt auth setup` Command
-
-**Status**: 💡 Idea
-**Complexity**: Low (few hours to 1 day)
-**Value**: High
-
-**Description**: Automates app registration creation in Microsoft Entra ID
-using the Azure CLI.
-Runs `az ad app create`, adds `DeviceManagementApps.ReadWrite.All` application
-and delegated permissions, grants admin consent, and outputs the `AZURE_CLIENT_ID`
-and `AZURE_TENANT_ID` values to set.
-Creates a natural namespace for future `napt auth status` and `napt auth logout`
-subcommands.
-
-**Benefits**:
-
-- Reduces one-time setup from a multi-step portal workflow to a single command
-- Requires only `az login` as a prerequisite — no portal navigation needed
-- Outputs exact env vars to set, eliminating copy-paste errors
-- Enables future auth management subcommands
-
-**Prerequisites**:
-
-- Azure CLI installed and authenticated with an account that can create app
-  registrations
-
 #### Intune App Categorization & Scope Tags
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
 **Value**: Medium
 
-**Description**: Expose `intune.category` and `intune.role_scope_tag_ids` as
+**Description**: Add `intune.category` and `intune.role_scope_tag_ids` as
 recipe fields.
-Both require a Graph API lookup before the app POST — category names must be
+Both require a Graph API lookup before the app POST: category names must be
 resolved to IDs via `GET /deviceAppManagement/mobileAppCategories`, and scope
 tag names must be resolved via `GET /deviceManagement/roleScopeTags`.
 
@@ -107,8 +82,6 @@ tag names must be resolved via `GET /deviceManagement/roleScopeTags`.
 
 - Categorized apps are easier to find in the Intune portal and Company Portal
 - Scope tags enable RBAC so only authorized admins can see/manage an app
-- Both fields are already stubbed in validation but produce no effect until
-  implemented
 
 **Dependencies**:
 
@@ -209,7 +182,8 @@ to catch errors before deployment.
 - Better developer experience
 - Reduces debugging time during deployment
 
-**Related**: TODO in `napt/build/packager.py` - discovered during testing
+**Related**: Overlaps with Recipe Linting & Best Practices below; syntax
+checking is the narrower first step.
 
 #### Recipe Linting & Best Practices
 
@@ -297,7 +271,8 @@ headers for .exe installers.
 - Enables version discovery for applications distributed as EXE
 - Useful for vendors who don't provide version in URL or API
 
-**Related**: Mentioned in `napt/discovery/url_download.py` docstring
+**Related**: `url_download` only extracts versions from MSI installers today
+and raises `ConfigError` for other extensions when no version is discoverable.
 
 #### Parallel Package Building
 
@@ -314,25 +289,6 @@ multi-app workflows.
 - Reduces time for monthly update cycles
 - Improves CI/CD pipeline performance
 - Progress reporting for multiple concurrent builds
-
-#### IntuneWinAppUtil Version Tracking
-
-**Status**: 💡 Idea
-**Complexity**: Low (few hours to 1 day)
-**Value**: Low
-
-**Description**: Track version of IntuneWinAppUtil.exe in cache metadata
-instead of always using latest from master, allowing pinning to specific
-commits/releases and optional configuration for tool version/source.
-
-**Benefits**:
-
-- Reproducible builds (pin to known-good version)
-- Control over tool updates
-- Better for air-gapped environments
-- Auto-detect when tool updates are available
-
-**Related**: TODO in `napt/build/packager.py:47`
 
 #### Minify Scripts at Intune Upload
 
@@ -357,11 +313,12 @@ Optional: PowerShell-invoked AST-based minifier for greater reduction.
 
 **Dependencies**:
 
-- Requires Intune upload implementation (or a separate "prepare for upload"
-  step that emits minified content)
+- Hooks into the existing `napt upload` path where detection and
+  requirements scripts are read from `packages/` and embedded in the
+  Graph payload
 
 **Related**: Intune default policy limit is 4 MB total; NAPT detection +
-requirements scripts are ~40 KB per app (~70–100 apps depending on code
+requirements scripts are ~40 KB per app (~70-100 apps depending on code
 signing)
 
 ---
@@ -371,6 +328,49 @@ signing)
 ---
 
 ## Recently Completed
+
+#### `napt auth setup` Command
+
+**Status**: ✅ Completed
+**Complexity**: Medium
+**Value**: High
+
+**Description**: `napt auth setup --tenant-id <id>` creates the NAPT app
+registration in Microsoft Entra ID directly through Microsoft Graph (no
+Azure CLI dependency), or brings an existing one up to spec: redirect URIs,
+application and delegated Graph permissions, service principal, and admin
+consent.
+Shipped alongside `napt auth login`, `status`, and `logout`.
+
+**Notes**:
+
+- Re-running is safe: compares the registration with what the installed
+  NAPT version needs and adds only what is missing, never removing anything
+- `--federated-issuer` / `--federated-subject` add a federated credential
+  so CI/CD can authenticate through OIDC without a client secret
+- Registrations are stamped with a provenance note; an unstamped name
+  match is left untouched unless `--adopt` is given
+- `--print-only` prints the equivalent portal checklist for tenants where
+  the automated path is not allowed
+
+**Related**: See [User Guide - App Registration Setup](user-guide.md#app-registration-setup).
+
+---
+
+#### IntuneWinAppUtil Version Pinning
+
+**Status**: ✅ Completed
+**Complexity**: Low
+**Value**: Low
+
+**Description**: `intunewin.release` in `defaults/org.yaml` pins the
+`IntuneWinAppUtil.exe` release `napt package` downloads (default `latest`).
+Each release is cached independently under `cache/tools/{version}/`, so
+builds are reproducible against a known-good tool version.
+
+**Related**: Shipped in 0.5.0. See [User Guide - Package Process](user-guide.md#package-process-napt-package).
+
+---
 
 #### Deployment Wave Management
 
@@ -464,11 +464,10 @@ Typo detection suggests similar field names (e.g., "Did you mean
 
 **Description**: `napt upload <recipe>` uploads `.intunewin` packages directly
 to Microsoft Intune via the Graph API.
-Authentication is automatic via `azure-identity` (`EnvironmentCredential` →
-`ManagedIdentityCredential` → `DeviceCodeCredential`).
 Detection and requirements scripts are embedded inline from build output.
-Developers set `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` and complete the device
-code flow; CI/CD sets all three `AZURE_*` env vars.
+Authentication now goes through `napt auth login` for developers and the
+`AZURE_*` environment variables or Azure CLI for CI/CD; see
+[User Guide - Authentication](user-guide.md#authentication).
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -20,14 +20,14 @@ The discovery process finds the latest version and downloads the installer:
 6. **Update Cache** - Updates `cache/discovery.json` with new version, file path, SHA-256 hash, and ETag (if download occurred)
 7. **Record Pending Release** - Updates `state/deployment/{app_id}.json` with the discovered release as the pending publication candidate when it differs from the published version. The pending slot holds one candidate and the newest discovery wins.
 
-**Output**: Downloaded installer in `downloads/` directory, updated discovery cache, updated deployment state
+**Output**: Downloaded installer in `downloads/{app_id}/`, updated discovery cache, updated deployment state
 
 ### Build Process (`napt build`)
 
 The build process creates a complete PSADT package from the recipe and downloaded installer:
 
 1. **Load Configuration** - Merges configuration layers (org → vendor → recipe)
-2. **Find Installer** - Locates installer in `downloads/` directory (tries URL filename, then app name/id, then most recent). Supports `.msi`, `.exe`, and `.msix` files
+2. **Find Installer** - Locates installer in `downloads/{app_id}/` (tries the recipe URL filename, then the filename recorded in the discovery cache or pending release, then an app name/id match, then the most recent file). Supports `.msi`, `.exe`, and `.msix` files
 3. **Extract Version** - Extracts version from installer file (MSI from ProductVersion, MSIX from AppxManifest.xml), otherwise uses discovery cache version
 4. **Get PSADT Release** - Downloads/caches PSADT Template_v4 from GitHub if not already cached
 5. **Create Build Directory** - Creates versioned directory using discovered app version: `builds/{app_id}/{version}/`
@@ -48,7 +48,7 @@ The build process creates a complete PSADT package from the recipe and downloade
     - Sets dynamic values (AppScriptDate, discovered version, PSADT version)
     - Preserves PSADT's structure and comments
 8. **Copy Installer** - Copies downloaded installer file to `Files/` directory:
-    - Source: `downloads/{installer_filename}`
+    - Source: `downloads/{app_id}/{installer_filename}`
     - Destination: `builds/{app_id}/{version}/Files/{installer_filename}`
     - Installer is accessible in scripts via `$($adtSession.DirFiles)` (PSADT 4.x)
 9. **Apply Branding** - Replaces PSADT default assets with custom branding (if configured):
@@ -96,9 +96,9 @@ identity name instead of registry scanning; which store is queried depends on
     - **Non-MSI installers (permissive):** Match any registry entry (MSI or non-MSI) to handle EXE installers that run embedded MSIs internally.
 
 - **Architecture filtering:**
-    - Controls which registry views are checked based on the `AppArch` value from `psadt.app_vars` in the recipe
-    - **MSI installers:** AppArch is automatically extracted from MSI package metadata during discovery (no manual configuration needed)
-    - **Non-MSI installers:** AppArch must be explicitly specified in `intune.detection` (e.g., `architecture: "x64"`)
+    - Controls which registry views are checked based on the installer architecture NAPT resolves at build time (NAPT sets `AppArch` in the generated script; it is not a recipe `app_vars` key)
+    - **MSI installers:** architecture is extracted from MSI package metadata (no manual configuration needed)
+    - **Non-MSI installers:** architecture must be specified in `intune.detection` (e.g., `architecture: "x64"`)
     - **Architecture values:**
         - `x64` / `arm64`: Checks only 64-bit registry view (ARM64 uses 64-bit registry)
         - `x86`: Checks only 32-bit registry view
@@ -152,8 +152,9 @@ Scripts are saved as siblings to the `packagefiles/` directory and are NOT inclu
 builds/napt-chrome/144.0.7559.110/
   ├── packagefiles/                                 # PSADT package (packaged into .intunewin)
   │   └── ...
-  ├── Google-Chrome-144.0.7559.110-Detection.ps1    # Detection script
-  └── Google-Chrome-144.0.7559.110-Requirements.ps1 # Requirements script (if generated)
+  ├── Google-Chrome_144.0.7559.110-Detection.ps1    # Detection script
+  ├── Google-Chrome_144.0.7559.110-Requirements.ps1 # Requirements script (if generated)
+  └── build-manifest.json                           # Installer hash and metadata
 ```
 
 **Configuration:** See [Recipe Reference - Intune Configuration](recipe-reference.md#intune-configuration) for `intune.detection` and `intune.build_types` options.
@@ -225,9 +226,10 @@ recipe's app:
     - Input: `packagefiles/` subdirectory of the build (PSADT structure)
     - Output: `Invoke-AppDeployToolkit.intunewin` in `packages/{app_id}/{version}/`
     - Previous version directory for this app is removed automatically
-5. **Copy Detection Scripts** - Copies `*-Detection.ps1` and `*-Requirements.ps1`
-   from the build version directory into `packages/{app_id}/{version}/` so that
-   `napt upload` is self-contained and does not need access to the builds directory
+5. **Copy Detection Scripts** - Copies `*-Detection.ps1`, `*-Requirements.ps1`,
+   and `build-manifest.json` from the build version directory into
+   `packages/{app_id}/{version}/` so that `napt upload` is self-contained and
+   does not need access to the builds directory
 6. **Optional Cleanup** - If `--clean-source` flag is used, removes the build
    version directory after successful packaging
 
@@ -299,8 +301,9 @@ source it picked:
 | Azure CLI (`AzureCliCredential`) | Nothing above applies and the Azure CLI is signed in as a service principal — CI/CD with OIDC through a login step such as GitHub Actions `azure/login`. Recommended over a client secret whenever your CI platform supports it. A CLI signed in as a person is refused, since its tokens belong to the Azure CLI's own application, not the NAPT registration |
 
 NAPT never opens a browser on its own.
-If no credential is available, commands fail with
-`Not authenticated. Run 'napt auth login'`.
+If no credential is available, commands fail with `Not authenticated.`
+followed by a hint for each option: run `napt auth login` interactively, or
+set the `AZURE_*` variables or sign in with `az login` for CI/CD.
 
 #### App Registration Setup
 
@@ -384,7 +387,8 @@ Tokens are cached in the OS credential store (DPAPI, Keychain, or
 libsecret) and refreshed silently until the session expires or is revoked.
 The remembered tenants and the cache live under `%LOCALAPPDATA%\napt`
 (Windows), `~/Library/Application Support/napt` (macOS), or
-`~/.config/napt` (Linux); set `NAPT_USER_DIR` to relocate them.
+`$XDG_CONFIG_HOME/napt` falling back to `~/.config/napt` (Linux); set
+`NAPT_USER_DIR` to relocate them.
 The `AZURE_*` environment variables play no part in interactive sign-in;
 they are how CI/CD supplies a credential (below), and when they are set
 they take precedence over your session.
@@ -506,7 +510,8 @@ After a complete workflow, your directory structure looks like:
 
 ```
 downloads/
-  └── googlechromestandaloneenterprise64.msi
+  └── napt-chrome/
+      └── googlechromestandaloneenterprise64.msi
 
 builds/
   └── napt-chrome/
@@ -522,15 +527,17 @@ builds/
           │   ├── SupportFiles/            # Empty (for additional files)
           │   ├── Invoke-AppDeployToolkit.ps1  # Generated script
           │   └── Invoke-AppDeployToolkit.exe  # From template
-          ├── Google-Chrome-142.0.7444.163-Detection.ps1
-          └── Google-Chrome-142.0.7444.163-Requirements.ps1
+          ├── Google-Chrome_142.0.7444.163-Detection.ps1
+          ├── Google-Chrome_142.0.7444.163-Requirements.ps1
+          └── build-manifest.json              # Installer hash and metadata
 
 packages/
   └── napt-chrome/
       └── 142.0.7444.163/                              # One version kept at a time
           ├── Invoke-AppDeployToolkit.intunewin        # Encrypted package
-          ├── Google-Chrome-142.0.7444.163-Detection.ps1    # Copied by napt package
-          └── Google-Chrome-142.0.7444.163-Requirements.ps1 # Copied by napt package
+          ├── Google-Chrome_142.0.7444.163-Detection.ps1    # Copied by napt package
+          ├── Google-Chrome_142.0.7444.163-Requirements.ps1 # Copied by napt package
+          └── build-manifest.json                      # Copied by napt package; read by napt upload
 
 cache/
   └── discovery.json                       # Discovery cache (disposable)
@@ -654,6 +661,7 @@ promotable in the same run.
 napt promote plan [RECIPE_OR_DIR] [OPTIONS]
 napt promote plan --check-drift --reconcile
 napt promote apply [RECIPE_OR_DIR] [OPTIONS]
+napt promote apply --plan-file state/plans/<id>.json
 ```
 
 For the full review-gated CI setup — publish PRs, promotion PRs, and
@@ -686,6 +694,7 @@ Manages the credential NAPT uses for Intune.
 See [Authentication](#authentication).
 
 ```bash
+napt auth setup --tenant-id ID [OPTIONS]
 napt auth login [--tenant-id ID] [--client-id ID] [--no-broker]
 napt auth status
 napt auth logout
@@ -699,7 +708,7 @@ All commands support verbosity flags to control output detail:
 |------|---------------|
 | (none) | Clean output with step indicators (e.g., `[1/4]`) and progress |
 | `--verbose` or `-v` | All of the above, plus HTTP requests/responses, file operations, SHA-256 hashes, and configuration loading |
-| `--debug` or `-d` | All verbose output, plus full YAML config dumps (org/vendor/recipe/merged), backend selection details, and regex match groups |
+| `--debug` or `-d` | All verbose output, plus full YAML config dumps (org/vendor/recipe/merged), backend selection details, and raw API responses |
 
 Debug mode includes all verbose output plus deep diagnostic information. Use `--verbose` for normal troubleshooting and `--debug` when you need to understand exactly what NAPT is doing internally.
 
@@ -771,7 +780,8 @@ intune:                # Optional: Intune-specific settings
 ### Quick Reference
 
 - **Top-level fields:** `apiVersion` (required), `name` (required), `id` (required),
-  `discovery` (required), `psadt` (required), `intune` (optional), `logging` (optional)
+  `discovery` (required), `psadt` (optional for MSI and MSIX; EXE installers need
+  `psadt.install` and `psadt.uninstall`), `intune` (optional), `logging` (optional)
 - **Discovery strategies:** See [Discovery Strategies](#discovery-strategies) section above for strategy selection and examples
 - **PSADT scripts:** NAPT substitutes `{{discovered_version}}` and `{{installer_filename}}` at build time (these are not PowerShell variables); `${UPPERCASE}` env vars work only in `discovery.token`/`discovery.headers`; use `$($adtSession.DirFiles)` for the files directory path (PSADT 4.x)
 
@@ -1105,7 +1115,7 @@ napt package recipes/Google/chrome.yaml
 
 ### Recipe Organization
 
-Organize recipes by vendor: `recipes/<Vendor>/<app>.yaml`. NAPT automatically detects vendor from directory structure and loads `defaults/vendors/<Vendor>.yaml` if it exists.
+Organize recipes by vendor: `recipes/<Vendor>/<app>.yaml`. NAPT detects the vendor from the recipe's parent directory name (falling back to `psadt.app_vars.AppVendor`) and loads `defaults/vendors/<Vendor>.yaml` if it exists.
 
 ### State Management
 
@@ -1137,12 +1147,13 @@ brew install msitools           # macOS
 
 **Problem**: Discovery cache corrupted
 
-```bash
-# NAPT automatically creates backup
-# Backup saved to: cache/discovery.json.backup
+NAPT logs a warning and continues without cache tracking for that run; the
+corrupted file is left in place. The cache is disposable, so delete it and
+rediscover:
 
-# Force re-download
-napt discover recipes/app.yaml --stateless
+```bash
+rm cache/discovery.json
+napt discover recipes/app.yaml
 ```
 
 **Problem**: GitHub API rate limit


### PR DESCRIPTION
## Description
Corrects every stale or wrong claim found by a full line-by-line review of README.md and every file under docs/ against the current code and CLI help output.

## Motivation
The docs had drifted from the code in a lot of small ways: sample console output that NAPT never prints, paths missing the per-app subdirectory, a cache "auto-backup" feature that doesn't exist, fields documented as required that aren't, real fields that were never documented, a roadmap still listing shipped features as ideas, and a branching guide describing a merge process we've never used. None of it was big on its own, but together it meant a new user following the docs would hit mismatches in the first ten minutes. This clears all of it before 0.10.0.

## Changes
- Sample output for `napt init`, `discover`, `build`, `package`, and `upload` replaced with what the commands actually print; version-specific values replaced with placeholders so the blocks don't rot
- Paths and names: `downloads/{app_id}/`, `packagefiles/`, underscore-joined detection and requirements script names, `build-manifest.json` in the directory trees, the 7-Zip walkthrough filename, and the README Developer Reference link
- Removed the nonexistent `cache/discovery.json.backup` recovery claim in two places and documented the real warn-and-continue behavior
- Recipe reference: `version_pattern` now optional with its default, `link_selector` is one-of with the newly documented `link_pattern`, `AppArch` removed from the app_vars list (NAPT sets it), `id` format reworded as a convention, `psadt` marked optional for MSI/MSIX, `category` section removed (never applied by upload), and new sections for `prerelease`, `brand_pack`, and `intunewin.release`
- User guide: `napt auth setup` in the auth synopsis, `promote apply --plan-file`, `$XDG_CONFIG_HOME`, `AppVendor` vendor-detection fallback, corrected `--debug` description and installer lookup order
- Roadmap: `napt auth setup` and IntuneWinAppUtil pinning moved to Recently Completed with accurate descriptions, Detection Script Generation added to the table, counts fixed, dead TODO references replaced
- Branching guide: squash-and-merge for every PR including releases, prefix table matches commit types (`feat/`, `fix/`), quality checklist lists ruff/black/pyright/vulture/pytest
- Quick start now points at auth, upload, and promote after packaging

## Testing
- [x] `mkdocs build --strict` clean; all new cross-doc anchors verified in the rendered site
- [x] Every factual change cross-checked against `napt/` by the napt-reviewer (verdict: ship)
- [x] Full test suite passes (812 tests); docs-only change

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors
