### PR TITLE
docs: Use sentence case for headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Packaging applications for Microsoft Intune with PSAppDeployToolkit (PSADT) typi
 
 This manual workflow is repetitive, difficult to automate in CI/CD pipelines, lacks version tracking, and requires re-doing most of the work for every update. NAPT automates this entire workflow with YAML-based recipes and automatic version tracking.
 
-### Key Features
+### Key features
 
 - ✅ **Automatic version tracking** - Automatic discovery from MSI, EXE, URLs, or APIs with caching to skip unnecessary downloads
 - ✅ **YAML-based recipes** - Define app packaging once with layered configuration (Organization → Vendor → Recipe)
@@ -38,7 +38,7 @@ This manual workflow is repetitive, difficult to automate in CI/CD pipelines, la
 - ✅ **Cross-platform workflow** - Run on Windows, Linux, and macOS (packaging requires Windows)
 - ✅ **Direct Intune upload** - Upload to Microsoft Intune via the Graph API, no portal required
 
-## Cross-Platform Support
+## Cross-platform support
 
 | Feature | Windows | Linux/macOS |
 |---------|---------|-------------|
@@ -47,13 +47,13 @@ This manual workflow is repetitive, difficult to automate in CI/CD pipelines, la
 | Intune Packaging | ✅ | ⚫ Windows Only |
 | Intune Upload | ✅ | ✅ |
 
-See the [Cross-Platform Support](https://rogercibrian.github.io/notapkgtool/user-guide/#cross-platform-support) section for platform-specific workflows.
+See the [Cross-platform support](https://rogercibrian.github.io/notapkgtool/user-guide/#cross-platform-support) section for platform-specific workflows.
 
-## Getting Started
+## Getting started
 
 See the [Quick Start Guide](https://rogercibrian.github.io/notapkgtool/quick-start/) for installation and setup.
 
-## Creating Recipes
+## Creating recipes
 
 Recipes are YAML configuration files that define how to discover, download, and package applications.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,8 +1,8 @@
-# Developer Reference
+# Developer reference
 
 Overview of NAPT's codebase structure, architecture, and key concepts for contributors.
 
-## Code Organization
+## Code organization
 
 NAPT's codebase structure matches the module organization. Here's the file structure:
 
@@ -72,7 +72,7 @@ napt/
     └── msix.py                 # MSIX metadata extraction (AppxManifest)
 ```
 
-### Data Flow
+### Data flow
 
 ```
 Recipe YAML
@@ -94,12 +94,12 @@ Recipe YAML
 Result (dataclass)
 ```
 
-## Quick Start
+## Quick start
 
 - **Adding a CLI command:** See [`cli/`](cli.md) for command registration patterns
 - **Adding discovery strategies:** Implement `DiscoveryStrategy` protocol from [`discovery/base.py`](discovery.md)
 
-## Key Concepts
+## Key concepts
 
 - **Discovery Strategies:** Protocol-based, stateless, listed in an explicit registry table (api_github, api_json, web_scrape). All return a `RemoteVersion` from configuration alone. The orchestrator runs the result through `resolve_with_cache` to skip the download when the version is unchanged. `url_download` is a separate flow (not a registered strategy) because it must download the file to determine the version.
 - **Configuration:** 3-layer system (org → vendor → recipe) with deep merging
@@ -107,7 +107,7 @@ Result (dataclass)
 - **Exceptions:** All NAPT domain errors use custom exceptions inheriting from `NAPTError` (ConfigError, NetworkError, PackagingError, StateError, AuthError) - allows catching all NAPT errors or specific types
 - **Return Types:** Frozen dataclasses from `results.py`, one per napt command's underlying operation (type-safe, immutable returns)
 
-## Design Principles
+## Design principles
 
 - Single Responsibility per module
 - Protocol-based interfaces (typing.Protocol)
@@ -122,7 +122,7 @@ Result (dataclass)
 - **New CLI command:** Create `napt/cli/<command>.py` with the `cmd_<name>()` handler and a `register(subparsers)` hook, call `register` from `main()` in `napt/cli/main.py`, and add `tests/cli/test_<command>.py` (strict one module per command)
 - **New config option:** Update schema in `config/loader.py`, add validation in `validation.py`, document in recipe schema
 
-## See Also
+## See also
 
 - [Discovery manager](discovery-manager.md) - Discovery orchestration
 - [Discovery API](discovery.md) - Discovery strategy implementations

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -1,19 +1,19 @@
-# Branching Strategy
+# Branching strategy
 
 NAPT uses **GitHub Flow** - a simple, branch-based workflow that keeps `main` always deployable.
 
-## Core Principles
+## Core principles
 
 1. **`main` branch is always stable** - Production-ready code only
 2. **Feature branches for all work** - Every change starts from a branch
 3. **Pull Requests for review** - All changes reviewed before merging
 4. **Merge frequently** - Keep branches short-lived (< 1 week ideal)
 
-## Quick Start
+## Quick start
 
 The most common workflow for making changes:
 
-### 1. Start New Work
+### 1. Start new work
 
 ```bash
 # Always start from updated main
@@ -24,7 +24,7 @@ git pull origin main
 git checkout -b feat/your-feature-name
 ```
 
-### 2. During Development
+### 2. During development
 
 ```bash
 # Make changes, commit frequently
@@ -35,7 +35,7 @@ git commit -m "feat: add your feature"
 git push origin feat/your-feature-name
 ```
 
-### 3. Create Pull Request
+### 3. Create pull request
 
 1. Push your branch to GitHub
 2. Create a Pull Request on GitHub
@@ -43,7 +43,7 @@ git push origin feat/your-feature-name
 4. Request review from maintainers
 5. Address any feedback
 
-### 4. After Merge
+### 4. After merge
 
 ```bash
 # Update your local main
@@ -56,9 +56,9 @@ git branch -d feat/your-feature-name
 # Remote branch is usually auto-deleted by GitHub
 ```
 
-## Branch Management
+## Branch management
 
-### Branch Structure
+### Branch structure
 
 ```
 main (always deployable)
@@ -68,7 +68,7 @@ main (always deployable)
 └── refactor/simplify-config-loader
 ```
 
-### Branch Naming Convention
+### Branch naming convention
 
 Use descriptive names with type prefixes:
 
@@ -87,7 +87,7 @@ The prefix is the conventional commit type the PR will squash to:
 `feature/` and `bugfix/` also appear in the history and are accepted, but
 prefer the short forms so the branch name and the squash commit type match.
 
-### Naming Rules
+### Naming rules
 
 - Use lowercase with hyphens
 - Be descriptive but concise (3-6 words)
@@ -110,9 +110,9 @@ Feat/My_Branch         # Wrong case
 fix-bug                # Too generic
 ```
 
-## Commit Guidelines
+## Commit guidelines
 
-### Commit Message Format
+### Commit message format
 
 Use conventional commit format for clarity:
 
@@ -122,7 +122,7 @@ Use conventional commit format for clarity:
 [optional body]
 ```
 
-### Commit Types
+### Commit types
 
 | Type | Purpose | Example |
 |------|---------|---------|
@@ -134,7 +134,7 @@ Use conventional commit format for clarity:
 | `chore` | Maintenance | `chore: update Poetry dependencies` |
 | `perf` | Performance | `perf: optimize version comparison` |
 
-### Commit Guidelines
+### Commit guidelines
 
 - Use imperative mood: "add" not "added" or "adds"
 - Keep subject line under 50 characters
@@ -156,18 +156,18 @@ git commit -m "Fix bug"               # No type prefix
 git commit -m "WIP"                   # Too vague
 ```
 
-## Pull Request Process
+## Pull request process
 
 When creating a PR, the [PR template](https://github.com/RogerCibrian/notapkgtool/blob/main/.github/PULL_REQUEST_TEMPLATE.md) auto-populates with sections for Description, Motivation, Changes, Testing, and Checklist.
 
-## Merge Strategy
+## Merge strategy
 
 **Squash and Merge, always**
 
 NAPT uses **squash and merge** for every Pull Request, including release
 PRs, to maintain a clean, readable history in `main`.
 
-### Why Squash and Merge?
+### Why squash and merge?
 
 - ✅ **Clean history**: One commit per feature/fix in `main`
 - ✅ **Conventional commits**: Each merge becomes a properly formatted commit
@@ -213,10 +213,10 @@ promotion), and that squashes like any other PR.
 - Use conventional commit prefixes in PR titles for easy squashing
 - If you accidentally use wrong merge method, you can revert and redo
 
-## Troubleshooting & Scenarios
+## Troubleshooting & scenarios
 
 
-### Multiple Related Changes
+### Multiple related changes
 
 If changes are closely related, keep in one branch:
 ```bash
@@ -232,7 +232,7 @@ feat/add-exe-support
 feat/add-rpm-support
 ```
 
-### Long-Running Features
+### Long-running features
 
 For features taking multiple days/weeks:
 1. Keep branch updated with `main` regularly
@@ -240,7 +240,7 @@ For features taking multiple days/weeks:
 3. Use draft PRs to show progress
 4. Consider feature flags for incomplete features
 
-### Urgent Hotfixes
+### Urgent hotfixes
 
 For critical production issues:
 ```bash
@@ -257,7 +257,7 @@ git push origin fix/security-vulnerability
 # Fast-track review and merge
 ```
 
-## Best Practices & Quality Checks
+## Best practices & quality checks
 
 ### DO ✅
 

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -1,14 +1,14 @@
-# Common Tasks
+# Common tasks
 
 Step-by-step guides for common NAPT workflows. Each task includes complete, working examples you can copy and adapt.
 
 > **💡 Tip:** Need help with a specific command? Use `napt <command> --help` to see all options and examples. For instance, `napt discover --help` shows discovery command details.
 
-## Initialize a New NAPT Project
+## Initialize a new NAPT project
 
 Set up the recommended directory structure for a new NAPT project.
 
-### Quick Setup
+### Quick setup
 
 ```bash
 # Create and enter project directory
@@ -44,7 +44,7 @@ Created (4):
 [SUCCESS] Project initialized!
 ```
 
-### What Gets Created
+### What gets created
 
 ```
 my-intune-packages/
@@ -56,7 +56,7 @@ my-intune-packages/
     └── deployment/           # Per-app deployment state (written by discover, upload, promote)
 ```
 
-### Handling Existing Files
+### Handling existing files
 
 NAPT safely skips existing files by default:
 
@@ -122,7 +122,7 @@ Skipped (3):
 [SUCCESS] Project initialized!
 ```
 
-### Next Steps After Init
+### Next steps after init
 
 1. **Edit organization defaults** (optional):
    ```bash
@@ -142,7 +142,7 @@ Skipped (3):
    napt discover recipes/Google/chrome.yaml --verbose
    ```
 
-## Create a Recipe for a GitHub Release App
+## Create a recipe for a GitHub release app
 
 Use this when the application is hosted on GitHub with releases.
 
@@ -196,7 +196,7 @@ napt discover recipes/Git/git.yaml --verbose
 - `version_pattern`: Regex to extract version from tag
 - `install`/`uninstall`: PowerShell deployment scripts
 
-## Create a Recipe for a Vendor Download Page
+## Create a recipe for a vendor download page
 
 Use this when the vendor has a download page listing installers (no API available).
 
@@ -258,7 +258,7 @@ napt discover recipes/7-Zip/7zip-x64-msi.yaml --verbose
   - `display_name`: Pattern with wildcards to match the installed app name
   - `override_msi_display_name`: Set to `true` to override MSI's versioned DisplayName
 
-## Create a Recipe for a JSON API Endpoint
+## Create a recipe for a JSON API endpoint
 
 Use this when the vendor provides a JSON API with version and download URL.
 
@@ -316,7 +316,7 @@ napt discover recipes/Vendor/app.yaml --verbose
 - `download_url_path`: JSONPath to download URL field
 - `headers`: Optional authentication headers
 
-## Create a Recipe for an MSIX Installer
+## Create a recipe for an MSIX installer
 
 Use this when the application distributes an `.msix` installer. NAPT extracts
 metadata from `AppxManifest.xml` and auto-generates install/uninstall commands.
@@ -395,7 +395,7 @@ psadt:
     Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq "Vendor.App" } | Remove-AppxProvisionedPackage -Online
 ```
 
-## Create a Recipe for a Fixed Download URL
+## Create a recipe for a fixed download URL
 
 Use this when the vendor has a stable download URL (like Chrome enterprise MSI).
 
@@ -434,11 +434,11 @@ napt discover recipes/Google/chrome.yaml --verbose
 
 **Note:** MSI files (`.msi` extension) are automatically detected and versions are extracted from the MSI ProductVersion property. Install/uninstall commands are auto-generated from the MSI (set `psadt.override_msi_commands: true` for custom commands). No additional configuration needed.
 
-## Handle Authentication Tokens
+## Handle authentication tokens
 
 Many APIs require authentication. Here's how to handle tokens securely.
 
-### Environment Variables (Recommended)
+### Environment variables (recommended)
 
 1. **Set token in environment:**
    ```powershell
@@ -468,7 +468,7 @@ Many APIs require authentication. Here's how to handle tokens securely.
      run: napt discover recipes/Vendor/app.yaml
    ```
 
-### Recipe-Level Tokens (Less Secure)
+### Recipe-level tokens (less secure)
 
 If you must store tokens in recipes (not recommended for production):
 
@@ -481,7 +481,7 @@ discovery:
 
 **Security best practice:** Always use environment variables or CI/CD secrets, never commit tokens to version control.
 
-## Test Recipes Before Production
+## Test recipes before production
 
 Validate and test recipes thoroughly before using in production.
 
@@ -527,7 +527,7 @@ Validate and test recipes thoroughly before using in production.
 
 Upload a packaged app to Microsoft Intune. Requires `napt package` to have run first.
 
-### App Registration Setup (one time per organization)
+### App registration setup (one time per organization)
 
 Fastest path, as at least an Application Administrator:
 
@@ -549,7 +549,7 @@ admin consent, and add the `http://localhost` and
 `ms-appx-web://Microsoft.AAD.BrokerPlugin/<client-id>` redirect URIs under
 **Mobile and desktop applications**.
 
-### Developer Setup (one time)
+### Developer setup (one time)
 
 Sign in once with the IDs from the app registration:
 
@@ -563,7 +563,7 @@ The IDs are remembered, so later sessions are just `napt auth login`, and
 `napt auth status` shows the account, tenant, and permissions in use;
 `napt auth logout` clears the session.
 
-### CI/CD Setup (one time)
+### CI/CD setup (one time)
 
 Prefer OIDC federation when your platform supports it (GitHub Actions does):
 add a federated credential to the app registration and let `azure/login`
@@ -579,7 +579,7 @@ AZURE_CLIENT_SECRET="<client secret value>"
 AZURE_TENANT_ID="<Directory (tenant) ID>"
 ```
 
-### Upload an App
+### Upload an app
 
 ```bash
 napt upload recipes/Google/chrome.yaml
@@ -621,7 +621,7 @@ With the default `intune.build_types: "both"`, the install entry and the
 `[Update]` entry are each created, uploaded, and committed (nine steps).
 `app_only` or `update_only` runs six.
 
-### Full Pipeline Example
+### Full pipeline example
 
 ```bash
 # 1. Check for new version (skips download if unchanged)
@@ -637,7 +637,7 @@ napt package recipes/Google/chrome.yaml
 napt upload recipes/Google/chrome.yaml
 ```
 
-### CI/CD Setup
+### CI/CD setup
 
 With OIDC federation (recommended):
 
@@ -676,7 +676,7 @@ With a client secret:
 The app registration must have the `DeviceManagementApps.ReadWrite.All` and
 `Group.Read.All` Microsoft Graph application permissions.
 
-### Override Publisher and Description
+### Override publisher and description
 
 By default, the publisher is inferred from the vendor directory name
 (e.g., `recipes/Google/` → `"Google"`). Override per-recipe with the
@@ -702,7 +702,7 @@ psadt:
   # ... rest of recipe
 ```
 
-### Override Upload Behavior
+### Override upload behavior
 
 Control how Intune handles installation, restarts, and script execution
 per-recipe using the `intune:` section.
@@ -1425,7 +1425,7 @@ jobs:
   could run on Linux with `msitools` installed for MSI version
   extraction.
 
-## Update Existing Recipes
+## Update existing recipes
 
 When a recipe needs changes (new version format, different download URL, etc.).
 
@@ -1460,7 +1460,7 @@ When a recipe needs changes (new version format, different download URL, etc.).
    napt upload recipes/Vendor/app.yaml
    ```
 
-## Troubleshoot Discovery Failures
+## Troubleshoot discovery failures
 
 Common issues and solutions when `napt discover` fails.
 
@@ -1557,7 +1557,7 @@ napt discover recipes/app.yaml --stateless
 **Note:** Deployment state files (`state/deployment/`) are authoritative and are never auto-replaced.
 If one is corrupted, fix the JSON or restore the file from a backup.
 
-## What's Next?
+## What's next?
 
 - **[User Guide](user-guide.md)** - Deep dive into discovery strategies, state management, and configuration
 - **[Creating Recipes](user-guide.md#discovery-strategies)** - Detailed strategy configuration guides

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,9 +2,9 @@
 
 Thank you for your interest in contributing to NAPT! We welcome ideas and feedback.
 
-## How to Contribute
+## How to contribute
 
-### Feature Ideas
+### Feature ideas
 
 Have an idea for NAPT? We'd love to hear it!
 
@@ -30,7 +30,7 @@ Have feedback, questions, or encountered issues? We'd love to hear from you!
 
 Have questions about using NAPT? Open a GitHub Discussion - we're happy to help!
 
-## Code Contributions
+## Code contributions
 
 We're currently not accepting code contributions. NAPT is still in active development and has not reached 1.0 yet. The project is evolving rapidly with frequent changes to APIs, schemas, configuration formats, and internal structure.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Packaging applications for Microsoft Intune with PSAppDeployToolkit (PSADT) typi
 
 This manual workflow is repetitive, difficult to automate in CI/CD pipelines, lacks version tracking, and requires re-doing most of the work for every update. NAPT automates this entire workflow with YAML-based recipes and automatic version tracking.
 
-### Key Features
+### Key features
 
 - ✅ **Automatic version tracking** - Automatic discovery from MSI, EXE, URLs, or APIs with caching to skip unnecessary downloads
 - ✅ **YAML-based recipes** - Define app packaging once with layered configuration (Organization → Vendor → Recipe)
@@ -36,7 +36,7 @@ This manual workflow is repetitive, difficult to automate in CI/CD pipelines, la
 - ✅ **Cross-platform workflow** - Run on Windows, Linux, and macOS (packaging requires Windows)
 - ✅ **Direct Intune upload** - Upload to Microsoft Intune via the Graph API, no portal required
 
-## Cross-Platform Support
+## Cross-platform support
 
 | Feature | Windows | Linux/macOS |
 |---------|---------|-------------|
@@ -45,13 +45,13 @@ This manual workflow is repetitive, difficult to automate in CI/CD pipelines, la
 | Intune Packaging | ✅ | ⚫ Windows Only |
 | Intune Upload | ✅ | ✅ |
 
-See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for platform-specific workflows.
+See the [Cross-platform support](user-guide.md#cross-platform-support) section for platform-specific workflows.
 
-## Getting Started
+## Getting started
 
 See the [Quick Start Guide](quick-start.md) for installation and setup.
 
-## Creating Recipes
+## Creating recipes
 
 Recipes are YAML configuration files that define how to discover, download, and package applications.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,4 +1,4 @@
-# Quick Start Guide
+# Quick start guide
 
 ## Installation
 
@@ -7,9 +7,9 @@
 - Python 3.11 or higher
 - Git
 
-### Choose Your Installation Method
+### Choose your installation method
 
-#### Option 1: pip (For Using NAPT)
+#### Option 1: pip (for using NAPT)
 
 Best for users who want to use the tool.
 
@@ -29,7 +29,7 @@ pip install napt
 napt --version
 ```
 
-#### Option 2: Poetry (For Development)
+#### Option 2: Poetry (for development)
 
 Best for contributing to NAPT.
 
@@ -52,7 +52,7 @@ poetry install
 napt --version
 ```
 
-### Platform Requirements
+### Platform requirements
 
 NAPT runs on Windows, Linux, and macOS with the following requirements:
 
@@ -81,11 +81,11 @@ sudo dnf install msitools
 brew install msitools
 ```
 
-See the [Cross-Platform Support](user-guide.md#cross-platform-support) section for platform-specific workflows.
+See the [Cross-platform support](user-guide.md#cross-platform-support) section for platform-specific workflows.
 
-## Basic Usage
+## Basic usage
 
-### Command-Line Options
+### Command-line options
 
 All NAPT commands support these helpful flags:
 
@@ -95,7 +95,7 @@ All NAPT commands support these helpful flags:
 
 Example: `napt discover --help` or `napt build --verbose`
 
-### Initialize a New Project
+### Initialize a new project
 
 Set up the recommended directory structure for a new NAPT project:
 
@@ -117,7 +117,7 @@ This creates:
 - `defaults/vendors/` - Directory for vendor-specific defaults
 - `state/deployment/` - Per-app deployment state files
 
-### Validate a Recipe
+### Validate a recipe
 
 Quick validation checks syntax and configuration without downloading anything:
 
@@ -125,7 +125,7 @@ Quick validation checks syntax and configuration without downloading anything:
 napt validate recipes/Google/chrome.yaml
 ```
 
-### Discover Latest Version
+### Discover latest version
 
 Download the installer and extract version information:
 
@@ -141,7 +141,7 @@ napt discover recipes/Google/chrome.yaml --output-dir ./cache
 napt discover recipes/Google/chrome.yaml --stateless
 ```
 
-### Build PSADT Package
+### Build PSADT package
 
 Create a complete PSADT package ready for deployment:
 
@@ -153,7 +153,7 @@ napt build recipes/Google/chrome.yaml
 napt build recipes/Google/chrome.yaml --downloads-dir ./downloads --output-dir ./builds
 ```
 
-### Create .intunewin Package
+### Create .intunewin package
 
 Package the PSADT build for Microsoft Intune:
 
@@ -165,9 +165,9 @@ napt package recipes/Google/chrome.yaml
 napt package recipes/Google/chrome.yaml --output-dir ./packages --clean-source
 ```
 
-## Example Workflows
+## Example workflows
 
-### Complete Workflow: Recipe to Package
+### Complete workflow: recipe to package
 
 Here's a complete workflow from recipe validation to Intune package:
 
@@ -271,7 +271,7 @@ Status:          success
 
 **Result:** Ready-to-upload .intunewin file in `packages/napt-chrome/<version>/`
 
-### Quick Check Workflow
+### Quick check workflow
 
 Check if a new version is available (skips re-downloading if unchanged):
 
@@ -293,7 +293,7 @@ this; the other strategies compare the discovered version to the cached one.
 **Note:** This requires having run `napt discover` at least once before to
 populate `cache/discovery.json`.
 
-### Clean Build Workflow
+### Clean build workflow
 
 Force a fresh download and rebuild:
 
@@ -308,7 +308,7 @@ napt build recipes/Google/chrome.yaml --output-dir ./my-builds
 napt package recipes/Google/chrome.yaml --clean-source
 ```
 
-## Common Tasks
+## Common tasks
 
 For step-by-step guides on common workflows, see [Common Tasks](common-tasks.md):
 
@@ -317,7 +317,7 @@ For step-by-step guides on common workflows, see [Common Tasks](common-tasks.md)
 - Create a recipe for a JSON API endpoint
 - Troubleshoot discovery failures
 
-## What's Next?
+## What's next?
 
 Now that you have NAPT installed and understand the basic commands, explore:
 

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -1,10 +1,10 @@
-# Recipe Reference
+# Recipe reference
 
 Complete documentation of all recipe fields, options, and configuration patterns. Use this as a reference when writing recipes.
 
 > **Tip:** For practical examples and workflows, see [Common Tasks](common-tasks.md). For strategy selection guidance, see [Discovery Strategies](user-guide.md#discovery-strategies) in the User Guide.
 
-## Top-Level Fields
+## Top-level fields
 
 ```yaml
 apiVersion: napt/v1        # Required: Recipe format version
@@ -54,7 +54,7 @@ name. Used to generate:
 
 **Naming Convention:** Use `napt-` prefix followed by application name (e.g., `napt-chrome`, `napt-git`).
 
-## Discovery Configuration
+## Discovery configuration
 
 The `discovery` section defines how NAPT finds and downloads the installer. The structure
 depends on the chosen `strategy`.
@@ -63,7 +63,7 @@ depends on the chosen `strategy`.
 
 - `strategy`: Required. One of: `api_github`, `api_json`, `url_download`, `web_scrape`
 
-### api_github Strategy
+### api_github strategy
 
 **Best for:** Open-source projects on GitHub with releases and semantic versioned tags.
 
@@ -145,7 +145,7 @@ pre-release.
 **How it works:** Queries GitHub Releases API, finds the latest release, matches assets using
 `asset_pattern`, extracts version from tag using `version_pattern`.
 
-### api_json Strategy
+### api_json strategy
 
 **Best for:** Vendors with JSON REST APIs, cloud services with version endpoints, or APIs
 requiring authentication.
@@ -211,7 +211,7 @@ headers:
 **How it works:** Makes HTTP GET request to `api_url`, extracts version using `version_path`,
 extracts download URL using `download_url_path`. Supports nested JSON paths.
 
-### url_download Strategy
+### url_download strategy
 
 **Best for:** Vendors with stable download URLs and MSI installers with embedded ProductVersion.
 
@@ -240,7 +240,7 @@ automatically extract ProductVersion. No configuration needed. Other file types 
 supported for version extraction — use a version-first strategy (api_github, api_json,
 web_scrape) instead.
 
-### web_scrape Strategy
+### web_scrape strategy
 
 **Best for:** Vendors with download pages listing installers when no direct download URL or API
 is available.
@@ -334,7 +334,7 @@ string syntax with `{0}`, `{1}`, etc. for capture groups.
 or `link_pattern` (regex), extracts the version from the URL using `version_pattern`, and
 formats it using `version_format` if provided.
 
-## PSADT Configuration
+## PSADT configuration
 
 The `psadt` section defines PowerShell deployment scripts and PSADT variables:
 
@@ -556,7 +556,7 @@ uninstall: |
   Uninstall-ADTApplication -Name "Application Name"
 ```
 
-## Intune Configuration
+## Intune configuration
 
 The `intune` section configures Win32 app settings for Intune packaging and upload.
 
@@ -1010,7 +1010,7 @@ output and embeds them as inline PowerShell rules in the Intune app record.
 See [Detection and Requirements Scripts](user-guide.md#detection-and-requirements-scripts) in
 the User Guide for how scripts work and how to configure them in Intune.
 
-## IntuneWinAppUtil Configuration
+## IntuneWinAppUtil configuration
 
 The `intunewin` section controls the Microsoft packaging tool `napt package`
 uses. Set in `defaults/org.yaml`; it is not a per-recipe setting.
@@ -1034,7 +1034,7 @@ Which `IntuneWinAppUtil.exe` release to download and run. Can be:
 Each release is cached independently under `cache/tools/{version}/`, so changing
 the pin never overwrites a previously downloaded tool.
 
-## Logging Configuration
+## Logging configuration
 
 The `logging` section controls on-device logging for detection and requirements scripts.
 Logs are written in CMTrace format (compatible with the Configuration Manager Trace Log
@@ -1062,7 +1062,7 @@ it does not exist and verifying write access). If that fails (e.g., permissions)
 to `C:\ProgramData\NAPT\` (system) or `%LOCALAPPDATA%\NAPT\` (user). If both fail, a warning is
 written to stderr and the script runs without a log file.
 
-## Deployment Configuration
+## Deployment configuration
 
 The `deployment` section controls upload strictness and deployment promotion.
 These settings are org policy — configure them in `defaults/org.yaml` and
@@ -1151,7 +1151,7 @@ How many superseded versions stay in Intune for rollback before deletion.
 `0` deletes a version as soon as it holds no rings.
 Enforced by `napt promote apply`; only NAPT-stamped apps are ever deleted.
 
-## Variable Substitution
+## Variable substitution
 
 Recipes use two distinct substitution mechanisms with different syntax.
 
@@ -1192,7 +1192,7 @@ psadt:
     Start-ADTProcess -FilePath "{{installer_filename}}" -ArgumentList "/S"
 ```
 
-### Setting Environment Variables
+### Setting environment variables
 
 **Windows (PowerShell):**
 ```powershell
@@ -1212,7 +1212,7 @@ export GITHUB_TOKEN="your_token_here"
 **Note:** For CI/CD, set environment variables in your pipeline configuration (GitHub Actions,
 Azure DevOps, etc.).
 
-## Complete Example
+## Complete example
 
 ```yaml
 apiVersion: napt/v1
@@ -1241,7 +1241,7 @@ psadt:
     Uninstall-ADTApplication -Name "Example Application"
 ```
 
-## See Also
+## See also
 
 - [Common Tasks](common-tasks.md) - Practical workflows and examples
 - [Discovery Strategies](user-guide.md#discovery-strategies) - Strategy selection guide

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-# NAPT Roadmap
+# NAPT roadmap
 
 ## Philosophy
 
@@ -19,7 +19,7 @@ This roadmap is a living document showing potential future directions for NAPT. 
 
 ---
 
-## Quick Reference
+## Quick reference
 
 | Feature | Status | Category | Complexity | Value |
 |---------|--------|----------|------------|-------|
@@ -50,13 +50,13 @@ This roadmap is a living document showing potential future directions for NAPT. 
 
 ---
 
-## Active Work
+## Active work
 
 _Nothing currently in progress._
 
 ---
 
-## Future Ideas (By Category)
+## Future ideas (by category)
 
 > **Note:** Categories are organized by how they impact users:
 >
@@ -64,9 +64,9 @@ _Nothing currently in progress._
 > - **Code Quality & Validation**: Tools that validate and improve recipe quality, including syntax checking, linting, and best practices enforcement.
 > - **Technical Enhancements**: Internal improvements and infrastructure enhancements that improve performance, add backend capabilities, or optimize the tool's operation.
 
-### User-Facing Features
+### User-facing features
 
-#### Intune App Categorization & Scope Tags
+#### Intune app categorization & scope tags
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
@@ -88,7 +88,7 @@ tag names must be resolved via `GET /deviceManagement/roleScopeTags`.
 - Requires two additional Graph API calls per upload (one per lookup type)
 - Error handling needed when a name doesn't match any tenant entry
 
-#### Pre/Post Install/Uninstall Script Support
+#### Pre/Post install/uninstall script support
 
 **Status**: 💡 Idea
 **Complexity**: Low (few hours to 1 day)
@@ -108,7 +108,7 @@ each deployment phase.
 
 **Related**: PSADT already has these phases in the template structure
 
-#### Enhanced CLI Help Menu
+#### Enhanced CLI help menu
 
 **Status**: 💡 Idea
 **Complexity**: Low (few hours to 1 day)
@@ -129,7 +129,7 @@ information, examples, and better organization.
 
 **Related**: CLI help currently minimal, relies on online documentation
 
-#### Configurable Install-Entry Cutover Ring
+#### Configurable install-entry cutover ring
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
@@ -164,9 +164,9 @@ the old one and updates right away.
 Bounded by the bake time of rings before the cutover point, so small
 with a pilot-sized first ring.
 
-### Code Quality & Validation
+### Code quality & validation
 
-#### PowerShell Validation
+#### PowerShell validation
 
 **Status**: 💡 Idea
 **Complexity**: High (3-5 days)
@@ -185,7 +185,7 @@ to catch errors before deployment.
 **Related**: Overlaps with Recipe Linting & Best Practices below; syntax
 checking is the narrower first step.
 
-#### Recipe Linting & Best Practices
+#### Recipe linting & best practices
 
 **Status**: 💡 Idea
 **Complexity**: High (3-5 days)
@@ -205,7 +205,7 @@ style guide enforcement.
 - Suggests improvements (e.g., use Uninstall-ADTApplication)
 - Warns about unknown fields (e.g., deprecated keys from old schema versions)
 
-#### Prerelease Version Ranking in Detection Scripts
+#### Prerelease version ranking in detection scripts
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
@@ -231,7 +231,7 @@ Semver-style ordering would treat prereleases as older than the release.
 **Related**: First iteration shipped with non-numeric segments counted as 0
 and a CMTrace warning when decoration is stripped
 
-#### Typed Config with Dataclasses
+#### Typed config with dataclasses
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
@@ -255,9 +255,9 @@ development time.
 - Schema should be stable (post-1.0 or when churn slows)
 - Current dict approach works well for rapid iteration
 
-### Technical Enhancements
+### Technical enhancements
 
-#### EXE Version Extraction
+#### EXE version extraction
 
 **Status**: 💡 Idea
 **Complexity**: High (3-5 days)
@@ -274,7 +274,7 @@ headers for .exe installers.
 **Related**: `url_download` only extracts versions from MSI installers today
 and raises `ConfigError` for other extensions when no version is discoverable.
 
-#### Parallel Package Building
+#### Parallel package building
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
@@ -290,7 +290,7 @@ multi-app workflows.
 - Improves CI/CD pipeline performance
 - Progress reporting for multiple concurrent builds
 
-#### Minify Scripts at Intune Upload
+#### Minify scripts at Intune upload
 
 **Status**: 💡 Idea
 **Complexity**: Medium (1-3 days)
@@ -323,13 +323,13 @@ signing)
 
 ---
 
-## Declined / Won't Implement
+## Declined / won't implement
 
 ---
 
-## Recently Completed
+## Recently completed
 
-#### `napt auth setup` Command
+#### `napt auth setup` command
 
 **Status**: ✅ Completed
 **Complexity**: Medium
@@ -357,7 +357,7 @@ Shipped alongside `napt auth login`, `status`, and `logout`.
 
 ---
 
-#### IntuneWinAppUtil Version Pinning
+#### IntuneWinAppUtil version pinning
 
 **Status**: ✅ Completed
 **Complexity**: Low
@@ -372,7 +372,7 @@ builds are reproducible against a known-good tool version.
 
 ---
 
-#### Deployment Wave Management
+#### Deployment wave management
 
 **Status**: ✅ Completed
 **Complexity**: Very High
@@ -411,7 +411,7 @@ republish with re-applied assignments) are deliberate follow-ups.
 
 ---
 
-#### Recipe Schema Redesign
+#### Recipe schema redesign
 
 **Status**: ✅ Completed
 **Complexity**: High
@@ -441,7 +441,7 @@ All changes were breaking and landed on branch `refactor/recipe-schema-redesign`
 
 ---
 
-#### Unrecognized Config Field Warnings
+#### Unrecognized config field warnings
 
 **Status**: ✅ Completed
 **Complexity**: Low
@@ -456,7 +456,7 @@ Typo detection suggests similar field names (e.g., "Did you mean
 
 ---
 
-#### Microsoft Intune Upload
+#### Microsoft Intune upload
 
 **Status**: ✅ Completed
 **Complexity**: High
@@ -471,7 +471,7 @@ Authentication now goes through `napt auth login` for developers and the
 
 ---
 
-#### Detection Script Generation
+#### Detection script generation
 
 **Status**: ✅ Completed
 **Complexity**: High

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,12 +1,12 @@
-# User Guide
+# User guide
 
 This guide covers NAPT's key features, configuration system, and advanced usage patterns.
 
-## How NAPT Works
+## How NAPT works
 
 NAPT automates the complete workflow from version discovery to Intune package creation. Understanding how each step works helps you troubleshoot issues and customize recipes effectively.
 
-### Discovery Process (`napt discover`)
+### Discovery process (`napt discover`)
 
 The discovery process finds the latest version and downloads the installer:
 
@@ -22,7 +22,7 @@ The discovery process finds the latest version and downloads the installer:
 
 **Output**: Downloaded installer in `downloads/{app_id}/`, updated discovery cache, updated deployment state
 
-### Build Process (`napt build`)
+### Build process (`napt build`)
 
 The build process creates a complete PSADT package from the recipe and downloaded installer:
 
@@ -59,7 +59,7 @@ The build process creates a complete PSADT package from the recipe and downloade
 
 **Output**: Complete PSADT package in `builds/{app_id}/{version}/` with detection script always present, and requirements script when `build_types` is `both` or `update_only`.
 
-#### Detection and Requirements Scripts
+#### Detection and requirements scripts
 
 NAPT generates PowerShell scripts used by Intune Win32 app entries to check installation state:
 
@@ -205,7 +205,7 @@ build time:
 Icon resolution order at upload: `intune.logo_path` (if set), then
 `icons/{id}.png`, then no icon with a warning.
 
-### Package Process (`napt package`)
+### Package process (`napt package`)
 
 The package process creates a `.intunewin` file from a PSADT build for the
 recipe's app:
@@ -237,7 +237,7 @@ recipe's app:
 ready for `napt upload`. Only one version is kept on disk per app at a time —
 packaging a new version removes the previous one automatically.
 
-### Upload Process (`napt upload`)
+### Upload process (`napt upload`)
 
 The upload process publishes a packaged app to Microsoft Intune via the
 Graph API. Run `napt package` before uploading.
@@ -306,7 +306,7 @@ If no credential is available, commands fail with `Not authenticated.`
 followed by a hint for each option: run `napt auth login` interactively, or
 set the `AZURE_*` variables or sign in with `az login` for CI/CD.
 
-#### App Registration Setup
+#### App registration setup
 
 Create the app registration once per organization.
 Two ways to do it:
@@ -505,7 +505,7 @@ AZURE_TENANT_ID="<Directory (tenant) ID>"
 A certificate works the same way with `AZURE_CLIENT_CERTIFICATE_PATH`
 instead of `AZURE_CLIENT_SECRET`.
 
-### Directory Structure
+### Directory structure
 
 After a complete workflow, your directory structure looks like:
 
@@ -548,7 +548,7 @@ state/
       └── napt-chrome.json                 # Deployment state (authoritative)
 ```
 
-## Commands Reference
+## Commands reference
 
 > **💡 Tip:** All commands support `--help` (or `-h`) to show detailed usage, options, and examples. Try `napt discover --help` to see what's available.
 
@@ -701,7 +701,7 @@ napt auth status
 napt auth logout
 ```
 
-### Output Modes
+### Output modes
 
 All commands support verbosity flags to control output detail:
 
@@ -713,11 +713,11 @@ All commands support verbosity flags to control output detail:
 
 Debug mode includes all verbose output plus deep diagnostic information. Use `--verbose` for normal troubleshooting and `--debug` when you need to understand exactly what NAPT is doing internally.
 
-## Discovery Strategies
+## Discovery strategies
 
 Discovery strategies are the core mechanism for obtaining application installers and extracting version information.
 
-### Available Strategies
+### Available strategies
 
 | Strategy | Version Source | Use Case | Unchanged Version Detection Speed |
 |----------|---------------|----------|---------------------|
@@ -728,7 +728,7 @@ Discovery strategies are the core mechanism for obtaining application installers
 
 > **Note:** For complete configuration examples and field documentation for each strategy, see [Recipe Reference](recipe-reference.md).
 
-### Decision Guide
+### Decision guide
 
 Use this flowchart to choose the right strategy:
 
@@ -745,14 +745,14 @@ flowchart TD
 
 **Performance Note**: Version-first strategies (everything except url_download) can skip downloads entirely when versions haven't changed, making them ideal for scheduled CI/CD checks.
 
-## Recipe Basics
+## Recipe basics
 
 A recipe file defines how to discover, download, and package an application. Recipes are YAML files that specify:
 
 - **Discovery strategy** - How to find the latest version and download URL
 - **PSADT configuration** - PowerShell deployment scripts and variables
 
-### Basic Structure
+### Basic structure
 
 ```yaml
 apiVersion: napt/v1    # Recipe format version
@@ -778,7 +778,7 @@ intune:                # Optional: Intune-specific settings
     architecture: "x64"               # Required for EXE installers
 ```
 
-### Quick Reference
+### Quick reference
 
 - **Top-level fields:** `apiVersion` (required), `name` (required), `id` (required),
   `discovery` (required), `psadt` (optional for MSI and MSIX; EXE installers need
@@ -786,13 +786,13 @@ intune:                # Optional: Intune-specific settings
 - **Discovery strategies:** See [Discovery Strategies](#discovery-strategies) section above for strategy selection and examples
 - **PSADT scripts:** NAPT substitutes `{{discovered_version}}` and `{{installer_filename}}` at build time (these are not PowerShell variables); `${UPPERCASE}` env vars work only in `discovery.token`/`discovery.headers`; use `$($adtSession.DirFiles)` for the files directory path (PSADT 4.x)
 
-### Complete Documentation
+### Complete documentation
 
 For complete field documentation, all options, and detailed examples, see the [Recipe Reference](recipe-reference.md) page.
 
 For practical workflows and copy-paste examples, see [Common Tasks](common-tasks.md).
 
-## State Management & Caching
+## State management & caching
 
 NAPT keeps two kinds of state with different purposes:
 
@@ -803,7 +803,7 @@ Safe to gitignore.
 Not regenerable.
 Written deterministically (fixed reading-order keys, no timestamps), so unchanged state produces byte-identical files and clean diffs — commit these files to version control if you want an auditable record or a PR-based review workflow.
 
-### Discovery Cache
+### Discovery cache
 
 The discovery cache avoids unnecessary downloads.
 This version-based caching is critical for CI/CD with frequent scheduled checks, providing fast feedback when applications haven't changed.
@@ -843,7 +843,7 @@ flowchart TD
 
 **Note:** The cache is updated after every discovery run, even when skipping downloads. This updates the `last_updated` timestamp and confirms the cached version is still current.
 
-### Deployment State
+### Deployment state
 
 Each app gets its own file, `state/deployment/<app_id>.json`, so concurrent changes to different apps never conflict and each file's diff is scoped to one app.
 Every file carries a `schemaVersion` (currently 1); NAPT refuses files
@@ -914,7 +914,7 @@ To hold one app's promotions during review, delete its plan file; the
 other apps' plans are unaffected, and the next plan run re-proposes
 whatever is still eligible.
 
-### Default Behavior (Stateful)
+### Default behavior (stateful)
 
 ```bash
 # Cache and deployment state tracking enabled by default
@@ -924,7 +924,7 @@ napt discover recipes/Google/chrome.yaml
 # Creates/updates: state/deployment/napt-chrome.json
 ```
 
-### Stateless Mode
+### Stateless mode
 
 ```bash
 # Disable the discovery cache and deployment state writes for one-off checks
@@ -934,12 +934,12 @@ napt discover recipes/Google/chrome.yaml --stateless
 # Useful for ad-hoc checks that should leave no trace
 ```
 
-## Configuration Layers
+## Configuration layers
 
 NAPT uses a layered configuration system that promotes DRY (Don't Repeat Yourself) principles.
 All defaults live in code; configuration files are optional overrides.
 
-### How Configuration Works
+### How configuration works
 
 ```
 Code defaults (always complete)     <- baseline, ships with napt
@@ -959,7 +959,7 @@ recipe.yaml                         <- recipe-specific overrides
 - Old configs never break when NAPT adds new features
 - Any setting can be overridden at any layer — org, vendor, or recipe
 
-### The Three Override Layers
+### The three override layers
 
 1. **Organization defaults** (`defaults/org.yaml`) - Base overrides for all apps.
 Optional; only needed if you want to customize settings organization-wide.
@@ -1000,7 +1000,7 @@ psadt:
 # AppVendor will be "Google LLC" (from vendor defaults)
 ```
 
-### Directory Flag Defaults
+### Directory flag defaults
 
 All directory flags follow the same pattern: CLI flag overrides config;
 config overrides the built-in default.
@@ -1053,7 +1053,7 @@ napt discover recipes/Google/chrome.yaml --output-dir /tmp/downloads
 napt build recipes/Google/chrome.yaml --downloads-dir /tmp/downloads
 ```
 
-### IntuneWinAppUtil Release Pinning
+### IntuneWinAppUtil release pinning
 
 By default NAPT always resolves `"latest"` for `IntuneWinAppUtil.exe` by querying
 the GitHub releases API and caching the resolved version.
@@ -1075,11 +1075,11 @@ intunewin:
   release: "latest"  # default; resolves via GitHub API on each run if not cached
 ```
 
-## Cross-Platform Support
+## Cross-platform support
 
 **NAPT is a Windows tool** for Microsoft Intune packaging. Develop on any platform, package on Windows.
 
-### Platform Compatibility Matrix
+### Platform compatibility matrix
 
 | Platform | Discover & Download | Build | Package |
 |----------|---------------------|-------|---------|
@@ -1087,13 +1087,13 @@ intunewin:
 | **Linux** | ✅ | ✅ | ⚫ Windows Only |
 | **macOS** | ✅ | ✅ | ⚫ Windows Only |
 
-### Why Windows for Packaging?
+### Why Windows for packaging?
 
 The `napt package` command uses Microsoft's [IntuneWinAppUtil.exe](https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool), which is a Windows-only .NET application. This is the official tool for creating .intunewin packages.
 
-### Recommended Workflows
+### Recommended workflows
 
-#### Workflow 1: All-Windows (Simplest)
+#### Workflow 1: all-Windows (simplest)
 ```bash
 # Run everything on Windows
 napt discover recipes/Google/chrome.yaml
@@ -1101,7 +1101,7 @@ napt build recipes/Google/chrome.yaml
 napt package recipes/Google/chrome.yaml
 ```
 
-#### Workflow 2: Mixed Platform Development
+#### Workflow 2: mixed platform development
 ```bash
 # On Linux/macOS: Discovery and build
 napt discover recipes/Google/chrome.yaml
@@ -1112,13 +1112,13 @@ napt build recipes/Google/chrome.yaml
 napt package recipes/Google/chrome.yaml
 ```
 
-## Best Practices
+## Best practices
 
-### Recipe Organization
+### Recipe organization
 
 Organize recipes by vendor: `recipes/<Vendor>/<app>.yaml`. NAPT detects the vendor from the recipe's parent directory name (falling back to `psadt.app_vars.AppVendor`) and loads `defaults/vendors/<Vendor>.yaml` if it exists.
 
-### State Management
+### State management
 
 **Production:** Keep state tracking enabled (default), use version control for deployment state files, run on schedule to detect updates, use `--verbose` in CI/CD.
 
@@ -1136,7 +1136,7 @@ fi
 
 ## Troubleshooting
 
-### Common Issues
+### Common issues
 
 **Problem**: MSI extraction fails on Linux/macOS
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,12 +74,12 @@ plugins:
 
 nav:
   - Home: index.md
-  - Quick Start: quick-start.md
-  - User Guide:
-    - User Guide: user-guide.md
-    - Common Tasks: common-tasks.md
-    - Recipe Reference: recipe-reference.md
-  - Developer Reference:
+  - Quick start: quick-start.md
+  - User guide:
+    - User guide: user-guide.md
+    - Common tasks: common-tasks.md
+    - Recipe reference: recipe-reference.md
+  - Developer reference:
     - Overview: api/index.md
     - cli: api/cli.md
     - exceptions: api/exceptions.md


### PR DESCRIPTION
## Description
Converts every heading in README.md, docs/, and the docs/api overview page from title case to sentence case, plus the five mkdocs nav labels so the sidebar matches the pages.

## Motivation
CLAUDE.md has said "use sentence case for headings" since January, but the rule was added after the docs were written and never applied to them. Only a dozen headings written since July followed it; the other ~300 were title case. A style rule that nearly the whole corpus violates isn't a rule, so this brings the corpus in line with it in one pass.

## Changes
- 174 headings converted across README.md, docs/*.md, and docs/api/index.md. changelog.md is deliberately untouched (Keep a Changelog headings)
- Nav labels in mkdocs.yml converted to match ("Quick start", "User guide", "Common tasks", "Recipe reference", "Developer reference")
- Three link texts pointing at the cross-platform section updated to match the renamed heading
- Preserved as written: the first word of every heading (so identifier headings like `api_github strategy` and `defaults/org.yaml` keep their lowercase), product names and acronyms (NAPT, PSADT, Intune, Entra, GitHub Actions, Company Portal, Azure Blob Storage, Conditional Access, CMTrace, IntuneWinAppUtil, Win32, 7-Zip, CI/CD, MSI/MSIX/EXE), quoted error text, and backticked code

No URLs change: slugify already lowercases, so a case-only rename never alters an anchor.

## Testing
- [x] `mkdocs build --strict` clean
- [x] All 4,709 rendered anchor ids are byte-identical before and after, so every inbound link keeps resolving
- [x] README.md and docs/index.md headings verified identical (one-way sync intact)
- [x] Docs-only; test suite unaffected

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] Tests pass
- [x] No linting errors
